### PR TITLE
Xielu beta eps fix, model/apertus

### DIFF
--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -31,7 +31,7 @@ python tools/checkpoint/convert.py \
 	--hf-tokenizer HF_TOKENIZER_NAME  # Optional, set it to save the tokenizer config in `SAVE_DIR`.
 ```
 Set `--test-logits` if you want to make sure logits of the converted model match with the megatron implementation (only possible with TP1,PP1).
-In order to be able to convert Apertus models, we instantiate a custom HF `SwissAIForCausalLM`; make sure to install the latest version of the transformers fork before running the conversion:
+In order to be able to convert Apertus models, we instantiate a custom HF `ApertusForCausalLM`; make sure to install the latest version of the transformers fork before running the conversion:
 ```
 git clone https://github.com/swiss-ai/transformers.git
 cd transformers

--- a/tools/checkpoint/loader_core.py
+++ b/tools/checkpoint/loader_core.py
@@ -325,6 +325,18 @@ def _load_checkpoint(queue, args):
                     message["mlp xielu alpha p"] = layer["mlp_xielu_alpha_p"].cpu()
                 if layer.get("mlp_xielu_alpha_n") is not None:
                     message["mlp xielu alpha n"] = layer["mlp_xielu_alpha_n"].cpu()
+                if layer.get("mlp_xielu_beta") is not None:
+                    beta_val = layer["mlp_xielu_beta"]
+                    if hasattr(beta_val, 'cpu'):
+                        message["mlp xielu beta"] = beta_val.cpu()
+                    else:
+                        message["mlp xielu beta"] = torch.tensor(beta_val)
+                if layer.get("mlp_xielu_eps") is not None:
+                    eps_val = layer["mlp_xielu_eps"]
+                    if hasattr(eps_val, 'cpu'):
+                        message["mlp xielu eps"] = eps_val.cpu()
+                    else:
+                        message["mlp xielu eps"] = torch.tensor(eps_val)
 
                 # Grab all parallel tensors for this layer
                 qkv_weight = []

--- a/tools/checkpoint/saver_swissai_hf.py
+++ b/tools/checkpoint/saver_swissai_hf.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 
 import torch
 import torch.multiprocessing as mp
-from transformers import AutoModelForCausalLM, SwissAIConfig, SwissAIForCausalLM, GenerationConfig
+from transformers import AutoModelForCausalLM, GenerationConfig, ApertusConfig, ApertusForCausalLM
 
 sys.path.append(os.path.abspath(
     os.path.join(os.path.dirname(__file__),
@@ -114,7 +114,7 @@ def save_checkpoint(queue: mp.Queue, args):
     elif md.checkpoint_args.xielu:
         activation = "xielu"
     else:
-        raise ValueError("SwissAI model must use xielu or swiglu")
+        raise ValueError("Apertus model must use xielu or swiglu")
 
     torch_dtype = torch.float32
     if md.checkpoint_args.bf16:
@@ -152,7 +152,7 @@ def save_checkpoint(queue: mp.Queue, args):
             tokenizer.save_pretrained(args.save_dir)
 
         ### save config.json
-        llama_conf = SwissAIConfig(
+        llama_conf = ApertusConfig(
             vocab_size=md.true_vocab_size if md.true_vocab_size else md.checkpoint_args.padded_vocab_size,
             hidden_size=md.checkpoint_args.hidden_size,
             intermediate_size=md.checkpoint_args.ffn_hidden_size,
@@ -174,8 +174,8 @@ def save_checkpoint(queue: mp.Queue, args):
             torch_dtype=torch_dtype,
             attention_dropout=md.checkpoint_args.attention_dropout,
             hidden_dropout=md.checkpoint_args.hidden_dropout,
-            model_type="swissai",
-            architectures=["SwissAIForCausalLM"],
+            model_type="apertus",
+            architectures=["ApertusForCausalLM"],
             qk_norm=md.checkpoint_args.qk_layernorm,
             post_norm=md.checkpoint_args.post_layer_norm if hasattr(md.checkpoint_args, "post_layer_norm") else False
         )
@@ -363,7 +363,7 @@ def save_checkpoint(queue: mp.Queue, args):
         del state_dict
         gc.collect()
         print(f"Loading the converted pytorch checkpoint in a Llama HF model from {tmp_save_dir}")
-        model = SwissAIForCausalLM.from_pretrained(
+        model = ApertusForCausalLM.from_pretrained(
             str(tmp_save_dir), torch_dtype=torch.bfloat16, low_cpu_mem_usage=False # last arg requires a recent version of accelerate
         )
 

--- a/tools/checkpoint/saver_swissai_hf.py
+++ b/tools/checkpoint/saver_swissai_hf.py
@@ -270,6 +270,17 @@ def save_checkpoint(queue: mp.Queue, args):
                     f"model.layers.{i_layer}.mlp.act_fn.alpha_p": message["mlp xielu alpha p"],
                     f"model.layers.{i_layer}.mlp.act_fn.alpha_n": message["mlp xielu alpha n"],
                 }
+                # Add beta and eps if they exist in the message
+                if "mlp xielu beta" in message:
+                    state_dict[f"model.layers.{i_layer}.mlp.act_fn.beta"] = message["mlp xielu beta"]
+                else:
+                    # Use default value if not present
+                    state_dict[f"model.layers.{i_layer}.mlp.act_fn.beta"] = torch.tensor(0.5)
+                if "mlp xielu eps" in message:
+                    state_dict[f"model.layers.{i_layer}.mlp.act_fn.eps"] = message["mlp xielu eps"]
+                else:
+                    # Use default value if not present
+                    state_dict[f"model.layers.{i_layer}.mlp.act_fn.eps"] = torch.tensor(-1e-6)
             qkv_weights = message["qkv weight"]
             qkv_weights = qkv_weights.reshape(
                 [qkv_total_heads, head_size, llama_conf.hidden_size]

--- a/tools/checkpoint/schema_core.py
+++ b/tools/checkpoint/schema_core.py
@@ -76,6 +76,8 @@ class CoreLocalSchema(CoreSchema):
             # xielu weights
             "mlp_xielu_alpha_p" : "mlp.activation_func.alpha_p",
             "mlp_xielu_alpha_n" : "mlp.activation_func.alpha_n",
+            "mlp_xielu_beta" : "mlp.activation_func.beta",
+            "mlp_xielu_eps" : "mlp.activation_func.eps",
         })
 
 
@@ -107,6 +109,8 @@ class CoreTESchema(CoreSchema):
             # xielu weights
             "mlp_xielu_alpha_p" : "mlp.activation_func.alpha_p",
             "mlp_xielu_alpha_n" : "mlp.activation_func.alpha_n",
+            "mlp_xielu_beta" : "mlp.activation_func.beta",
+            "mlp_xielu_eps" : "mlp.activation_func.eps",
 
         })
 
@@ -143,6 +147,8 @@ class CoreMoETESchema(CoreSchema):
             # xielu weights
             **{f"mlp_xielu_alpha_p.{expert_idx}" : f"mlp.experts.local_experts.{expert_idx}.activation_func.alpha_p.weight" for expert_idx in range(num_local_experts) },
             **{f"mlp_xielu_alpha_n.{expert_idx}" : f"mlp.experts.local_experts.{expert_idx}.activation_func.alpha_n.weight" for expert_idx in range(num_local_experts) },
+            **{f"mlp_xielu_beta.{expert_idx}" : f"mlp.experts.local_experts.{expert_idx}.activation_func.beta" for expert_idx in range(num_local_experts) },
+            **{f"mlp_xielu_eps.{expert_idx}" : f"mlp.experts.local_experts.{expert_idx}.activation_func.eps" for expert_idx in range(num_local_experts) },
         })
 
 


### PR DESCRIPTION
Save Xielu beta eps parameters and change the name model from SwissAI to Apertus.