### PR TITLE
Small fixes

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1085,24 +1085,19 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
         eta = str(timedelta(seconds=int(eta_seconds)))
 
         if writer:
+            writer.add_scalar('iteration-time', elapsed_time_per_iteration, iteration)
             writer.add_scalar('tokens-per-sec-per-GPU', tokens_per_sec_per_gpu, iteration)
             writer.add_scalar('eta-seconds', eta_seconds, iteration)
             
         if wandb_writer:
             wandb_writer.log({
+                'iteration-time': elapsed_time_per_iteration,
                 'tokens-per-sec-per-GPU': tokens_per_sec_per_gpu,
                 'eta-seconds': eta_seconds
             }, iteration)
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
 
-        if args.log_timers_to_tensorboard:
-            if writer:
-                writer.add_scalar('iteration-time',
-                                  elapsed_time_per_iteration, iteration)
-            if wandb_writer:
-                wandb_writer.log({'iteration-time': elapsed_time_per_iteration},
-                                 iteration)
         log_string = f" [{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]"
         log_string += ' iteration {:8d}/{:8d} |'.format(
             iteration, args.train_iters)
@@ -1119,11 +1114,10 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
         log_string += f" tokens/sec/gpu: {tokens_per_sec_per_gpu:.1f} |"
         if args.log_throughput:
             log_string += f' throughput per GPU (TFLOP/s/GPU): {throughput:.1f} |'
-            if args.log_timers_to_tensorboard:
-                if writer:
-                    writer.add_scalar('throughput', throughput, iteration)
-                if wandb_writer:
-                    wandb_writer.log({'TFLOPs-per-GPU': throughput}, iteration)
+            if writer:
+                writer.add_scalar('throughput', throughput, iteration)
+            if wandb_writer:
+                wandb_writer.log({'TFLOPs-per-GPU': throughput}, iteration)
         # Decoupled_learning_rate should be not None only on first and last pipeline stage.
         log_string += f' learning rate: {learning_rate:.6E} |'
         if args.decoupled_lr is not None and (mpu.is_pipeline_first_stage(ignore_virtual=True) or

--- a/submit-llama3-70b.sh
+++ b/submit-llama3-70b.sh
@@ -60,7 +60,7 @@ BACKUP_CODEBASE_DIR=$EXP_DIR/Megatron-LM
 export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
-export OMP_NUM_THREADS=$((SLURM_CPUS_PER_TASK/SLURM_GPUS_PER_NODE))
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 
 # We are preparing for torch.distributed programs so it wants:
 # - MASTER_ADDR, MASTER_PORT, WORLD_SIZE - already known before `srun`
@@ -120,6 +120,7 @@ TRAINING_ARGS=(
 	--no-check-for-nan-in-loss-and-grad
 	--train-iters $TRAINING_STEPS
 	--log-interval 1
+	--eval-iters 0
 	--cross-entropy-loss-fusion
 	--disable-bias-linear
 	--optimizer adam
@@ -288,14 +289,6 @@ echo -e "\n$(nvidia-smi)" >> $COMPUTE_ENVIRONMENT_DIR # CUDA Version & Driver
 printf '=%.0s' {1..100} >> $COMPUTE_ENVIRONMENT_DIR 
 echo -e "\nEnvironment Variables:\n\n$(printenv)" >> $COMPUTE_ENVIRONMENT_DIR
 printf '=%.0s' {1..100} >> $COMPUTE_ENVIRONMENT_DIR 
-
-SRUN_ARGS=" \
-	-lu \
-	--cpus-per-task $SLURM_CPUS_PER_TASK \
-	--wait 60 \
-	--jobid $SLURM_JOB_ID \
-	--kill-on-bad-exit 1 \
-	"
 
 srun -lu bash -c 'echo $(hostname) $(nvidia-smi | grep -o "|\\s*[0-9]*MiB")' > $GPU_MEM_LOGGING
 

--- a/submit-llama3-8b.sh
+++ b/submit-llama3-8b.sh
@@ -60,7 +60,7 @@ BACKUP_CODEBASE_DIR=$EXP_DIR/Megatron-LM
 export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
-export OMP_NUM_THREADS=$((SLURM_CPUS_PER_TASK/SLURM_GPUS_PER_NODE))
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 
 # We are preparing for torch.distributed programs so it wants:
 # - MASTER_ADDR, MASTER_PORT, WORLD_SIZE - already known before `srun`
@@ -120,6 +120,7 @@ TRAINING_ARGS=(
 	--no-check-for-nan-in-loss-and-grad
 	--train-iters $TRAINING_STEPS
 	--log-interval 1
+	--eval-iters 0
 	--cross-entropy-loss-fusion
 	--disable-bias-linear
 	--optimizer adam
@@ -282,14 +283,6 @@ echo -e "\n$(nvidia-smi)" >> $COMPUTE_ENVIRONMENT_DIR # CUDA Version & Driver
 printf '=%.0s' {1..100} >> $COMPUTE_ENVIRONMENT_DIR 
 echo -e "\nEnvironment Variables:\n\n$(printenv)" >> $COMPUTE_ENVIRONMENT_DIR
 printf '=%.0s' {1..100} >> $COMPUTE_ENVIRONMENT_DIR 
-
-SRUN_ARGS=" \
-	-lu \
-	--cpus-per-task $SLURM_CPUS_PER_TASK \
-	--wait 60 \
-	--jobid $SLURM_JOB_ID \
-	--kill-on-bad-exit 1 \
-	"
 
 srun -lu bash -c 'echo $(hostname) $(nvidia-smi | grep -o "|\\s*[0-9]*MiB")' > $GPU_MEM_LOGGING
 


### PR DESCRIPTION
- By default we log `iteration-time`. Previously was necessary to set `log_timers_to_tensorboard`
- Log TFLOPs if `log_throutput` is set, no longing requiring to set `log_timers_to_tensorboard`
- In launcher scripts:
  - Corrected `OMP_NUM_THREADS`
  - Set `eval_iters` to 0. Previously we were not performing any validation as `split` is `100,0,0`, but this way is more explicit
  - Delete unused `SRUN_ARGS`
 
wandb [run](https://wandb.ai/tj-solergibert/Megatron-Clariden-logging/runs/1zmu2psr?nw=nwusertjsolergibert)