### PR TITLE
Evaluation pipeline

### DIFF
--- a/megatron/inference/text_generation_server.py
+++ b/megatron/inference/text_generation_server.py
@@ -227,10 +227,10 @@ class MegatronGenerate(Resource):
 
 
 class MegatronServer(object):
-    def __init__(self, model, args=None):
+    def __init__(self, model, engine, args=None):
         self.app = Flask(__name__, static_url_path='')
         api = Api(self.app)
-        api.add_resource(MegatronGenerate, '/api', resource_class_args=[model, args])
+        api.add_resource(MegatronGenerate, '/api', resource_class_args=[engine, args])
         api.add_resource(MegatronCompletions, '/completions', resource_class_args=[model])
 
     def run(self, url, port):

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -852,24 +852,28 @@ def _load_base_checkpoint(
     non_persistent_iteration = _get_non_persistent_iteration(
         non_persistent_global_dir, args, checkpointing_context
     )
-    iteration, release = -1, False
-    tracker_filename = 'because load directory is not defined'
-    if load_dir is not None:
-        tracker_filename = get_checkpoint_tracker_filename(load_dir)
-        if os.path.isfile(tracker_filename):
-            iteration, release = read_metadata(tracker_filename)
-    if non_persistent_iteration != -1:  # there is a non-persistent checkpoint
-        if non_persistent_iteration >= iteration:
-            return _load_non_persistent_base_checkpoint(
-                non_persistent_global_dir,
-                args,
-                rank0,
-                sharded_state_dict,
-                non_persistent_iteration,
-                checkpointing_context,
-            )
-        else:
-            print_rank_0('WARNING: non-persistent checkpoints are older than persistent checkpoint')
+    if args.ckpt_step is None:
+        iteration, release = -1, False
+        tracker_filename = 'because load directory is not defined'
+        if load_dir is not None:
+            tracker_filename = get_checkpoint_tracker_filename(load_dir)
+            if os.path.isfile(tracker_filename):
+                iteration, release = read_metadata(tracker_filename)
+        if non_persistent_iteration != -1:  # there is a non-persistent checkpoint
+            if non_persistent_iteration >= iteration:
+                return _load_non_persistent_base_checkpoint(
+                    non_persistent_global_dir,
+                    args,
+                    rank0,
+                    sharded_state_dict,
+                    non_persistent_iteration,
+                    checkpointing_context,
+                )
+            else:
+                print_rank_0('WARNING: non-persistent checkpoints are older than persistent checkpoint')
+    else:
+        iteration = args.ckpt_step
+        release = False
 
     # Otherwise we are dealing with global checkpoints
     # If no tracker file, return nothing

--- a/scripts/evaluation/README.md
+++ b/scripts/evaluation/README.md
@@ -1,0 +1,28 @@
+# Evaluation pipeline
+
+This file explains how to launch the evaluation pipeline.
+Quick usage:
+```
+WANDB_API_KEY=<key> TOKENIZER=<tokenizer> bash scripts/evaluation/submit_evaluation.sh <ckp-path> --size <model-size> --wandb-entity <entity> --wandb-project <project> --wandb-id <runid> --iteration <it> --tasks hellaswag
+```
+This will create a `evaluate.sbatch` file and submit it to evaluate the model at `ckp-path` loading iteration `<it>` in the hellaswag benchmark.
+The `<size>` should be set to 1 or 8 (set it to 1 if training models <1B parameters).
+Run `bash scripts/evaluation/submit_evaluation.sh --help` for more information on the variables and arguments available.
+
+Important things to note:
+- To get W&B sync working correctly, a few changes have been made to the lm-eval-harness repo.
+  These changes are found in: https://github.com/AleHD/lm-evaluation-harness.
+  Tested commit: `522929f5f6c76f2f31ad705ef9f685326838b709`.
+- You will need to install some libraries to run eval harness.
+  As a hotfix for the moment, you can install them to your user library inside a compute node:
+  ```
+  srun --pty --time=01:00:00 --account=a-a06 --environment=/capstor/store/cscs/swissai/a06/containers/NeMo/nemo-latest.toml -- bash
+  git clone git@github.com:AleHD/lm-evaluation-harness.git
+  pip install --user .[api]
+  ```
+- It is important to **not** set your `--wandb-id` to the runID of the checkpoint you are trying to evaluate: **this will corrupt the Step counter**, making it harder to continue using that run for further training.
+- W&B does not support multiple connexions to the same run, so parallel evaluation of the same checkpoint in different iterations (under the assumption it will go the same run) is not supported.
+  This is enforced via the `#SBATCH --dependency=singleton` argument inside the submission file.
+- Currently, evaluating on multi-gpu is not supported, so running `--size 70` models **will hang**.
+  This is because the inference engine was updated in commit [cb678cc](https://github.com/swiss-ai/Megatron-LM/commit/cb678cccf5c706cfc9f83a1ab6ae4d2cb9b1c5f3), but the openai completions endpoint that is used by eval-harness, was not updated.
+  There is an easy hotfix currently applied for non-distributed models to run, but further work must be made to ensure multi-gpu.

--- a/scripts/evaluation/submit_evaluation.sh
+++ b/scripts/evaluation/submit_evaluation.sh
@@ -1,0 +1,238 @@
+# TODO: Where to put eval output?
+# TODO: Support nodes>1 maybe?
+# TODO: Currently tp*pp>1 hangs :(
+# TODO: Need to update completions to use MCoreEngine
+
+# Define default variables.
+DEF_MEGATRON_PATH=$(dirname $(dirname $( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )))  # Grandparent of current file location.
+DEF_LOGS_DIR=$PWD/"eval-logs"
+DEF_SBATCH_PATH=$PWD/evaluate.sbatch
+DEF_CONTAINER_PATH="/capstor/store/cscs/swissai/a06/containers/NeMo/nemo-latest.toml"
+DEF_LM_HARNESS_PATH="/capstor/store/cscs/swissai/a06/users/ahernnde/workspace/lm-evaluation-harness"
+DEF_ACCOUNT=a-a06
+DEF_TOKENIZER=/users/fsimin/tokenizer_nemo/
+
+DEF_IT=latest
+DEF_TASKS=arc_easy
+DEF_LIMIT=1000
+
+# Usage function.
+usage () {
+	echo "Usage: submit_evaluation.sh <checkpoint-path> [options...]"
+	echo "Submits a slurm sbatch to run evaluation of the specified path. Specify either --size or --tp and --pp in order to convert the checkpoint to a more efficient distributed config for inference."
+	echo "In addition, there are a few environment variables you can set to specify some paths (optional)."
+	echo ""
+	echo "Arguments:"
+	echo "  <checkpoint-path>: Path of the megatron checkpoint to evaluate."
+	echo ""
+	echo "Options:"
+	echo "  --help: Prints this message and exits."
+	echo "  --size (choices={1, 3, 8, 70}): The size of the checkpoint to evaluate. If not set, --tp and --pp should be specified."
+	echo "  --tasks: lm-eval-harness tasks to run (default=$DEF_TASKS)."
+	echo "  --limit (int>0 or 'null'): lm-eval-harness limit samples per task (default=$DEF_LIMIT)."
+	echo "  --tp (int>0): Target TP size for inference. Ignored if --size is set, required otherwise."
+	echo "  --pp (int>0): Target PP size for inference. Ignored if --size is set, required otherwise."
+	echo "  --iteration (int>0 | 'latest'): What iteration to evaluate (default=$DEF_IT)"
+	echo "  --wandb-project"
+	echo "  --wandb-entity"
+	echo "  --wandb-id"
+	echo ""
+	echo "Variables:"
+	echo "  MEGATRON_PATH: Megatron root (default=$DEF_MEGATRON_PATH)."
+	echo "  LOGS_DIR: Slurm logs directry (default=$DEF_LOGS_DIR)."
+	echo "  SBATCH_PATH: Where to save the sbatch file (default=$DEF_SBATCH_PATH)."
+	echo "  CONTAINER_PATH: Container path (default=$DEF_CONTAINER_PATH)."
+	echo "  LM_HARNESS_PATH: lm-eval-harness root (default=$DEF_LM_HARNESS_PATH)."
+	echo "  ACCOUNT: Slurm account (default=$DEF_ACCOUNT)."
+	echo "  TOKENIZER: Huggingface tokenizer (default=$DEF_TOKENIZER)."
+}
+
+# Set variables.
+if [ -z ${MEGATRON_PATH+x} ]; then
+	MEGATRON_PATH=$DEF_MEGATRON_PATH
+fi
+if [ -z ${LOGS_DIR+x} ]; then
+	LOGS_DIR=$DEF_LOGS_DIR
+fi
+if [ -z ${SBATCH_PATH+x} ]; then
+	SBATCH_PATH=$DEF_SBATCH_PATH
+fi
+if [ -z ${CONTAINER_PATH+x} ]; then
+	CONTAINER_PATH=$DEF_CONTAINER_PATH
+fi
+if [ -z ${ACCOUNT+x} ]; then
+	ACCOUNT=$DEF_ACCOUNT
+fi
+if [ -z ${LM_HARNESS_PATH+x} ]; then
+	LM_HARNESS_PATH=$DEF_LM_HARNESS_PATH
+fi
+if [ -z ${TOKENIZER+x} ]; then
+	TOKENIZER=$DEF_TOKENIZER
+fi
+
+# Parse args.
+if [[ $# -eq 0 ]]; then
+	echo Invalid argument count: $# >&2
+	usage
+	exit 1
+fi
+
+CHECKPOINT_PATH=$1
+shift
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--help)
+			usage; exit 0;;
+		--size)
+			if [ $2 -eq 1 ] || [ $2 -eq 3 ] || [ $2 -eq 8 ]; then
+				TP=1
+				PP=1
+			elif [ $2 -eq 70 ]; then
+				TP=4
+				PP=1
+			else
+				echo Unknown size $2. Choices={1, 8, 70}. >&2
+				exit 1
+			fi
+			shift 2;;
+
+		--tasks)
+			TASKS=$2; shift 2;;
+		--limit)
+			LIMIT=$2; shift 2;;
+		--iteration)
+			ITERATION=$2; shift 2;;
+		--wandb-project)
+			WANDB_PROJECT=$2; shift 2;;
+		--wandb-entity)
+			WANDB_ENTITY=$2; shift 2;;
+		--wandb-id)
+			WANDB_ID=$2; shift 2;;
+
+		--tp)
+			if [ -z ${TP+x} ]; then  # check if undef to ignore --tp if --size is set.
+				TP=$2
+			fi
+			shift 2;;
+
+		--pp)
+			if [ -z ${PP+x} ]; then  # check if undef to ignore --pp if --size is set.
+				PP=$2
+			fi
+			shift 2;;
+
+		*)
+			echo "Unexpected argument $1" >&2
+			usage
+			exit 1
+	esac
+done
+
+if [ -z ${TP+x} ]; then
+	echo Neither --size nor --tp was specified. >&2
+	exit 1
+fi
+
+if [ -z ${PP+x} ]; then
+	echo Neither --size nor --pp was specified. >&2
+	exit 1
+fi
+
+if [ -z ${ITERATION+x} ]; then
+	ITERATION=$DEF_IT
+fi
+if [ -z ${TASKS+x} ]; then
+	TASKS=$DEF_TASKS
+fi
+if [ -z ${LIMIT+x} ]; then
+	LIMIT=$DEF_LIMIT
+fi
+
+# Build eval args depending on this scripts args.
+if [ $LIMIT != null ]; then
+	LIMIT_ARGS="--limit=$LIMIT"
+fi
+if [ $ITERATION = latest ]; then
+	ITERATION=$(cat $CHECKPOINT_PATH/latest_checkpointed_iteration.txt)
+fi
+
+if [ ! -z ${WANDB_ENTITY+x} ] || [ ! -z ${WANDB_PROJECT+x} ] || [ ! -z ${WANDB_ID+x} ]; then
+	if [ -z ${WANDB_ENTITY+x} ] || [ -z ${WANDB_PROJECT+x} ] || [ -z ${WANDB_ID+x} ]; then
+		echo "Either all --wandb-entity, --wandb-project and --wandb-id should be set, or neither" >&2
+		exit 1
+	fi
+	WANDB_ARGS="--wandb_args entity=$WANDB_ENTITY,project=$WANDB_PROJECT,id=$WANDB_ID,resume=allow,step=$ITERATION"
+fi
+
+# Make sure TP and PP settings make sense.
+GPUS_PER_NODE=4
+WORLD_SIZE=$(($TP*PP))
+if (( WORLD_SIZE > GPUS_PER_NODE )); then
+	echo "tp*pp > gpus_per_node not supported yet" >&2
+	exit 1
+fi
+if [ $WORLD_SIZE -eq 0 ]; then  # TODO: fix this optimization, not used for now as WORLD_SIZE>0 always.
+	echo "tp*pp = 1. DP optimization enabled"
+	NPROC_PER_NODE=$GPUS_PER_NODE
+	DP=$GPUS_PER_NODE
+else
+	NPROC_PER_NODE=$WORLD_SIZE
+	DP=1
+fi
+
+# Some useful variables.
+JOBNAME=evaluate_$(echo $CHECKPOINT_PATH | tr / _)
+ENDPOINT_PORT=5000
+MBS=1
+TORCHRUN_ARGS=(
+	--nproc-per-node $NPROC_PER_NODE
+	--nnodes 1
+	--master-addr localhost
+	--master-port $(($ENDPOINT_PORT + 1000))
+)
+
+# Now let's prepare the sbatch.
+cat > $SBATCH_PATH <<- EOM
+#!/bin/bash
+#SBATCH --account=a-a06
+#SBATCH --cpus-per-task=288
+#SBATCH --gres=gpu:4
+#SBATCH --environment=$CONTAINER_PATH
+#SBATCH --job-name=$JOBNAME
+#SBATCH --mem=460000
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --output=$LOGS_DIR/${JOBNAME}_%j.out
+#SBATCH --error=$LOGS_DIR/${JOBNAME}_%j.err
+#SBATCH --time=12:00:00
+#SBATCH --exclusive
+#SBATCH --dependency=singleton
+
+# Step 0: Some useful logs.
+export MASTER_ADDR=\$(hostname)
+echo "Using nodes: \$SLURM_JOB_NODELIST"
+srun -l bash -c 'echo \$(hostname) \$(nvidia-smi | grep -o "|\\s*[0-9]*MiB")'
+
+srun -l --unbuffered numactl --membind=0-3 bash -c "
+	export CUDA_DEVICE_MAX_CONNECTIONS=1
+	set -e
+
+	# Step 1: Launch inference endpoint.
+	echo Spinning inference endpoint
+	cd $MEGATRON_PATH
+	torchrun ${TORCHRUN_ARGS[@]} tools/run_text_generation_server.py --tensor-model-parallel-size=$TP --pipeline-model-parallel-size=$PP --use-checkpoint-args --load=$CHECKPOINT_PATH --bf16 --micro-batch-size=$MBS --max-batch-size=$DP --tokenizer-type=HuggingFaceTokenizer --tokenizer-model=$TOKENIZER --seed=42 --port=$ENDPOINT_PORT --ckpt-step=$ITERATION --finetune &
+
+	# Step 2: Launch lm-harness.
+	echo Running lm-eval-harness.
+	cd $LM_HARNESS_PATH
+	python lm_eval/__main__.py --model local-completions --tasks $TASKS --model_args base_url=http://localhost:5000/completions,tokenized_requests=False,tokenizer=$TOKENIZER,num_concurrent=8,timeout=43200 --batch_size=$DP --output=eval_\$SLURM_JOBID $LIMIT_ARGS $WANDB_ARGS
+"
+EOM
+
+echo Saved sbatch to $SBATCH_PATH
+OUT=$(sbatch $SBATCH_PATH)
+echo $OUT
+
+IFS=' ' read -ra CHUNKS <<< $OUT
+JOBID=${CHUNKS[-1]}
+echo Logs go to: $LOGS_DIR/${JOBNAME}_$JOBID.out

--- a/tools/checkpoint/loader_core.py
+++ b/tools/checkpoint/loader_core.py
@@ -220,6 +220,7 @@ def _load_checkpoint(queue, args):
     md = types.SimpleNamespace()
     md.model_type = args.model_type
     md.num_layers = margs.num_layers
+    md.encoder_num_layers = margs.num_layers
     md.hidden_size = margs.hidden_size
     md.seq_length = margs.seq_length
     md.num_attention_heads = margs.num_attention_heads

--- a/tools/run_text_generation_server.py
+++ b/tools/run_text_generation_server.py
@@ -184,5 +184,5 @@ if __name__ == "__main__":
     inference_engine = get_inference_engine(args, model)
 
     if mpu.is_pipeline_first_stage() and mpu.get_tensor_model_parallel_rank() == 0:
-        server = MegatronServer(inference_engine, args)
+        server = MegatronServer(model, inference_engine, args)
         server.run("0.0.0.0",port=args.port)


### PR DESCRIPTION
Initial implementation of the evaluation pipeline. I tested it using @ischlag checkpoints (1B and 300M), results available here: https://wandb.ai/alehc/swissai-ablations.

![image](https://github.com/user-attachments/assets/83dfa39f-fb47-418a-adcd-6d652052d028)

For reproducibility purposes, I also will include the commands I used for both:
```
# 1B
WANDB_API_KEY=<key> LOGS_DIR=$PWD/eval-logs-v2 TOKENIZER=nvidia/OpenMath2-Llama3.1-8B bash scripts/evaluation/submit_evaluation.sh /capstor/store/cscs/swissai/a06/users/schlag/llama3-1b-21n --size 1 --wandb-entity alehc --wandb-project swissai-ablations --wandb-id llama3-1b-21n-eval-attempt3 --iteration 5000 --tasks hellaswag  # iteration 10k, 20k, etc were submitted as seperate commands.
# 300M
WANDB_API_KEY=<key> LOGS_DIR=$PWD/eval-logs-v2 TOKENIZER=nvidia/OpenMath2-Llama3.1-8B bash scripts/evaluation/submit_evaluation.sh /capstor/store/cscs/swissai/a06/megatron_runs/llama3_baselines/llama3-300m-8n-4096sl-256gbsz/checkpoints/ --size 1 --wandb-entity alehc --wandb-project swissai-ablations --wandb-id llama3-300m-8n-4096sl-256gbsz-eval-attempt2 --iteration 2000 --tasks hellaswag  # iterations 4k, 6k, 8k were submitted as sperate commands.
```

There are a few limitations/things to consider regarding the current implementation:
- Multi-gpu is not yet supported.
- Parallel evaluation of the same checkpoint in different iterations is not supported (enforced via the `#SBATCH --dependency=singleton`).
- The `--wandb-id` should be **different** from the training run.

For more information about this limitations and usage instructions see `scripts/evaluation/README.md`.