### PR TITLE
norm logging per param

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1162,6 +1162,8 @@ def _add_logging_args(parser):
 
     group.add_argument('--log-params-norm', action='store_true',
                        help='If set, calculate and log parameters norm.')
+    group.add_argument('--log-params-norm-per-layer', action='store_true',
+                       help='If set, calculate and log parameters norm.')
     group.add_argument('--log-num-zeros-in-grad', action='store_true',
                        help='If set, calculate and log the number of zeros in gradient.')
     group.add_argument('--log-throughput', action='store_true',

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1162,7 +1162,7 @@ def _add_logging_args(parser):
 
     group.add_argument('--log-params-norm', action='store_true',
                        help='If set, calculate and log parameters norm.')
-    group.add_argument('--log-params-norm-per-layer', action='store_true',
+    group.add_argument('--log-params-norm-per-param', action='store_true',
                        help='If set, calculate and log parameters norm.')
     group.add_argument('--log-num-zeros-in-grad', action='store_true',
                        help='If set, calculate and log the number of zeros in gradient.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1163,7 +1163,7 @@ def _add_logging_args(parser):
     group.add_argument('--log-params-norm', action='store_true',
                        help='If set, calculate and log parameters norm.')
     group.add_argument('--log-params-norm-per-param', action='store_true',
-                       help='If set, calculate and log parameters norm.')
+                       help='If set, calculate and log norm for each parameter individually.')
     group.add_argument('--log-num-zeros-in-grad', action='store_true',
                        help='If set, calculate and log the number of zeros in gradient.')
     group.add_argument('--log-throughput', action='store_true',

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -74,6 +74,7 @@ from .async_utils import maybe_finalize_async_save
 from .utils import (
     append_to_progress_log,
     calc_params_l2_norm,
+    calc_params_l2_norm_per_layer,
     check_adlr_autoresume_termination,
     logical_and_across_model_parallel_group,
     reduce_max_stat_across_model_parallel_group,
@@ -869,7 +870,7 @@ def train_step(forward_step_func, data_iterator,
 
 def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_rate, iteration,
                  loss_scale, report_memory_flag, skipped_iter,
-                 grad_norm, params_norm, num_zeros_in_grad):
+                 grad_norm, params_norm, params_norm_per_layer, num_zeros_in_grad):
     """Log training information such as losses, timing, ...."""
     args = get_args()
     timers = get_timers()
@@ -1017,6 +1018,13 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
                               args.consumed_train_samples)
             if wandb_writer:
                 wandb_writer.log({'params-norm': params_norm}, iteration)
+        if params_norm_per_layer is not None:
+            for k, v in params_norm_per_layer.items():
+                writer.add_scalar(f'params-norm/{k}', v, iteration)
+                writer.add_scalar(f'params-norm vs samples/{k}', v,
+                              args.consumed_train_samples)
+                if wandb_writer:
+                    wandb_writer.log({f'params-norm/{k}': v}, iteration)
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
@@ -1578,6 +1586,10 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
 
         if args.log_params_norm:
             params_norm = calc_params_l2_norm(model)
+        params_norm_per_layer = None
+        if args.log_params_norm_per_layer:
+            params_norm_per_layer = calc_params_l2_norm_per_layer(model)
+
         learning_rate = None
         decoupled_learning_rate = None
         for param_group in optimizer.param_groups:
@@ -1590,7 +1602,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                                           decoupled_learning_rate,
                                           iteration, loss_scale,
                                           report_memory_flag, skipped_iter,
-                                          grad_norm, params_norm, num_zeros_in_grad)
+                                          grad_norm, params_norm, params_norm_per_layer, num_zeros_in_grad)
 
         # Evaluation.
         if args.eval_interval and iteration % args.eval_interval == 0 and \

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -74,7 +74,7 @@ from .async_utils import maybe_finalize_async_save
 from .utils import (
     append_to_progress_log,
     calc_params_l2_norm,
-    calc_params_l2_norm_per_layer,
+    calc_params_l2_norm_per_param,
     check_adlr_autoresume_termination,
     logical_and_across_model_parallel_group,
     reduce_max_stat_across_model_parallel_group,
@@ -870,7 +870,7 @@ def train_step(forward_step_func, data_iterator,
 
 def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_rate, iteration,
                  loss_scale, report_memory_flag, skipped_iter,
-                 grad_norm, params_norm, params_norm_per_layer, num_zeros_in_grad):
+                 grad_norm, params_norm, params_norm_per_param, num_zeros_in_grad):
     """Log training information such as losses, timing, ...."""
     args = get_args()
     timers = get_timers()
@@ -1018,8 +1018,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
                               args.consumed_train_samples)
             if wandb_writer:
                 wandb_writer.log({'params-norm': params_norm}, iteration)
-        if params_norm_per_layer is not None:
-            for k, v in params_norm_per_layer.items():
+        if params_norm_per_param is not None:
+            for k, v in params_norm_per_param.items():
                 writer.add_scalar(f'params-norm/{k}', v, iteration)
                 writer.add_scalar(f'params-norm vs samples/{k}', v,
                               args.consumed_train_samples)
@@ -1586,9 +1586,9 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
 
         if args.log_params_norm:
             params_norm = calc_params_l2_norm(model)
-        params_norm_per_layer = None
-        if args.log_params_norm_per_layer:
-            params_norm_per_layer = calc_params_l2_norm_per_layer(model)
+        params_norm_per_param = None
+        if args.log_params_norm_per_param:
+            params_norm_per_param = calc_params_l2_norm_per_param(model)
 
         learning_rate = None
         decoupled_learning_rate = None
@@ -1602,7 +1602,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                                           decoupled_learning_rate,
                                           iteration, loss_scale,
                                           report_memory_flag, skipped_iter,
-                                          grad_norm, params_norm, params_norm_per_layer, num_zeros_in_grad)
+                                          grad_norm, params_norm, params_norm_per_param, num_zeros_in_grad)
 
         # Evaluation.
         if args.eval_interval and iteration % args.eval_interval == 0 and \

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -511,7 +511,7 @@ def get_batch_on_this_tp_rank(data_iterator):
 def update_use_dist_ckpt(args):
     args.use_dist_ckpt = args.ckpt_format != "torch"
 
-def calc_params_l2_norm_per_layer(model):
+def calc_params_l2_norm_per_param(model):
     """
     Calculate the L2 norm of each parameter individually, while properly synchronizing
     over the different parallel groups (data, model, and expert/pipeline parallel groups).


### PR DESCRIPTION
with the flag `log-params-norm-per-param`, allows to log the l2 norms of all parameters. i have not done throughput tests yet (we should), but his will be helpful for debugging when the loss explodes to potentially pinpoint the source 

EDIT: i had tried with DP and TP, where the global norm matches (up to some precision) the summed up norms of the individual norms calculated by the new function. also, i removed the incorrect lines that i myself had added to the global norm computation -- not sure what was going wrong before when i was testing it, but it is working fine now