### PR TITLE
Improved performance of the 8B model

### DIFF
--- a/submit-llama3-8b.sh
+++ b/submit-llama3-8b.sh
@@ -150,11 +150,11 @@ LEARNING_RATE_ARGS=(
 	--lr-warmup-iters 2000
 )
 
-#	--load $CKPT_DIR  # delete this to NOT reload from the latest checkpoint
 CHECKPOINTING_ARGS=(
 	--save $CKPT_DIR
 	--save-interval $CHECKPOINT_STEPS
 	--ckpt-format torch_dist
+	--load $CKPT_DIR  # delete this to NOT reload from the latest checkpoint
 	--async-save
 )
 

--- a/submit-llama3-8b.sh
+++ b/submit-llama3-8b.sh
@@ -23,9 +23,9 @@ DATASETS="/capstor/store/cscs/swissai/a06/datasets_tokenized/nemo/Llama-3.1-70B/
 # This config trains for ~100B tokens with 1024 * 4096 = 4_194_304 tokens per batch.
 # Results in 1024 / 4 = 256 forward passes with 2 replicas per node requires 128 nodes such 
 # that each replica does batch accumulation of 1 and 64 nodes for batch accumulation of 8.
-MBS=4 # Note(ischlag) mbsz > 1 and cp > 1 is broken
-GBS=1024
-SEQ_LEN=4096 
+MBS=1
+GBS=512
+SEQ_LEN=8192 
 TRAINING_STEPS=23842
 CHECKPOINT_STEPS=1000
 
@@ -40,7 +40,7 @@ MEGATRON_LM_DIR=/iopsstor/scratch/cscs/$USER/Megatron-LM
 DATASET_CACHE_DIR=/iopsstor/scratch/cscs/$USER/datasets/cache
 
 # Logging directories & artifacts
-PROJECT_NAME=Meditron-Clariden
+PROJECT_NAME=Megatron-Clariden
 EXP_NAME=llama3-8b-${SLURM_NNODES}n-${SEQ_LEN}sl-${GBS}gbsz
 PROJECT_DIR=$MEGATRON_LM_DIR/logs/Meg-Runs/$PROJECT_NAME
 
@@ -163,9 +163,8 @@ MIXED_PRECISION_ARGS=(
 )
 
 DISTRIBUTED_ARGS=(
-	--tensor-model-parallel-size 2
+	--tensor-model-parallel-size 1
 	--pipeline-model-parallel-size 1
-	--context-parallel-size 1
 	--use-distributed-optimizer
     --overlap-grad-reduce
     --overlap-param-gather


### PR DESCRIPTION
With 64 nodes we are able to fit the 8B with sequence length = 8192 in a single GPU (Thanks to the distributed optimizer). Check the wandb runs [here](https://wandb.ai/tj-solergibert/Clariden-8B-performance-64n?nw=nwusertjsolergibert&panelDisplayName=tokens-per-sec-per-gpu&panelSectionName=Charts). Summary:
- Baseline (MBS 4, SEQLEN 4096, TP 2): ~8000 Tokens/Sec/GPU
- Improved (This PR, MBS 1, SEQLEN 8192, TP 1): ~**8290** Tokens/Sec/GPU (85 GB)
- With SEQLEN 4096, MBS 2, TP 1 **& DataLoader num workers 2**: ~**8840** Tokens/Sec/GPU (87 GB)
  - Despite we get better throughput keep in mind that we halve the sequence length and we are forced to use num_workers = 2 with all the risks that this entails. Check JOB [157542](https://wandb.ai/tj-solergibert/Clariden-8B-performance-64n/runs/grwes9a4?nw=nwusertjsolergibert) for throughput with num_workers = 1.

<img width="1090" alt="image" src="https://github.com/user-attachments/assets/6bedb2cd-875e-4d1e-b7a1-7c0db4dfa63d" />
