### PR TITLE
fix 1B baseline hyperparams

### DIFF
--- a/submit-llama3-1b.sh
+++ b/submit-llama3-1b.sh
@@ -243,8 +243,7 @@ if [ "$NSYS_PROFILER" = true ]; then
     TRAINING_CMD="$NSYS_LAUNCHER $TRAINING_CMD --profile"
 fi
 
-# Save sbatch script
-cat $0 >> $EXP_DIR/submit_run.sbatch
+cp $0 $DEBUG_DIR
 
 # Checkpoint Compute Environment
 echo -e "$(date)" > $COMPUTE_ENVIRONMENT_DIR 

--- a/submit-llama3-1b.sh
+++ b/submit-llama3-1b.sh
@@ -40,7 +40,7 @@ DATASET_CACHE_DIR=/iopsstor/scratch/cscs/$USER/datasets/cache
 
 # Logging directories & artifacts
 PROJECT_NAME=Megatron-Clariden
-EXP_NAME=llama3-1b-${SLURM_NNODES}n-${SEQ_LEN}sl-${GBS}gbsz-TEST2
+EXP_NAME=llama3-1b-${SLURM_NNODES}n-${SEQ_LEN}sl-${GBS}gbsz
 PROJECT_DIR=$MEGATRON_LM_DIR/logs/Meg-Runs/$PROJECT_NAME
 
 #########################################


### PR DESCRIPTION
Fixed the 1B model to have proper lr and batch size running over 100B runs. 

Logs and checkpoints have been copied to 

`/capstor/store/cscs/swissai/a06/megatron_runs/llama3_baselines/llama3-1b-21n`

And I copied the wandb logs into this public wandb project:

[](https://wandb.ai/ischlag/llama3-1b-baseline?nw=nwuserischlag)