### PR TITLE
Cherry-picking upstream commit 478dfe0 to fix checkpoint writing in NGC 25.03 onwards

### DIFF
--- a/tests/unit_tests/dist_checkpointing/test_async_save.py
+++ b/tests/unit_tests/dist_checkpointing/test_async_save.py
@@ -13,7 +13,9 @@ from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 
-def write_data_os_err_mock_fn(local_proc_idx, write_bucket, results_queue, count_queue, use_fsync):
+def write_data_os_err_mock_fn(
+    transform_list, local_proc_idx, write_bucket, results_queue, count_queue, use_fsync
+):
     """Raises an error on worker #2 during storage save"""
     try:
         if local_proc_idx == 2:


### PR DESCRIPTION
This integrates minimal changes from

ADLR/megatron-lm!2796 - Extend FileSystemWriterAsync for DCP stream extensions

as suggested in 

https://swissai-initiative.slack.com/archives/C07TW7B58A3/p1746632802582019?thread_ts=1746598424.180579&cid=C07TW7B58A3

and is tested with ap3-70b on 16 GH200 nodes:
- writing checkpoints now works with NGC 25.03
- these checkpoints can also be resumed succesfully, both in an NGC 25.03 container and also in an older one (24.12)
- additionally, checkpoint writing with older images (24.12) is unaffected
