### PR TITLE
Ckpt fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can submit issues and create branches on `https://github.com/swiss-ai/Megatr
 
 9. In your PR explain what you did and why. 
 
-10. If you make a contribution with a run, use the `scripts/copy_wandb_project.py` to create a copy in a new fresh wandb project that contains only the relevant run and the respective baseline. See instructions in the next section.
+10. If you make a contribution with a run, either use the wandb web UI to move your run into a new folder (select the run in the runs table and a move button will appear) or use the `scripts/copy_wandb_project.py` to create a copy in a new fresh wandb project that contains only the relevant run and the respective baseline (but in this case all runs will start from step 0). See instructions in the next section on how to use the copy script.
 
 11. If you want to archive your logs, move your log folder `~/Megatron-LM/logs/Meg-Runs/your_project_name/your_experiment_name` to `/capstor/store/cscs/swissai/a06/megatron_runs` and share the path in your PR.
 

--- a/submit-llama3-1b.sh
+++ b/submit-llama3-1b.sh
@@ -26,7 +26,7 @@ MBS=3
 GBS=504
 SEQ_LEN=4096
 TRAINING_STEPS=48441
-CHECKPOINT_STEPS=5000
+CHECKPOINT_STEPS=1000
 
 #### Debugging ####
 LOG_NCCL=false # Log NCCL_DEBUG=info. Every process will dump the logging into separate files, check `NCCL_DEBUG_FILE`
@@ -45,8 +45,8 @@ PROJECT_DIR=$MEGATRON_LM_DIR/logs/Meg-Runs/$PROJECT_NAME
 
 #########################################
 
-CKPT_DIR=$PROJECT_DIR/checkpoints
 EXP_DIR=$PROJECT_DIR/$EXP_NAME
+CKPT_DIR=$EXP_DIR/checkpoints
 TRIGGER_DIR=$EXP_DIR/triggers
 DEBUG_DIR=$EXP_DIR/debug/$SLURM_JOB_ID
 COMPUTE_ENVIRONMENT_DIR=$DEBUG_DIR/compute_environment.txt


### PR DESCRIPTION
Fix ckpt path so different runs don't interfere with each other. Added improved instructions on how to move / copy runs into a different project because the copy script will always start the step counter from 0 and this cannot be undone unless we introduce a custom step counter. 

Here is the confirmation that the checkpointing now works:
[](https://wandb.ai/ischlag/checkpoint_debug_feb?nw=nwuserischlag)