### PR TITLE
Rope Scaling Factor Fix

### DIFF
--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -133,6 +133,7 @@ def model_provider(pre_process=True, post_process=True) -> Union[GPTModel, megat
                 rotary_percent=args.rotary_percent,
                 rotary_base=args.rotary_base,
                 rope_scaling=args.use_rope_scaling,
+                rope_scaling_factor=args.rope_scaling_factor,
                 final_layernorm=args.final_layernorm,
                 input_embeddings_multiplier=args.input_embeddings_multiplier,
             )


### PR DESCRIPTION
Current code always defaults to rope_scaling_factor=8 
The one line fix properly passes rope_scaling_factor from arguments to the model