### PR TITLE
Multimodality/sft extension

### DIFF
--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -7,6 +7,7 @@ first phase of packed SFT training where you need to determine the actual
 number of packed samples without loading the full model.
 
 IMPORTANT REQUIREMENTS:
+    - SEED MUST MATCH your intended training run (determines packing)
     - Parallelism settings (TP/PP/EP) MUST match your actual training run
     - World size can be smaller (minimal DP) but TP/PP/EP must be identical
     - Model architecture params are only needed for validation (not used in packing)
@@ -122,27 +123,12 @@ def build_train_valid_test_datasets(train_val_test_num_samples):
 
     print_rank_0("> finished creating GPT datasets ...")
 
-    # Print stats and exit
-    if args.sft and args.sft_pack_samples:
-        print_rank_0("=" * 80)
-        print_rank_0("SFT DATASET PACKING - Sample counts calculated")
-        print_rank_0("=" * 80)
-        print_rank_0(f"Training dataset: {len(train_ds)} packed samples available")
-        if valid_ds:
-            print_rank_0(f"Validation dataset: {len(valid_ds)} packed samples available")
-        if test_ds:
-            print_rank_0(f"Test dataset: {len(test_ds)} packed samples available")
-        print_rank_0("=" * 80)
-        print_rank_0("Use these values to configure --train-samples for your training run.")
-        print_rank_0("Exiting now.")
-        sys.exit(0)
-    else:
-        print_rank_0("ERROR: This script requires both --sft and --sft-pack-samples flags")
-        sys.exit(1)
-
 
 def get_train_val_test_num_samples():
-    """Calculate the number of samples for train/val/test datasets."""
+    """
+    Calculate the number of samples for train/val/test datasets.
+    The numbers here are not important for sample packing calculation but needed for init.
+    """
     args = get_args()
 
     # From training.py build_train_valid_test_datasets function
@@ -161,11 +147,6 @@ def get_train_val_test_num_samples():
         eval_iters * args.global_batch_size,
         test_iters * args.global_batch_size
     ]
-
-    print_rank_0(' > datasets target sizes (minimum size):')
-    print_rank_0('    train:      {}'.format(train_val_test_num_samples[0]))
-    print_rank_0('    validation: {}'.format(train_val_test_num_samples[1]))
-    print_rank_0('    test:       {}'.format(train_val_test_num_samples[2]))
 
     return train_val_test_num_samples
 
@@ -201,6 +182,10 @@ def main():
     print_rank_0("This script will build the dataset index and report packed sample counts")
     print_rank_0("=" * 80)
     print_rank_0("")
+    print_rank_0("IMPORTANT: SEED must match your intended training run! It determines packing and thus num of samples.")
+    print_rank_0(f"  Seed: {args.seed}")
+    print_rank_0("=" * 80)
+    print_rank_0("")
     print_rank_0("IMPORTANT: Parallelism settings (TP/PP/EP) should match your training run!")
     print_rank_0(f"  Tensor Parallel: {args.tensor_model_parallel_size}")
     print_rank_0(f"  Pipeline Parallel: {args.pipeline_model_parallel_size}")
@@ -221,11 +206,8 @@ def main():
     # Calculate train/val/test sample counts
     train_val_test_num_samples = get_train_val_test_num_samples()
 
-    # Build datasets (this will trigger the packing process and exit)
+    # Build datasets (this will trigger the packing process)
     build_train_valid_test_datasets(train_val_test_num_samples)
-
-    # This shouldn't be reached
-    print_rank_0("Dataset initialization completed")
 
 
 if __name__ == "__main__":

--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+"""Initialize SFT dataset with packing to determine sample counts.
+
+This script initializes the SFT dataset in the same way as pretrain_gpt.py
+but exits immediately after dataset initialization. This is useful for the
+first phase of packed SFT training where you need to determine the actual
+number of packed samples without loading the full model.
+
+IMPORTANT REQUIREMENTS:
+    - Parallelism settings (TP/PP/EP) MUST match your actual training run
+    - World size can be smaller (minimal DP) but TP/PP/EP must be identical
+    - Model architecture params are only needed for validation (not used in packing)
+
+Usage:
+    python initialize_sft_dataset.py <same arguments as pretrain_gpt.py>
+
+    Must include: --sft --sft-pack-samples
+
+Example (for a training run with TP=8, PP=4):
+    torchrun --nproc_per_node=32 initialize_sft_dataset.py \\
+        --tensor-model-parallel-size 8 \\
+        --pipeline-model-parallel-size 4 \\
+        --num-layers 32 \\
+        --hidden-size 4096 \\
+        --seq-length 2048 \\
+        --data-path /path/to/data \\
+        --tokenizer-type GPT2BPETokenizer \\
+        --vocab-file /path/to/vocab.json \\
+        --merge-file /path/to/merges.txt \\
+        --sft \\
+        --sft-pack-samples \\
+        --train-iters 1000 \\
+        --global-batch-size 8
+
+    # Note: nproc_per_node = TP * PP = 32 (world size can be = TP*PP*minimal_DP)
+"""
+
+import sys
+from typing import List, Optional, Tuple
+
+from megatron.training import get_args
+from megatron.training import print_rank_0
+from megatron.training import get_tokenizer
+from megatron.core import mpu
+from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
+from megatron.core.datasets.gpt_dataset import MockGPTDataset, GPTDataset
+from megatron.training.initialize import initialize_megatron
+from megatron.training.utils import get_blend_and_blend_per_split
+
+
+def is_dataset_built_on_rank():
+    """Determine if dataset should be built on this rank."""
+    return (
+        mpu.is_pipeline_first_stage() or mpu.is_pipeline_last_stage()
+    ) and mpu.get_tensor_model_parallel_rank() == 0
+
+
+def core_gpt_dataset_config_from_args(args):
+    """Create GPTDatasetConfig from command line arguments."""
+    tokenizer = get_tokenizer()
+
+    # Sometimes --data-path is too long, instead we parse it from a file.
+    blend: Optional[Tuple[List[str], Optional[List[float]]]]
+    blend_per_split: Optional[List[Optional[Tuple[List[str], Optional[List[float]]]]]]
+    blend, blend_per_split = get_blend_and_blend_per_split(args)
+
+    return GPTDatasetConfig(
+        random_seed=args.seed,
+        sequence_length=args.seq_length,
+        blend=blend,
+        blend_per_split=blend_per_split,
+        split=args.split,
+        num_dataset_builder_threads=args.num_dataset_builder_threads,
+        path_to_cache=args.data_cache_path,
+        mmap_bin_files=args.mmap_bin_files,
+        tokenizer=tokenizer,
+        reset_position_ids=args.reset_position_ids,
+        reset_attention_mask=args.reset_attention_mask,
+        eod_mask_loss=args.eod_mask_loss,
+        create_attention_mask=args.create_attention_mask_in_dataloader,
+        s3_cache_path=args.s3_cache_path,
+        goldfish_loss=args.goldfish_loss,
+        goldfish_k=args.goldfish_k,
+        goldfish_h=args.goldfish_h,
+        sft_mask_special_tokens=args.sft_mask_special_tokens,
+        sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
+        sft_plw=args.sft_plw,
+        sft_pack_samples=args.sft_pack_samples
+    )
+
+
+def build_train_valid_test_datasets(train_val_test_num_samples):
+    """Build the train, test, and validation datasets.
+
+    Args:
+        train_val_test_num_samples: A list containing the number of samples in train, test, and validation.
+
+    Returns:
+        train_ds, valid_ds, test_ds: The constructed datasets
+    """
+    args = get_args()
+
+    config = core_gpt_dataset_config_from_args(args)
+
+    if args.sft:
+        from megatron.core.datasets.sft_dataset import SFTIndexedDataset
+        dataset_type = SFTIndexedDataset
+    elif args.mock_data:
+        dataset_type = MockGPTDataset
+    else:
+        dataset_type = GPTDataset
+
+    print_rank_0("> building train, validation, and test datasets for GPT ...")
+
+    train_ds, valid_ds, test_ds = BlendedMegatronDatasetBuilder(
+        dataset_type,
+        train_val_test_num_samples,
+        is_dataset_built_on_rank,
+        config
+    ).build()
+
+    print_rank_0("> finished creating GPT datasets ...")
+
+    # Print stats and exit
+    if args.sft and args.sft_pack_samples:
+        print_rank_0("=" * 80)
+        print_rank_0("SFT DATASET PACKING - Sample counts calculated")
+        print_rank_0("=" * 80)
+        print_rank_0(f"Training dataset: {len(train_ds)} packed samples available")
+        if valid_ds:
+            print_rank_0(f"Validation dataset: {len(valid_ds)} packed samples available")
+        if test_ds:
+            print_rank_0(f"Test dataset: {len(test_ds)} packed samples available")
+        print_rank_0("=" * 80)
+        print_rank_0("Use these values to configure --train-samples for your training run.")
+        print_rank_0("Exiting now.")
+        sys.exit(0)
+    else:
+        print_rank_0("ERROR: This script requires both --sft and --sft-pack-samples flags")
+        sys.exit(1)
+
+
+def get_train_val_test_num_samples():
+    """Calculate the number of samples for train/val/test datasets."""
+    args = get_args()
+
+    # From training.py build_train_valid_test_datasets function
+    # We need to determine train_val_test_num_samples
+
+    # Number of train/valid/test samples.
+    if args.train_samples:
+        train_samples = args.train_samples
+    else:
+        train_samples = args.train_iters * args.global_batch_size
+
+    eval_iters = (args.train_iters // args.eval_interval + 1) * args.eval_iters
+    test_iters = args.eval_iters
+    train_val_test_num_samples = [
+        train_samples,
+        eval_iters * args.global_batch_size,
+        test_iters * args.global_batch_size
+    ]
+
+    print_rank_0(' > datasets target sizes (minimum size):')
+    print_rank_0('    train:      {}'.format(train_val_test_num_samples[0]))
+    print_rank_0('    validation: {}'.format(train_val_test_num_samples[1]))
+    print_rank_0('    test:       {}'.format(train_val_test_num_samples[2]))
+
+    return train_val_test_num_samples
+
+
+def main():
+    """Main function to initialize dataset and exit."""
+
+    # Initialize Megatron (this handles argument parsing and distributed setup)
+    initialize_megatron(
+        extra_args_provider=None,
+        args_defaults={'tokenizer_type': 'GPT2BPETokenizer'},
+    )
+
+    args = get_args()
+
+    # Validate required arguments
+    if not args.sft or not args.sft_pack_samples:
+        print_rank_0("=" * 80)
+        print_rank_0("ERROR: This script requires both --sft and --sft-pack-samples flags")
+        print_rank_0("=" * 80)
+        print_rank_0("This script is specifically for determining packed sample counts")
+        print_rank_0("before running a full SFT training job with sample packing.")
+        print_rank_0("")
+        print_rank_0("Usage:")
+        print_rank_0("  python initialize_sft_dataset.py <args> --sft --sft-pack-samples")
+        print_rank_0("")
+        print_rank_0("For normal training without packing, use pretrain_gpt.py")
+        print_rank_0("=" * 80)
+        sys.exit(1)
+
+    print_rank_0("=" * 80)
+    print_rank_0("SFT Dataset Initialization Script")
+    print_rank_0("This script will build the dataset index and report packed sample counts")
+    print_rank_0("=" * 80)
+    print_rank_0("")
+    print_rank_0("IMPORTANT: Parallelism settings (TP/PP/EP) should match your training run!")
+    print_rank_0(f"  Tensor Parallel: {args.tensor_model_parallel_size}")
+    print_rank_0(f"  Pipeline Parallel: {args.pipeline_model_parallel_size}")
+    if args.expert_model_parallel_size > 1:
+        print_rank_0(f"  Expert Parallel: {args.expert_model_parallel_size}")
+    print_rank_0(f"  World Size: {args.world_size}")
+    print_rank_0("")
+    print_rank_0("Note: Model architecture parameters (--num-layers, --hidden-size, etc.)")
+    print_rank_0("      are only needed to pass Megatron's validation. They don't affect")
+    print_rank_0("      the dataset packing calculation, which only depends on:")
+    print_rank_0("      - Data paths and tokenizer")
+    print_rank_0("      - Sequence length (--seq-length)")
+    print_rank_0("      - Global batch size (--global-batch-size)")
+    print_rank_0("      - Parallelism settings (TP/PP/EP)")
+    print_rank_0("=" * 80)
+    print_rank_0("")
+
+    # Calculate train/val/test sample counts
+    train_val_test_num_samples = get_train_val_test_num_samples()
+
+    # Build datasets (this will trigger the packing process and exit)
+    build_train_valid_test_datasets(train_val_test_num_samples)
+
+    # This shouldn't be reached
+    print_rank_0("Dataset initialization completed")
+
+
+if __name__ == "__main__":
+    main()

--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -87,7 +87,8 @@ def core_gpt_dataset_config_from_args(args):
         sft_mask_special_tokens=args.sft_mask_special_tokens,
         sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
         sft_plw=args.sft_plw,
-        sft_pack_samples=args.sft_pack_samples
+        sft_pack_samples=args.sft_pack_samples,
+        skip_margin_samples=args.data_skip_margin_samples
     )
 
 

--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -96,7 +96,6 @@ def core_gpt_dataset_config_from_args(args):
         sft_pack_samples=args.sft_pack_samples,
         sft_equalize_sample_loss=args.sft_equalize_sample_loss,
         sft_load_loss_mask=args.sft_load_loss_mask,
-        sft_disable_assistant_mask=args.sft_disable_assistant_mask,
         skip_margin_samples=args.data_skip_margin_samples
     )
 

--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -66,9 +66,16 @@ def core_gpt_dataset_config_from_args(args):
     blend_per_split: Optional[List[Optional[Tuple[List[str], Optional[List[float]]]]]]
     blend, blend_per_split = get_blend_and_blend_per_split(args)
 
+    # Double sequence length if loading loss masks from disk (dataset stores tokens + loss_mask concatenated)
+    sequence_length = args.seq_length
+    if args.sft and args.sft_load_loss_mask:
+        sequence_length = args.seq_length * 2
+        print_rank_0(f"> SFT: Loading loss masks from disk, doubling dataset sequence_length to {sequence_length} "
+                     f"(model will see {args.seq_length} tokens)")
+
     return GPTDatasetConfig(
         random_seed=args.seed,
-        sequence_length=args.seq_length,
+        sequence_length=sequence_length,
         blend=blend,
         blend_per_split=blend_per_split,
         split=args.split,
@@ -88,6 +95,8 @@ def core_gpt_dataset_config_from_args(args):
         sft_plw=args.sft_plw,
         sft_pack_samples=args.sft_pack_samples,
         sft_equalize_sample_loss=args.sft_equalize_sample_loss,
+        sft_load_loss_mask=args.sft_load_loss_mask,
+        sft_disable_assistant_mask=args.sft_disable_assistant_mask,
         skip_margin_samples=args.data_skip_margin_samples
     )
 

--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -85,9 +85,9 @@ def core_gpt_dataset_config_from_args(args):
         goldfish_k=args.goldfish_k,
         goldfish_h=args.goldfish_h,
         sft_mask_special_tokens=args.sft_mask_special_tokens,
-        sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
         sft_plw=args.sft_plw,
         sft_pack_samples=args.sft_pack_samples,
+        sft_equalize_sample_loss=args.sft_equalize_sample_loss,
         skip_margin_samples=args.data_skip_margin_samples
     )
 

--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -214,8 +214,11 @@ class BlendedMegatronDatasetBuilder(object):
                 # The number of samples we plan to use per dataset
                 sizes_per_dataset_target = _get_size_per_split_per_dataset(weights, self.sizes)
                 # The number of samples we plan to build per dataset
+                # Skip margin if requested (useful for fixed-size datasets like SFT packed)
+                # Otherwise use margin=0.5% to ensure we have enough samples
+                margin = 0.0 if self.config.skip_margin_samples else 0.5
                 sizes_per_dataset_buffer = _get_size_per_split_per_dataset(
-                    weights, self.sizes, margin=0.5
+                    weights, self.sizes, margin=margin
                 )
 
             # Build each dataset in parallel
@@ -297,8 +300,11 @@ class BlendedMegatronDatasetBuilder(object):
                             weights, sizes_spoof
                         )
                         # The number of samples we plan to build per dataset
+                        # Skip margin if requested (useful for fixed-size datasets like SFT packed)
+                        # Otherwise use margin=0.5% to ensure we have enough samples
+                        margin = 0.0 if self.config.skip_margin_samples else 0.5
                         sizes_per_dataset_buffer = _get_size_per_split_per_dataset(
-                            weights, sizes_spoof, margin=0.5
+                            weights, sizes_spoof, margin=margin
                         )
 
                     # Build each dataset in parallel

--- a/megatron/core/datasets/blended_megatron_dataset_config.py
+++ b/megatron/core/datasets/blended_megatron_dataset_config.py
@@ -63,6 +63,11 @@ class BlendedMegatronDatasetConfig:
     tokenizer: Optional[MegatronTokenizer] = None
     """The MegatronTokenizer instance. Required for datasets that do online tokenization."""
 
+    skip_margin_samples: bool = False
+    """Whether to skip the 0.5% margin when calculating dataset sizes. When True, requests
+       exactly the number of samples needed without buffer. Useful for datasets with fixed
+       size (e.g., SFT packed datasets) where samples cannot be regenerated."""
+
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""
         if self.blend_per_split is not None and any(self.blend_per_split):

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -69,7 +69,6 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     sft_pack_samples: bool = False # Enable packing multiple whole documents per sequence for SFT
     sft_equalize_sample_loss: bool = False # loss between samples will be equal
     sft_load_loss_mask: bool = False # Load pre-computed loss masks from disk alongside tokens
-    sft_disable_assistant_mask: bool = False # Disable assistant mask computation (set to None)
 
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -264,6 +264,7 @@ class GPTDataset(MegatronDataset):
                 "attention_mask": attention_mask,
                 "loss_mask": loss_mask,
                 "position_ids": position_ids,
+                "assistant_mask": None,  # Not used for standard GPT training
             }
         else:
             return {
@@ -271,6 +272,7 @@ class GPTDataset(MegatronDataset):
                 "labels": labels,
                 "loss_mask": loss_mask,
                 "position_ids": position_ids,
+                "assistant_mask": None,  # Not used for standard GPT training
             }
 
     def _query_document_sample_shuffle_indices(

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -64,8 +64,9 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     """
     SFT Options
     """
-    sft_mask_special_tokens: bool = True
-    sft_do_not_mask_image_tokens: bool = False
+    sft_mask_special_tokens: bool = True # Mask EOD, BOD and assistant sequence begin tokens, NOT end of turn
+    sft_do_not_mask_image_tokens: bool = False # always keep image tokens unmasked
+    sft_debug: bool = False # debug prints
 
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -265,7 +265,6 @@ class GPTDataset(MegatronDataset):
                 "attention_mask": attention_mask,
                 "loss_mask": loss_mask,
                 "position_ids": position_ids,
-                "assistant_mask": None,  # Not used for standard GPT training
             }
         else:
             return {
@@ -273,7 +272,6 @@ class GPTDataset(MegatronDataset):
                 "labels": labels,
                 "loss_mask": loss_mask,
                 "position_ids": position_ids,
-                "assistant_mask": None,  # Not used for standard GPT training
             }
 
     def _query_document_sample_shuffle_indices(

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -65,10 +65,10 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     SFT Options
     """
     sft_mask_special_tokens: bool = True # Mask EOD, BOD and assistant sequence begin tokens, NOT end of turn
-    sft_do_not_mask_image_tokens: bool = False # always keep image tokens unmasked
-    sft_debug: bool = False # debug prints
+    sft_debug: bool = False # store data samples for debugging
     sft_plw: float = 0.0 # prompt loss weight used
     sft_pack_samples: bool = False # Enable packing multiple whole documents per sequence for SFT
+    sft_equalize_sample_loss: bool = False # loss between samples will be equal
 
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -61,6 +61,12 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     s3_cache_path: str = None
     """Path for caching indices for s3 dataloading."""
 
+    """
+    SFT Options
+    """
+    sft_mask_special_tokens: bool = True
+    sft_do_not_mask_image_tokens: bool = False
+
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""
         super().__post_init__()

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -67,6 +67,7 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     sft_mask_special_tokens: bool = True # Mask EOD, BOD and assistant sequence begin tokens, NOT end of turn
     sft_do_not_mask_image_tokens: bool = False # always keep image tokens unmasked
     sft_debug: bool = False # debug prints
+    sft_plw: float = 0.0 # prompt loss weight used
 
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -68,6 +68,7 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     sft_do_not_mask_image_tokens: bool = False # always keep image tokens unmasked
     sft_debug: bool = False # debug prints
     sft_plw: float = 0.0 # prompt loss weight used
+    sft_pack_samples: bool = False # Enable packing multiple whole documents per sequence for SFT
 
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -65,10 +65,11 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     SFT Options
     """
     sft_mask_special_tokens: bool = True # Mask EOD, BOD and assistant sequence begin tokens, NOT end of turn
-    sft_debug: bool = False # store data samples for debugging
     sft_plw: float = 0.0 # prompt loss weight used
     sft_pack_samples: bool = False # Enable packing multiple whole documents per sequence for SFT
     sft_equalize_sample_loss: bool = False # loss between samples will be equal
+    sft_load_loss_mask: bool = False # Load pre-computed loss masks from disk alongside tokens
+    sft_disable_assistant_mask: bool = False # Disable assistant mask computation (set to None)
 
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""

--- a/megatron/core/datasets/helpers.cpp
+++ b/megatron/core/datasets/helpers.cpp
@@ -245,6 +245,95 @@ py::array_t<T> build_sample_idx(
   );
 }
 
+template <typename DocIdx>
+py::array_t<DocIdx> build_sample_idx_packed_whole_docs(
+    const py::array_t<int32_t>& sizes_,
+    const py::array_t<DocIdx>& doc_idx_,
+    int32_t seq_length,
+    bool drop_last_partial_sequence,
+    int32_t add_extra_token_to_sequence) {
+    /* Build the sample index for SFT with whole-document packing.
+     * Pack whole documents into sequences until the next document doesn't fit.
+     * Never split documents across sequences - pad the remainder instead.
+     *
+     * Returns a 2D array [num_samples + 1, 2] where each row contains:
+     *   [document_idx_index, 0]  (offset is always 0 since we only use whole docs)
+     */
+
+    // Ensure the input arrays are not empty
+    if (sizes_.size() == 0) {
+        throw std::domain_error("sizes_ is empty");
+    }
+    if (doc_idx_.size() == 0) {
+        throw std::domain_error("doc_idx_ is empty");
+    }
+
+    // Get buffer pointers
+    const int32_t* sizes = sizes_.data();
+    const DocIdx* doc_idx = doc_idx_.data(); // doc_idx keeps track of list of document indices
+
+    // Calculate adjusted sequence length
+    int32_t adjusted_seq_length = seq_length + add_extra_token_to_sequence;
+
+    // Count the number of samples we can create
+    std::vector<std::pair<DocIdx, DocIdx>> sample_starts;
+    sample_starts.reserve(doc_idx_.size()); // estimate
+
+    // Iterate through documents and pack them
+    DocIdx doc_idx_index = 0;
+    while (doc_idx_index < doc_idx_.size()) {
+        // Start a new sample
+        sample_starts.push_back({doc_idx_index, 0});
+        int32_t remaining_seq_length = adjusted_seq_length;
+
+        // keep track of number of added documents to seq. If the 1st doc is too long, it is kept, so it can be truncated or discarded in client code
+        int32_t documents_in_sample = 0;
+
+        // Pack whole documents into this sequence
+        while (doc_idx_index < doc_idx_.size()) {
+            DocIdx doc_id = doc_idx[doc_idx_index];
+            int32_t doc_length = sizes[doc_id];
+
+            // Check if document fits in remaining space
+            if (doc_length <= remaining_seq_length) {
+                // Document fits - include it
+                remaining_seq_length -= doc_length;
+                total_tokens_seen += doc_length;
+                doc_idx_index++;
+                documents_in_sample++;
+            } else {
+                // Document doesn't fit
+                if (documents_in_sample == 0) {
+                    // if it was the 1st doc that doesnt fit, use it anyway and go to next sample. Leave truncation or discard to client code
+                    // other case: spare this doc for next sample (dont increase doc idx)
+                    doc_idx_index++;
+                }
+                break;
+            }
+
+            // If we've packed exactly to the sequence length, move to next sequence
+            if (remaining_seq_length == 0) {
+                break;
+            }
+        }
+    }
+
+    // Add the final boundary marker
+    sample_starts.push_back({doc_idx_index, 0});
+
+    // Convert to numpy array [num_samples + 1, 2]
+    size_t num_samples = sample_starts.size();
+    auto result = py::array_t<DocIdx>({num_samples, size_t(2)});
+    auto r = result.mutable_unchecked<2>();
+
+    for (size_t i = 0; i < num_samples; ++i) {
+        r(i, 0) = sample_starts[i].first;   // document_idx_index
+        r(i, 1) = sample_starts[i].second;  // offset (always 0)
+    }
+
+    return result;
+}
+
 inline int32_t get_target_sample_len(const int32_t short_seq_ratio,
                                      const int32_t max_length,
                                      std::mt19937 &rand32_gen)
@@ -841,6 +930,8 @@ PYBIND11_MODULE(helpers_cpp, m)
   m.def("build_blocks_mapping", &build_blocks_mapping);
   m.def("build_sample_idx_int32", &build_sample_idx<int32_t>);
   m.def("build_sample_idx_int64", &build_sample_idx<int64_t>);
+  m.def("build_sample_idx_packed_whole_docs_int32", &build_sample_idx_packed_whole_docs<int32_t>);
+  m.def("build_sample_idx_packed_whole_docs_int64", &build_sample_idx_packed_whole_docs<int64_t>);
   m.def("build_blending_indices", &build_blending_indices);
   m.def("build_exhaustive_blending_indices", &build_exhaustive_blending_indices);
 }

--- a/megatron/core/datasets/helpers.cpp
+++ b/megatron/core/datasets/helpers.cpp
@@ -322,7 +322,7 @@ py::array_t<DocIdx> build_sample_idx_packed_whole_docs(
     // Convert to numpy array [num_samples + 1, 2]
     size_t num_samples = sample_starts.size();
     auto result = py::array_t<DocIdx>({num_samples, size_t(2)});
-    auto r = result.mutable_unchecked<2>();
+    auto r = result.template mutable_unchecked<2>();
 
     for (size_t i = 0; i < num_samples; ++i) {
         r(i, 0) = sample_starts[i].first;   // document_idx_index

--- a/megatron/core/datasets/helpers.cpp
+++ b/megatron/core/datasets/helpers.cpp
@@ -250,7 +250,6 @@ py::array_t<DocIdx> build_sample_idx_packed_whole_docs(
     const py::array_t<int32_t>& sizes_,
     const py::array_t<DocIdx>& doc_idx_,
     int32_t seq_length,
-    bool drop_last_partial_sequence,
     int32_t add_extra_token_to_sequence) {
     /* Build the sample index for SFT with whole-document packing.
      * Pack whole documents into sequences until the next document doesn't fit.
@@ -298,7 +297,6 @@ py::array_t<DocIdx> build_sample_idx_packed_whole_docs(
             if (doc_length <= remaining_seq_length) {
                 // Document fits - include it
                 remaining_seq_length -= doc_length;
-                total_tokens_seen += doc_length;
                 doc_idx_index++;
                 documents_in_sample++;
             } else {

--- a/megatron/core/datasets/helpers.py
+++ b/megatron/core/datasets/helpers.py
@@ -64,7 +64,7 @@ def build_sample_idx(
         )
     return sample_idx
 
-
+@DeprecationWarning
 def build_sample_idx_packed_whole_docs_python(
     sizes: numpy.ndarray,
     document_indices: numpy.ndarray,
@@ -72,6 +72,9 @@ def build_sample_idx_packed_whole_docs_python(
     add_extra_token_to_sequence: bool = True,
 ):
     """Build the 2-D sample index for SFT with whole-document packing (Pure Python version)
+
+    DEPRECATED: This function is kept for reference and testing only.
+    Use build_sample_idx_packed_whole_docs() instead, which uses the optimized C++ implementation.
 
     Packs whole documents into sequences until the next document doesn't fit. Never splits
     documents across sequences.
@@ -164,7 +167,7 @@ def build_sample_idx_packed_whole_docs(
     Packs whole documents into sequences until the next document doesn't fit. Never splits
     documents across sequences.
 
-    Currently uses Python implementation. C++ version is available but not used.
+    Uses the optimized C++ implementation from helpers.cpp for better performance.
 
     Args:
         sizes (numpy.ndarray): The 1-D array of document lengths
@@ -179,29 +182,29 @@ def build_sample_idx_packed_whole_docs(
     Returns:
         numpy.ndarray: The 2-D sample index where offset column is always 0 (whole documents only)
     """
-    # Use Python implementation
-    return build_sample_idx_packed_whole_docs_python(
-        sizes,
-        document_indices,
-        sequence_length,
-        add_extra_token_to_sequence,
-    )
+    # Use C++ implementation for better performance
+    sample_idx_max = max(document_indices.shape[0], sizes.max())
+    if sample_idx_max <= numpy.iinfo(numpy.int32).max:
+        sample_idx = build_sample_idx_packed_whole_docs_int32(
+            sizes,
+            document_indices,
+            sequence_length,
+            1 if add_extra_token_to_sequence else 0,
+        )
+        assert sample_idx.min() >= 0 and sample_idx.max() <= sample_idx_max
+    else:
+        sample_idx = build_sample_idx_packed_whole_docs_int64(
+            sizes,
+            document_indices,
+            sequence_length,
+            1 if add_extra_token_to_sequence else 0,
+        )
+    return sample_idx
 
-    # C++ implementation (kept for reference, not currently used):
-    # sample_idx_max = max(document_indices.shape[0], sizes.max())
-    # if sample_idx_max <= numpy.iinfo(numpy.int32).max:
-    #     sample_idx = build_sample_idx_packed_whole_docs_int32(
-    #         sizes,
-    #         document_indices,
-    #         sequence_length,
-    #         1 if add_extra_token_to_sequence else 0,
-    #     )
-    #     assert sample_idx.min() >= 0 and sample_idx.max() <= sample_idx_max
-    # else:
-    #     sample_idx = build_sample_idx_packed_whole_docs_int64(
-    #         sizes,
-    #         document_indices,
-    #         sequence_length,
-    #         1 if add_extra_token_to_sequence else 0,
-    #     )
-    # return sample_idx
+    # Python implementation (kept for reference/testing):
+    # return build_sample_idx_packed_whole_docs_python(
+    #     sizes,
+    #     document_indices,
+    #     sequence_length,
+    #     add_extra_token_to_sequence,
+    # )

--- a/megatron/core/datasets/helpers.py
+++ b/megatron/core/datasets/helpers.py
@@ -65,14 +65,13 @@ def build_sample_idx(
     return sample_idx
 
 
-def build_sample_idx_packed_whole_docs(
+def build_sample_idx_packed_whole_docs_python(
     sizes: numpy.ndarray,
     document_indices: numpy.ndarray,
     sequence_length: int,
-    drop_last_partial_sequence: bool = True,
     add_extra_token_to_sequence: bool = True,
 ):
-    """Build the 2-D sample index for SFT with whole-document packing using C++ function
+    """Build the 2-D sample index for SFT with whole-document packing (Pure Python version)
 
     Packs whole documents into sequences until the next document doesn't fit. Never splits
     documents across sequences.
@@ -84,8 +83,95 @@ def build_sample_idx_packed_whole_docs(
 
         sequence_length (int): The sequence length
 
-        drop_last_partial_sequence (bool): Whether to omit the last partial sequence in the sample
-            index should it exist. Defaults to True.
+        add_extra_token_to_sequence (bool): Whether to build samples with sequence length
+            `sequence_length + 1`. Defaults to True.
+
+    Returns:
+        numpy.ndarray: The 2-D sample index where offset column is always 0 (whole documents only)
+    """
+    # Ensure input arrays are not empty
+    if sizes.size == 0:
+        raise ValueError("sizes array is empty")
+    if document_indices.size == 0:
+        raise ValueError("document_indices array is empty")
+
+    # Calculate adjusted sequence length
+    adjusted_seq_length = sequence_length + (1 if add_extra_token_to_sequence else 0)
+
+    # List to store sample starts as (document_idx_index, offset) pairs
+    sample_starts = []
+    num_docs = len(document_indices)
+
+    # Iterate through documents and pack them
+    doc_idx_index = 0
+    while doc_idx_index < num_docs:
+        # Start a new sample
+        sample_starts.append((doc_idx_index, 0))
+        remaining_seq_length = adjusted_seq_length
+
+        # Keep track of number of added documents to sequence
+        # If the 1st doc is too long, it is kept so it can be truncated or discarded in client code
+        documents_in_sample = 0
+
+        # Pack whole documents into this sequence
+        while doc_idx_index < num_docs:
+            doc_id = document_indices[doc_idx_index]
+            doc_length = sizes[doc_id]
+
+            # Check if document fits in remaining space
+            if doc_length <= remaining_seq_length:
+                # Document fits - include it
+                remaining_seq_length -= doc_length
+                doc_idx_index += 1
+                documents_in_sample += 1
+            else:
+                # Document doesn't fit
+                if documents_in_sample == 0:
+                    # If it was the 1st doc that doesn't fit, use it anyway and go to next sample
+                    # Leave truncation or discard to client code
+                    doc_idx_index += 1
+                # Otherwise: spare this doc for next sample (don't increase doc_idx_index)
+                break
+
+            # If we've packed exactly to the sequence length, move to next sequence
+            if remaining_seq_length == 0:
+                break
+
+    # Add the final boundary marker
+    sample_starts.append((doc_idx_index, 0))
+
+    # Convert to numpy array [num_samples + 1, 2]
+    # Determine appropriate dtype based on max index
+    max_idx = max(len(document_indices), sizes.max()) if len(sample_starts) > 0 else 0
+    if max_idx <= numpy.iinfo(numpy.int32).max:
+        dtype = numpy.int32
+    else:
+        dtype = numpy.int64
+
+    sample_index = numpy.array(sample_starts, dtype=dtype)
+
+    return sample_index
+
+
+def build_sample_idx_packed_whole_docs(
+    sizes: numpy.ndarray,
+    document_indices: numpy.ndarray,
+    sequence_length: int,
+    add_extra_token_to_sequence: bool = True,
+):
+    """Build the 2-D sample index for SFT with whole-document packing
+
+    Packs whole documents into sequences until the next document doesn't fit. Never splits
+    documents across sequences.
+
+    Currently uses Python implementation. C++ version is available but not used.
+
+    Args:
+        sizes (numpy.ndarray): The 1-D array of document lengths
+
+        document_indices (numpy.ndarray): The 1-D array of document indices
+
+        sequence_length (int): The sequence length
 
         add_extra_token_to_sequence (bool): Whether to build samples with sequence length
             `sequence_length + 1`. Defaults to True.
@@ -93,22 +179,29 @@ def build_sample_idx_packed_whole_docs(
     Returns:
         numpy.ndarray: The 2-D sample index where offset column is always 0 (whole documents only)
     """
-    sample_idx_max = max(document_indices.shape[0], sizes.max())
-    if sample_idx_max <= numpy.iinfo(numpy.int32).max:
-        sample_idx = build_sample_idx_packed_whole_docs_int32(
-            sizes,
-            document_indices,
-            sequence_length,
-            drop_last_partial_sequence,
-            1 if add_extra_token_to_sequence else 0,
-        )
-        assert sample_idx.min() >= 0 and sample_idx.max() <= sample_idx_max
-    else:
-        sample_idx = build_sample_idx_packed_whole_docs_int64(
-            sizes,
-            document_indices,
-            sequence_length,
-            drop_last_partial_sequence,
-            1 if add_extra_token_to_sequence else 0,
-        )
-    return sample_idx
+    # Use Python implementation
+    return build_sample_idx_packed_whole_docs_python(
+        sizes,
+        document_indices,
+        sequence_length,
+        add_extra_token_to_sequence,
+    )
+
+    # C++ implementation (kept for reference, not currently used):
+    # sample_idx_max = max(document_indices.shape[0], sizes.max())
+    # if sample_idx_max <= numpy.iinfo(numpy.int32).max:
+    #     sample_idx = build_sample_idx_packed_whole_docs_int32(
+    #         sizes,
+    #         document_indices,
+    #         sequence_length,
+    #         1 if add_extra_token_to_sequence else 0,
+    #     )
+    #     assert sample_idx.min() >= 0 and sample_idx.max() <= sample_idx_max
+    # else:
+    #     sample_idx = build_sample_idx_packed_whole_docs_int64(
+    #         sizes,
+    #         document_indices,
+    #         sequence_length,
+    #         1 if add_extra_token_to_sequence else 0,
+    #     )
+    # return sample_idx

--- a/megatron/core/datasets/helpers.py
+++ b/megatron/core/datasets/helpers.py
@@ -64,97 +64,6 @@ def build_sample_idx(
         )
     return sample_idx
 
-@DeprecationWarning
-def build_sample_idx_packed_whole_docs_python(
-    sizes: numpy.ndarray,
-    document_indices: numpy.ndarray,
-    sequence_length: int,
-    add_extra_token_to_sequence: bool = True,
-):
-    """Build the 2-D sample index for SFT with whole-document packing (Pure Python version)
-
-    DEPRECATED: This function is kept for reference and testing only.
-    Use build_sample_idx_packed_whole_docs() instead, which uses the optimized C++ implementation.
-
-    Packs whole documents into sequences until the next document doesn't fit. Never splits
-    documents across sequences.
-
-    Args:
-        sizes (numpy.ndarray): The 1-D array of document lengths
-
-        document_indices (numpy.ndarray): The 1-D array of document indices
-
-        sequence_length (int): The sequence length
-
-        add_extra_token_to_sequence (bool): Whether to build samples with sequence length
-            `sequence_length + 1`. Defaults to True.
-
-    Returns:
-        numpy.ndarray: The 2-D sample index where offset column is always 0 (whole documents only)
-    """
-    # Ensure input arrays are not empty
-    if sizes.size == 0:
-        raise ValueError("sizes array is empty")
-    if document_indices.size == 0:
-        raise ValueError("document_indices array is empty")
-
-    # Calculate adjusted sequence length
-    adjusted_seq_length = sequence_length + (1 if add_extra_token_to_sequence else 0)
-
-    # List to store sample starts as (document_idx_index, offset) pairs
-    sample_starts = []
-    num_docs = len(document_indices)
-
-    # Iterate through documents and pack them
-    doc_idx_index = 0
-    while doc_idx_index < num_docs:
-        # Start a new sample
-        sample_starts.append((doc_idx_index, 0))
-        remaining_seq_length = adjusted_seq_length
-
-        # Keep track of number of added documents to sequence
-        # If the 1st doc is too long, it is kept so it can be truncated or discarded in client code
-        documents_in_sample = 0
-
-        # Pack whole documents into this sequence
-        while doc_idx_index < num_docs:
-            doc_id = document_indices[doc_idx_index]
-            doc_length = sizes[doc_id]
-
-            # Check if document fits in remaining space
-            if doc_length <= remaining_seq_length:
-                # Document fits - include it
-                remaining_seq_length -= doc_length
-                doc_idx_index += 1
-                documents_in_sample += 1
-            else:
-                # Document doesn't fit
-                if documents_in_sample == 0:
-                    # If it was the 1st doc that doesn't fit, use it anyway and go to next sample
-                    # Leave truncation or discard to client code
-                    doc_idx_index += 1
-                # Otherwise: spare this doc for next sample (don't increase doc_idx_index)
-                break
-
-            # If we've packed exactly to the sequence length, move to next sequence
-            if remaining_seq_length == 0:
-                break
-
-    # Add the final boundary marker
-    sample_starts.append((doc_idx_index, 0))
-
-    # Convert to numpy array [num_samples + 1, 2]
-    # Determine appropriate dtype based on max index
-    max_idx = max(len(document_indices), sizes.max()) if len(sample_starts) > 0 else 0
-    if max_idx <= numpy.iinfo(numpy.int32).max:
-        dtype = numpy.int32
-    else:
-        dtype = numpy.int64
-
-    sample_index = numpy.array(sample_starts, dtype=dtype)
-
-    return sample_index
-
 
 def build_sample_idx_packed_whole_docs(
     sizes: numpy.ndarray,
@@ -201,10 +110,3 @@ def build_sample_idx_packed_whole_docs(
         )
     return sample_idx
 
-    # Python implementation (kept for reference/testing):
-    # return build_sample_idx_packed_whole_docs_python(
-    #     sizes,
-    #     document_indices,
-    #     sequence_length,
-    #     add_extra_token_to_sequence,
-    # )

--- a/megatron/core/datasets/helpers.py
+++ b/megatron/core/datasets/helpers.py
@@ -6,6 +6,7 @@ import numpy
 # Explicit imports for readability
 from megatron.core.datasets.helpers_cpp import *
 from megatron.core.datasets.helpers_cpp import build_sample_idx_int32, build_sample_idx_int64
+from megatron.core.datasets.helpers_cpp import build_sample_idx_packed_whole_docs_int32, build_sample_idx_packed_whole_docs_int64
 
 
 def build_sample_idx(
@@ -58,6 +59,55 @@ def build_sample_idx(
             sequence_length,
             num_epochs,
             tokens_per_epoch,
+            drop_last_partial_sequence,
+            1 if add_extra_token_to_sequence else 0,
+        )
+    return sample_idx
+
+
+def build_sample_idx_packed_whole_docs(
+    sizes: numpy.ndarray,
+    document_indices: numpy.ndarray,
+    sequence_length: int,
+    drop_last_partial_sequence: bool = True,
+    add_extra_token_to_sequence: bool = True,
+):
+    """Build the 2-D sample index for SFT with whole-document packing using C++ function
+
+    Packs whole documents into sequences until the next document doesn't fit. Never splits
+    documents across sequences.
+
+    Args:
+        sizes (numpy.ndarray): The 1-D array of document lengths
+
+        document_indices (numpy.ndarray): The 1-D array of document indices
+
+        sequence_length (int): The sequence length
+
+        drop_last_partial_sequence (bool): Whether to omit the last partial sequence in the sample
+            index should it exist. Defaults to True.
+
+        add_extra_token_to_sequence (bool): Whether to build samples with sequence length
+            `sequence_length + 1`. Defaults to True.
+
+    Returns:
+        numpy.ndarray: The 2-D sample index where offset column is always 0 (whole documents only)
+    """
+    sample_idx_max = max(document_indices.shape[0], sizes.max())
+    if sample_idx_max <= numpy.iinfo(numpy.int32).max:
+        sample_idx = build_sample_idx_packed_whole_docs_int32(
+            sizes,
+            document_indices,
+            sequence_length,
+            drop_last_partial_sequence,
+            1 if add_extra_token_to_sequence else 0,
+        )
+        assert sample_idx.min() >= 0 and sample_idx.max() <= sample_idx_max
+    else:
+        sample_idx = build_sample_idx_packed_whole_docs_int64(
+            sizes,
+            document_indices,
+            sequence_length,
             drop_last_partial_sequence,
             1 if add_extra_token_to_sequence else 0,
         )

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -146,6 +146,11 @@ class SFTIndexedDataset(GPTDataset):
             )
 
         if path_to_cache:
+            log_single_rank(
+                logger,
+                logging.WARNING,
+                f"path_to_cache exists! Search for indices in: {path_to_cache}",
+            )
             base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}-packed"
             get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
             path_to_description = get_path_to("description.txt")
@@ -173,19 +178,17 @@ class SFTIndexedDataset(GPTDataset):
             log_single_rank(
                 logger,
                 logging.INFO,
-                f"Build and save the {type(self).__name__} {self.index_split.name} packed indices",
+                f"No cached indices! Build and save the {type(self).__name__} {self.index_split.name} packed indices",
             )
 
             t_beg = time.time()
 
             sequence_length = self.config.sequence_length
             num_epochs = self._get_num_epochs_packed()
-
-            # SFT packing: use only ONE epoch (no document replication)
             numpy_random_state = np.random.RandomState(self.config.random_seed)
 
             # Copy of base document indices (num_epochs times). Shuffled within each copy.
-            document_index = _build_document_index_packed(num_epochs, self.indices.copy().astype(np.int32), numpy_random_state)
+            document_index = _build_document_index(num_epochs, self.indices.copy().astype(np.int32), numpy_random_state)
 
             # Build the sample index using whole-document packing
             assert document_index.dtype == np.int32
@@ -206,7 +209,6 @@ class SFTIndexedDataset(GPTDataset):
 
             num_samples_available = sample_index.shape[0] - 1
 
-            # Log packing statistics
             self._log_packing_statistics(document_index, sample_index, from_cache=False)
 
             # Validate: if num_samples requested exceeds what's available, abort
@@ -309,6 +311,11 @@ class SFTIndexedDataset(GPTDataset):
             )
 
         if path_to_cache:
+            log_single_rank(
+                logger,
+                logging.WARNING,
+                f"path_to_cache exists! Search for indices in: {path_to_cache}",
+            )
             base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}"
             get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
             path_to_description = get_path_to("description.txt")
@@ -351,11 +358,8 @@ class SFTIndexedDataset(GPTDataset):
                 docs_per_epoch = len(self.indices)
                 num_epochs = (num_samples + docs_per_epoch - 1) // docs_per_epoch
 
-            # Build document index by repeating indices for each epoch
-            document_index = np.tile(self.indices, num_epochs).astype(np.int32)
-
-            # Shuffle all documents
-            numpy_random_state.shuffle(document_index)
+            # Build document index by repeating indices for each epoch (shuffle per epoch)
+            document_index = _build_document_index(num_epochs, self.indices.copy().astype(np.int32), numpy_random_state)
 
             # Truncate to exact number of samples if specified (ex. If last epoch is partial)
             if self.num_samples is not None:
@@ -765,7 +769,7 @@ def get_matching_mask_by_start_end(sequence, begin_seq: torch.Tensor, end_seq: t
     return mask
 
 
-def _build_document_index_packed(num_epochs: int,
+def _build_document_index(num_epochs: int,
                                  documents: np.ndarray,
                                  numpy_random_state: np.random.RandomState
 ) -> np.ndarray:

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -4,6 +4,8 @@ import time
 import os
 import logging
 import numpy as np
+import json
+from pathlib import Path
 import torch
 import torch.nn.functional as F
 
@@ -33,6 +35,8 @@ class SFTIndexedDataset(GPTDataset):
         # Call Megatron Dataset init instead of direct parent, as we initialize index differently
         MegatronDataset.__init__(self, dataset, dataset_path, indexed_indices, num_samples, index_split, config)
 
+        self.debug_writer = DebugDataWriter(output_dir="/users/rkreft/debug_data")  # Initialize once, outside the loop
+
         self.tokenizer = config.tokenizer
         # Set pad token
         try:
@@ -40,7 +44,7 @@ class SFTIndexedDataset(GPTDataset):
         except Exception:
             self._pad_token_id = _PAD_TOKEN_ID
 
-        # End of Document token to add end to truncated samples
+        # End of Document token to add end to truncated samples TODO: currently works with HF tokenizers only
         self._eod_token_id = self.tokenizer.eod
         self._bos_token_id = self.tokenizer.bos
         # TODO: Pass sequences dynamically
@@ -49,13 +53,18 @@ class SFTIndexedDataset(GPTDataset):
         self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>', add_special_tokens=False)
         self._sft_assistant_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>assistant<|end_header_id|>',
                                                                 add_special_tokens=False)
+        # TODO: Make multimodality optional - configurable or just leave this as long as there is only one option?
+        self._img_begin_sequence = self.tokenizer.tokenize('<|img_start|>', add_special_tokens=False)
+        self._img_end_sequence = self.tokenizer.tokenize('<|img_end|>', add_special_tokens=False)
+
         # Configure token(sequences to remove from loss calculations)
         self.tokens_to_mask = [] # a list of: token ids or sequences of token ids to mask
         if self.config.sft_mask_special_tokens:
             # add tokenizer special tokens like EOS, BOS to be masked
-            self.tokens_to_mask += list(self.tokenizer.special_tokens)
-            self.tokens_to_mask.append(self._sft_user_assistant_sequence)
-        logger.warning(f"Masking the following tokens/token-sequences: {self.tokens_to_mask}")
+            self.tokens_to_mask.append([self._eod_token_id])
+            self.tokens_to_mask.append([self._bos_token_id])
+            self.tokens_to_mask.append(self._sft_assistant_begin_sequence)
+        log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {self.tokens_to_mask}", )
 
         # Build shuffle indices
         self.document_index = self._build_single_document_indices()
@@ -212,7 +221,8 @@ class SFTIndexedDataset(GPTDataset):
                 text = np.concatenate([trunc_doc, np.array([self._eod_token_id])])
             else:
                 padding_length = target_length - len(document)
-                text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+                # Pad on left side with pad token
+                text = np.concatenate([np.full(padding_length, self._pad_token_id, dtype=np.int64), document])
 
         text = torch.from_numpy(text).long()
 
@@ -250,17 +260,39 @@ class SFTIndexedDataset(GPTDataset):
         loss_mask[labels == self._pad_token_id] = 0.0
 
         # DEBUG: Log how many tokens are actually being trained on
-        #num_unmasked = loss_mask.sum().item()
-        #total_tokens = loss_mask.numel()
-        #if idx is not None and idx % 100 == 0:  # Log every 100 samples
-        #    logger.warning(f"Sample {idx}: {num_unmasked}/{total_tokens} tokens unmasked "
-        #                 f"({100*num_unmasked/total_tokens:.1f}%), "
-        #                 f"doc_length={len(torch.from_numpy(document))}, "
-        #                 f"num_pad_tokens={(labels == self._pad_token_id).sum().item()}")
-        #    user_begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
-        #    logger.warning(f"Sample {idx}: Looking for user_begin pattern: {user_begin_seq.tolist()}")
-        #    logger.warning(f"Sample {idx}: Token sequence sample: {tokens[:100].tolist()}")
-        #    logger.warning(f"Sample {idx}: Loss mask sample: {loss_mask[:100].tolist()}")
+        num_unmasked = loss_mask.sum().item()
+        total_tokens = loss_mask.numel()
+
+        if False and idx is not None and idx % 100 == 0:  # Log every 100 samples
+            logger.warning(f"Sample {idx} - DOC {actual_doc_id}: {num_unmasked}/{total_tokens} tokens unmasked "
+                            f"({100*num_unmasked/total_tokens:.1f}%), "
+                            f"doc_length={len(torch.from_numpy(document))}, "
+                            f"num_pad_tokens={(labels == self._pad_token_id).sum().item()}")
+            
+            # Store to files
+            self.debug_writer.append_sample(
+                idx=idx,
+                actual_doc_id=actual_doc_id,
+                tokens=tokens,
+                loss_mask=loss_mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                labels=labels,
+                document_length=len(torch.from_numpy(document)),
+                pad_token_id=self._pad_token_id
+            )
+            
+            # Continue with existing logging
+            user_begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
+            logger.warning(f"Sample {idx}: Looking for user_begin pattern: {user_begin_seq.tolist()}")
+            logger.warning(f"Sample {idx}: Token sequence sample: {tokens[:100].tolist()}")
+            logger.warning(f"Sample {idx}: Loss mask sample: {loss_mask[:100].tolist()}")
+            logger.warning(f"Sample {idx}: Loss mask sample last 100: {loss_mask[-100:].tolist()}")
+            logger.warning(f"Sample {idx}: Position ids sample: {position_ids[:100].tolist()}")
+            if attention_mask is not None:
+                logger.warning(f"Sample {idx}: Attention mask sample (1=masked): {attention_mask[0,0,:100].long().tolist()}")
+        # END DEBUG
+
 
         # Map pad tokens to valid embedding indices
         tokens[tokens == self._pad_token_id] = 0
@@ -315,50 +347,8 @@ class SFTIndexedDataset(GPTDataset):
         begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
         end_seq = torch.tensor(self._sft_turn_end_sequence, dtype=tokens.dtype, device=tokens.device)
 
-        begin_len = len(begin_seq)
-        end_len = len(end_seq)
-
-        if 0 < begin_len <= len(tokens):
-            matches_begin = get_matching_mask(tokens, begin_seq, only_begin=True)
-
-            if end_len > 0:
-                matches_end = get_matching_mask(tokens, end_seq, only_begin=True)
-
-                begin_indices = torch.where(matches_begin)[0]
-                end_indices = torch.where(matches_end)[0]
-
-                # Vectorized masking
-                if len(begin_indices) > 0 and len(end_indices) > 0:
-                    # For each begin, find the next ends (vectorized)
-                    end_matrix = end_indices.unsqueeze(0) > begin_indices.unsqueeze(1)
-                    has_valid_end = end_matrix.any(dim=1)
-                    first_end_idx = end_matrix.int().argmax(dim=1)
-
-                    # Compute end positions for each begin
-                    end_positions = torch.where(
-                        has_valid_end,
-                        end_indices[first_end_idx] + end_len,
-                        len(loss_mask)
-                    )
-
-                    # Create ranges and mask in one go, Shape: (num_begins, max_range_len)
-                    max_len = (end_positions - begin_indices).max().item()
-                    ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
-                    lengths = (end_positions - begin_indices).unsqueeze(1)
-
-                    # Get all indices to mask
-                    mask_positions = begin_indices.unsqueeze(1) + ranges
-                    valid_mask = ranges < lengths
-                    indices_to_mask = mask_positions[valid_mask]
-
-                    loss_mask[indices_to_mask] = 0.0
-                elif len(begin_indices) > 0:
-                    # No end sequences, mask from each begin to the end
-                    max_len = len(loss_mask) - begin_indices.min().item()
-                    ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
-                    mask_positions = begin_indices.unsqueeze(1) + ranges
-                    valid = mask_positions < len(loss_mask)
-                    loss_mask[mask_positions[valid]] = 0.0
+        user_seq_mask = get_matching_mask_by_start_end(tokens, begin_seq, end_seq)
+        loss_mask[user_seq_mask] = 0.0
 
         # 2) Mask other token(sequences) as configured in init (might contain BOS, EOS, assistant begin)
         for t in self.tokens_to_mask:
@@ -371,19 +361,27 @@ class SFTIndexedDataset(GPTDataset):
                 raise ValueError(f"Invalid token to mask: {t}")
             loss_mask[mask] = 0.0
 
+        # 3) Unmask Image tokens if configured
+        if self.config.sft_do_not_mask_image_tokens:
+            img_begin_tensor = torch.tensor(self._img_begin_sequence, dtype=tokens.dtype, device=tokens.device)
+            img_end_tensor = torch.tensor(self._img_end_sequence, dtype=tokens.dtype, device=tokens.device)
+            img_seq_mask = get_matching_mask_by_start_end(tokens, img_begin_tensor, img_end_tensor)
+            loss_mask[img_seq_mask] = 1.0
+
+        # 4) Create attention mask, excluding padding tokens from attention
         if create_attention_mask:
             # Here me mask attention from all padding tokens to all other tokens and vice versa
             attention_mask = torch.tril(
                 torch.ones((self.config.sequence_length, self.config.sequence_length), device=tokens.device)
             )
             # Mask padding tokens in attention mask:
-            #no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
+            no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
             
             # Mask both rows (queries from padding) and columns (keys to padding)
             # Row masking: padding tokens shouldn't attend to anything
-            #attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
+            attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
             # Column masking: nothing should attend to padding tokens
-            #attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
+            attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
             
             # Convert attention mask to binary:
             attention_mask = attention_mask.unsqueeze(0)
@@ -419,3 +417,135 @@ def get_matching_mask(sequence, query: torch.Tensor, only_begin:bool=True):
     return matches
 
 
+def get_matching_mask_by_start_end(tokens, begin_seq: torch.Tensor, end_seq: torch.Tensor):
+    """
+    Given a sequence and a start and end query, return a mask indicating which positions in the sequence
+    are between the start and end queries (inclusive).
+    """
+    mask = torch.zeros(len(tokens), dtype=torch.bool, device=tokens.device)
+    begin_len = len(begin_seq)
+    end_len = len(end_seq)
+
+    if 0 < begin_len <= len(tokens):
+        matches_begin = get_matching_mask(tokens, begin_seq, only_begin=True)
+
+        if end_len > 0:
+            matches_end = get_matching_mask(tokens, end_seq, only_begin=True)
+
+            begin_indices = torch.where(matches_begin)[0]
+            end_indices = torch.where(matches_end)[0]
+
+            # Vectorized masking
+            if len(begin_indices) > 0 and len(end_indices) > 0:
+                # For each begin, find the next ends (vectorized)
+                end_matrix = end_indices.unsqueeze(0) > begin_indices.unsqueeze(1)
+                has_valid_end = end_matrix.any(dim=1)
+                first_end_idx = end_matrix.int().argmax(dim=1)
+
+                # Compute end positions for each begin
+                end_positions = torch.where(
+                    has_valid_end,
+                    end_indices[first_end_idx] + end_len,
+                    len(mask)
+                )
+
+                # Create ranges and mask in one go, Shape: (num_begins, max_range_len)
+                max_len = (end_positions - begin_indices).max().item()
+                ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
+                lengths = (end_positions - begin_indices).unsqueeze(1)
+
+                # Get all indices to mask
+                mask_positions = begin_indices.unsqueeze(1) + ranges
+                valid_mask = ranges < lengths
+                indices_to_mask = mask_positions[valid_mask]
+
+                mask[indices_to_mask] = True
+            elif len(begin_indices) > 0:
+                # No end sequences, mask from each begin to the end
+                max_len = len(mask) - begin_indices.min().item()
+                ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
+                mask_positions = begin_indices.unsqueeze(1) + ranges
+                valid = mask_positions < len(mask)
+                mask[mask_positions[valid]] = True
+    return mask
+
+
+class DebugDataWriter:
+    """Helper class to write debug data to files."""
+    
+    def __init__(self, output_dir="debug_data"):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(exist_ok=True)
+        self.metadata_file = self.output_dir / "metadata.jsonl"
+        self.tokens_file = self.output_dir / "tokens.npy"
+        self.loss_mask_file = self.output_dir / "loss_mask.npy"
+        self.attention_mask_file = self.output_dir / "attention_mask.npy"
+        
+        # Initialize files if they don't exist
+        if not self.tokens_file.exists():
+            self._init_array_file(self.tokens_file)
+        if not self.loss_mask_file.exists():
+            self._init_array_file(self.loss_mask_file)
+        if not self.attention_mask_file.exists():
+            self._init_array_file(self.attention_mask_file)
+    
+    def _init_array_file(self, filepath):
+        """Initialize an empty numpy array file."""
+        np.save(filepath, np.array([]))
+    
+    def append_sample(self, idx, actual_doc_id, tokens, loss_mask, 
+                     attention_mask=None, position_ids=None, 
+                     labels=None, document_length=None, pad_token_id=None):
+        """Append a sample to the debug files."""
+        
+        # Convert tensors to numpy
+        tokens_np = tokens.cpu().numpy() if torch.is_tensor(tokens) else tokens
+        loss_mask_np = loss_mask.cpu().numpy() if torch.is_tensor(loss_mask) else loss_mask
+        
+        # Load existing data
+        tokens_data = np.load(self.tokens_file, allow_pickle=True)
+        loss_mask_data = np.load(self.loss_mask_file, allow_pickle=True)
+        
+        # Append new data
+        if tokens_data.size == 0:
+            tokens_data = np.array([tokens_np], dtype=object)
+            loss_mask_data = np.array([loss_mask_np], dtype=object)
+        else:
+            tokens_data = np.append(tokens_data, [tokens_np])
+            loss_mask_data = np.append(loss_mask_data, [loss_mask_np])
+        
+        # Save updated arrays
+        np.save(self.tokens_file, tokens_data)
+        np.save(self.loss_mask_file, loss_mask_data)
+        
+        # Handle attention mask
+        if attention_mask is not None:
+            attention_mask_np = attention_mask.cpu().numpy() if torch.is_tensor(attention_mask) else attention_mask
+            attention_mask_data = np.load(self.attention_mask_file, allow_pickle=True)
+            
+            if attention_mask_data.size == 0:
+                attention_mask_data = np.array([attention_mask_np], dtype=object)
+            else:
+                attention_mask_data = np.append(attention_mask_data, [attention_mask_np])
+            
+            np.save(self.attention_mask_file, attention_mask_data)
+        
+        # Save metadata
+        num_unmasked = loss_mask_np.sum()
+        total_tokens = loss_mask_np.size
+        
+        metadata = {
+            "sample_idx": int(idx) if idx is not None else None,
+            "doc_id": int(actual_doc_id) if actual_doc_id is not None else None,
+            "num_unmasked": int(num_unmasked),
+            "total_tokens": int(total_tokens),
+            "unmasked_percentage": float(100 * num_unmasked / total_tokens),
+            "document_length": int(document_length) if document_length is not None else None,
+            "num_pad_tokens": int((labels == pad_token_id).sum()) if labels is not None and pad_token_id is not None else None,
+            "sequence_length": int(len(tokens_np)),
+            "has_attention_mask": attention_mask is not None
+        }
+        
+        # Append metadata as JSONL
+        with open(self.metadata_file, 'a') as f:
+            f.write(json.dumps(metadata) + '\n')

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -44,7 +44,7 @@ class SFTIndexedDataset(GPTDataset):
         try:
             self._pad_token_id = self.tokenizer.pad
             log_single_rank(logger, logging.INFO, f"Using tokenizer pad token ID: {self._pad_token_id}")
-        except (AttributeError, KeyError, TypeError) as e:
+        except (AttributeError, KeyError, TypeError, NotImplementedError) as e:
             self._pad_token_id = _PAD_TOKEN_ID
             log_single_rank(logger, logging.WARNING,
                           f"Tokenizer pad token not available ({type(e).__name__}), using default: {self._pad_token_id}")
@@ -61,13 +61,13 @@ class SFTIndexedDataset(GPTDataset):
 
         # Configure token (sequences) to remove from loss calculation
         self.tokens_to_mask = []
-        if self.config.sft_mask_special_tokens:
+        if self.config.sft_mask_special_tokens and not self.config.sft_load_loss_mask:
             # add tokenizer special tokens like EOS, BOS and assistant begin to be masked. Never mask End of turn.
             self.tokens_to_mask.append(torch.tensor([self._eod_token_id], dtype=torch.long))
             self.tokens_to_mask.append(torch.tensor([self._bos_token_id], dtype=torch.long))
             self.tokens_to_mask.append(self._sft_assistant_begin_sequence)  # already a tensor
             self.tokens_to_mask.append(self._sft_user_begin_sequence)
-        log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
+        log_single_rank(logger, logging.WARNING, f"On the fly masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
 
         # Set actual model sequence length (config.sequence_length is doubled if loading loss masks from disk)
         if self.config.sft_load_loss_mask:
@@ -403,7 +403,7 @@ class SFTIndexedDataset(GPTDataset):
         # Concatenate all documents
         if len(document_tokens) > 0:
             text = np.concatenate(document_tokens)
-            eos_idx = np.concatenate(doc_end_indices).cumsum() - 1
+            eos_idx = np.array(doc_end_indices).cumsum() - 1
             if self.config.sft_load_loss_mask:
                 loss_mask_data = np.concatenate(document_loss_masks)
             else:

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -5,6 +5,7 @@ import os
 import logging
 import numpy as np
 import torch
+import torch.nn.functional as F
 
 from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID, GPTDataset, _GOLDFISH_TOKEN_ID
 from megatron.core.datasets.indexed_dataset import IndexedDataset
@@ -34,11 +35,16 @@ class SFTIndexedDataset(GPTDataset):
         # Call Megatron Dataset init instead of direct parent, as we initialize index differently
         MegatronDataset.__init__(self, dataset, dataset_path, indices, num_samples, index_split, config)
 
+        self.tokenizer = config.tokenizer
         # Set pad token
         try:
             self._pad_token_id = self.config.tokenizer.pad
         except Exception:
             self._pad_token_id = _PAD_TOKEN_ID
+
+        # TODO: Pass sequences dynamically
+        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>assistant<|end_header_id|>\n\n')
+        self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>')
 
         # Build shuffle indices
         self.document_index, self.shuffle_index = self._build_single_document_indices()
@@ -336,7 +342,41 @@ class SFTIndexedDataset(GPTDataset):
         # Loss mask.
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
-        # TODO[Raphael]: find prompts and mask them
+        # Mask user sequences for loss
+        begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
+        end_seq = torch.tensor(self._sft_turn_end_sequence, dtype=tokens.dtype, device=tokens.device)
+
+        begin_len = len(begin_seq)
+        end_len = len(end_seq)
+
+        if begin_len > 0 and len(tokens) >= begin_len:
+            # Vectorized pattern matching using unfold
+            if begin_len == 1:
+                matches_begin = (tokens == begin_seq[0])
+            else:
+                # Create sliding windows
+                windows = tokens.unfold(0, begin_len, 1)
+                # Compare all windows at once
+                matches_begin = (windows == begin_seq).all(dim=1)
+                # Pad to original length
+                matches_begin = F.pad(matches_begin, (0, begin_len - 1), value=False)
+
+            if end_len > 0:
+                if end_len == 1:
+                    matches_end = (tokens == end_seq[0])
+                else:
+                    windows = tokens.unfold(0, end_len, 1)
+                    matches_end = (windows == end_seq).all(dim=1)
+                    matches_end = F.pad(matches_end, (0, end_len - 1), value=False)
+
+                begin_indices = torch.where(matches_begin)[0]
+                end_indices = torch.where(matches_end)[0]
+
+                # Vectorized masking
+                for begin_idx in begin_indices:
+                    next_ends = end_indices[end_indices > begin_idx]
+                    end = next_ends[0].item() + end_len if len(next_ends) > 0 else len(loss_mask)
+                    loss_mask[begin_idx.item():end] = 0.0
 
         # Mask eod if wanted
         if eod_mask_loss:

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -525,10 +525,6 @@ class SFTIndexedDataset(GPTDataset):
             labels
         )
 
-        # Mask loss for padded tokens (this also masks batch padding if idx is None)
-        loss_mask[labels == self._pad_token_id] = 0.0
-        assistant_mask[labels == self._pad_token_id] = 0.0
-
         # DEBUG: if activated, log every 100 samples
         if self.config.sft_debug and idx is not None and idx % 100 == 0:  # Log every 100 samples
             num_unmasked = loss_mask.sum().item()
@@ -668,7 +664,11 @@ class SFTIndexedDataset(GPTDataset):
         else:
             attention_mask = None
 
-        # 4) Equalize sample loss
+        # 4) Mask padding tokens (must be done BEFORE equalization to ensure correct normalization)
+        loss_mask[data == self._pad_token_id] = 0.0
+        assistant_mask[data == self._pad_token_id] = 0.0
+
+        # 5) Equalize sample loss
         if self.config.sft_equalize_sample_loss:
             if len(eod_indices) > 0:
                 # Process each sample segment (between EOD tokens)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -62,13 +62,13 @@ class SFTIndexedDataset(GPTDataset):
         self._img_end_sequence = torch.tensor(self.tokenizer.img_end_token, dtype=torch.long)
 
         # Configure token (sequences) to remove from loss calculation
-        # Pre-compute as tensors for efficiency
         self.tokens_to_mask = []
         if self.config.sft_mask_special_tokens:
             # add tokenizer special tokens like EOS, BOS and assistant begin to be masked. Never mask End of turn.
             self.tokens_to_mask.append(torch.tensor([self._eod_token_id], dtype=torch.long))
             self.tokens_to_mask.append(torch.tensor([self._bos_token_id], dtype=torch.long))
             self.tokens_to_mask.append(self._sft_assistant_begin_sequence)  # already a tensor
+            self.tokens_to_mask.append(self._sft_user_begin_sequence)
         log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
 
         # Build shuffle indices
@@ -221,7 +221,7 @@ class SFTIndexedDataset(GPTDataset):
             labels = torch.roll(text, shifts=-1, dims=0)
             labels[-1] = self._pad_token_id
 
-        # Generate mask and position ids
+        # Generate mask and position ids. If PLW activated, loss mask will have partial weight for user input tokens
         attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
             labels
         )
@@ -303,9 +303,9 @@ class SFTIndexedDataset(GPTDataset):
         end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
 
         user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
-        loss_mask[user_seq_mask] = 0.0
+        loss_mask[user_seq_mask] = self.sft_plw_value # value is 0 by default for full masking
 
-        # 2) Mask other token(sequences) as configured in init (might contain BOS, EOS, assistant begin)
+        # 2) Mask other token(sequences) fully(set weight to 0) as configured in init (might contain BOS, EOS, assistant begin)
         for t in self.tokens_to_mask:
             # Use pre-computed tensor, just move to correct device/dtype
             t_tensor = t.to(dtype=data.dtype, device=data.device)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -23,7 +23,7 @@ class SFTIndexedDataset(GPTDataset):
     The dataset used during SFT. Uses Low Level Indexed Dataset to load from pre-tokenized SFT data.
     Each original document/dataset-sample is loaded one by one and padded to fill the sequence length.
     """
-    APPROX_NUM_PACKED_DOCS_PER_SEQ = 1.4
+    APPROX_NUM_PACKED_DOCS_PER_SEQ = 3
 
     def __init__(
         self,
@@ -214,10 +214,10 @@ class SFTIndexedDataset(GPTDataset):
                 add_extra_token_to_sequence=self.config.add_extra_token_to_sequence,
             )
 
-            num_samples_available = sample_index.shape[0] - 1
-
+            # TODO: packing statistics might be not accurate as multi-epoch support now in place!
             self._log_packing_statistics(document_index, sample_index, from_cache=False)
 
+            num_samples_available = sample_index.shape[0] - 1
             # Validate: if num_samples requested exceeds what's available, abort
             if self.num_samples is not None and self.num_samples > num_samples_available:
                 error_msg = (
@@ -226,6 +226,9 @@ class SFTIndexedDataset(GPTDataset):
                 )
                 log_single_rank(logger, logging.ERROR, error_msg)
                 raise ValueError(error_msg)
+            else:
+                # only keep samples needed
+                sample_index = sample_index[:self.num_samples]
 
             # Build the shuffle index (sample level)
             shuffle_index = _build_shuffle_index(
@@ -295,13 +298,12 @@ class SFTIndexedDataset(GPTDataset):
 
     def _get_num_epochs_packed(self) -> int:
         """
-        Calculate approximative upperbound of number of epochs based on requested samples and number of tokens per epoch.
+        Calculate approximative upperbound of number of epochs based on requested samples and number of documents per epoch.
         Assume a constant sample packing efficiency: ex. On avg 1.5 docs per sequence.
         """
         n_docs = self.numel_low_level_dataset(self.dataset)
         approx_sample_per_epoch = n_docs / self.APPROX_NUM_PACKED_DOCS_PER_SEQ
-        num_epochs = int(np.ceil(self.num_samples / approx_sample_per_epoch))
-        return num_epochs
+        return int(np.ceil(self.num_samples / approx_sample_per_epoch))
 
     def _build_single_document_indices(self) -> np.ndarray:
         """

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -228,7 +228,7 @@ class SFTIndexedDataset(GPTDataset):
                 raise ValueError(error_msg)
             else:
                 # only keep samples needed
-                sample_index = sample_index[:self.num_samples]
+                sample_index = sample_index[:self.num_samples+1]
 
             # Build the shuffle index (sample level)
             shuffle_index = _build_shuffle_index(
@@ -287,9 +287,7 @@ class SFTIndexedDataset(GPTDataset):
         if self.num_samples is not None and self.num_samples > num_samples_available:
             error_msg = (
                 f"ERROR: Requested {self.num_samples} training samples but only "
-                f"{num_samples_available} packed samples available from dataset. "
-                f"This would lead to crashed training in the end." 
-                "To mitigate this multi-epoch support would have to be supported!"
+                f"{num_samples_available} packed samples available from dataset."
             )
             log_single_rank(logger, logging.ERROR, error_msg)
             raise ValueError(error_msg)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -222,12 +222,13 @@ class SFTIndexedDataset(GPTDataset):
             labels[-1] = self._pad_token_id
 
         # Generate mask and position ids. If PLW activated, loss mask will have partial weight for user input tokens
-        attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
+        attention_mask, loss_mask, position_ids, assistant_mask = self._get_ltor_masks_and_position_ids(
             labels
         )
 
         # Mask loss for padded tokens (this also masks batch padding if idx is None)
         loss_mask[labels == self._pad_token_id] = 0.0
+        assistant_mask[labels == self._pad_token_id] = 0.0
 
         # DEBUG: if activated, log every 100 samples
         if self.config.sft_debug and idx is not None and idx % 100 == 0:  # Log every 100 samples
@@ -276,6 +277,7 @@ class SFTIndexedDataset(GPTDataset):
                 "attention_mask": attention_mask,
                 "loss_mask": loss_mask,
                 "position_ids": position_ids,
+                "assistant_mask": assistant_mask,
             }
         else:
             return {
@@ -283,6 +285,7 @@ class SFTIndexedDataset(GPTDataset):
                 "labels": labels,
                 "loss_mask": loss_mask,
                 "position_ids": position_ids,
+                "assistant_mask": assistant_mask,
             }
 
     def _get_ltor_masks_and_position_ids(self, data):
@@ -292,6 +295,7 @@ class SFTIndexedDataset(GPTDataset):
             2. Can mask arbitrary token sequences (e.g. assistant begin, assistant end, BOS, EOS)
         Both options can be Configured in the init.
         Finally, creates an attention mask if configured. The attention mask will exclude padding tokens from attention.
+        Also creates an assistant_mask to identify assistant response tokens for separate loss tracking.
         """
         assert not self.config.reset_position_ids and not self.config.reset_attention_mask
 
@@ -305,6 +309,9 @@ class SFTIndexedDataset(GPTDataset):
         user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
         loss_mask[user_seq_mask] = self.sft_plw_value # value is 0 by default for full masking
 
+        # 1b) Create assistant mask: everything that is not user sequences
+        assistant_mask = (~user_seq_mask).float()
+
         # 2) Mask other token(sequences) fully(set weight to 0) as configured in init (might contain BOS, EOS, assistant begin)
         for t in self.tokens_to_mask:
             # Use pre-computed tensor, just move to correct device/dtype
@@ -316,6 +323,8 @@ class SFTIndexedDataset(GPTDataset):
             else:
                 raise ValueError(f"Invalid token to mask: {t}")
             loss_mask[mask] = 0.0
+            # Also mask special tokens from assistant_mask
+            assistant_mask[mask] = 0.0
 
         # 3) Unmask Image tokens if configured
         if self.config.sft_do_not_mask_image_tokens:
@@ -333,20 +342,20 @@ class SFTIndexedDataset(GPTDataset):
             )
             # Mask padding tokens in attention mask:
             no_padding_mask = (data != self._pad_token_id).float() # 1=real, 0=padding
-            
+
             # Mask both rows (queries from padding) and columns (keys to padding)
             # Row masking: padding tokens shouldn't attend to anything
             attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
             # Column masking: nothing should attend to padding tokens
             attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
-            
+
             # Convert attention mask to binary:
             attention_mask = attention_mask.unsqueeze(0)
             attention_mask = attention_mask < 0.5
         else:
             attention_mask = None
 
-        return attention_mask, loss_mask, position_ids
+        return attention_mask, loss_mask, position_ids, assistant_mask
 
 
 def get_matching_mask(sequence, query: torch.Tensor, only_begin:bool=True):

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -5,8 +5,6 @@ import os
 import logging
 
 import numpy as np
-import json
-from pathlib import Path
 import torch
 import torch.nn.functional as F
 
@@ -37,9 +35,6 @@ class SFTIndexedDataset(GPTDataset):
         # Call Megatron Dataset init instead of direct parent, as we initialize index differently
         MegatronDataset.__init__(self, dataset, dataset_path, indexed_indices, num_samples, index_split, config)
 
-        if self.config.sft_debug:
-            self.debug_writer = DebugDataWriter(output_dir="/users/rkreft/debug_data")  # Initialize once, outside the loop
-
         # Set and log plw weight
         self.sft_plw_value = config.sft_plw
         log_single_rank(logger, logging.INFO, f"SFT PLW: {self.sft_plw_value}", )
@@ -48,8 +43,11 @@ class SFTIndexedDataset(GPTDataset):
         # Set pad token
         try:
             self._pad_token_id = self.tokenizer.pad
-        except Exception:
+            log_single_rank(logger, logging.INFO, f"Using tokenizer pad token ID: {self._pad_token_id}")
+        except (AttributeError, KeyError, TypeError) as e:
             self._pad_token_id = _PAD_TOKEN_ID
+            log_single_rank(logger, logging.WARNING,
+                          f"Tokenizer pad token not available ({type(e).__name__}), using default: {self._pad_token_id}")
 
         # End of Document token to add end to truncated samples TODO: currently works with HF tokenizers only
         self._eod_token_id = self.tokenizer.eod
@@ -60,8 +58,6 @@ class SFTIndexedDataset(GPTDataset):
         self._sft_user_begin_sequence = torch.tensor(self.tokenizer.sft_user_begin_sequence, dtype=torch.long)
         self._sft_turn_end_sequence = torch.tensor(self.tokenizer.sft_eot_token, dtype=torch.long)
         self._sft_assistant_begin_sequence = torch.tensor(self.tokenizer.sft_assistant_begin_sequence, dtype=torch.long)
-        self._img_begin_sequence = torch.tensor(self.tokenizer.img_begin_token, dtype=torch.long)
-        self._img_end_sequence = torch.tensor(self.tokenizer.img_end_token, dtype=torch.long)
 
         # Configure token (sequences) to remove from loss calculation
         self.tokens_to_mask = []
@@ -72,6 +68,25 @@ class SFTIndexedDataset(GPTDataset):
             self.tokens_to_mask.append(self._sft_assistant_begin_sequence)  # already a tensor
             self.tokens_to_mask.append(self._sft_user_begin_sequence)
         log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
+
+        # Set actual model sequence length (config.sequence_length is doubled if loading loss masks from disk)
+        if self.config.sft_load_loss_mask:
+            self.model_seq_length = self.config.sequence_length // 2
+            log_single_rank(logger, logging.INFO,
+                          f"Loading loss masks from disk: dataset seq_length={self.config.sequence_length}, "
+                          f"model seq_length={self.model_seq_length}")
+        else:
+            self.model_seq_length = self.config.sequence_length
+
+        # Initialize cache manager
+        self.cache_manager = IndexCacheManager(
+            config=self.config,
+            dataset_path_prefix=self.dataset.path_prefix,
+            unique_description=self.unique_description,
+            unique_description_hash=self.unique_description_hash,
+            dataset_class_name=type(self).__name__,
+            split_name=self.index_split.name
+        )
 
         # Build indices based on packing mode
         if self.config.sft_pack_samples:
@@ -90,7 +105,7 @@ class SFTIndexedDataset(GPTDataset):
         """
         Extend key attributes from Megatron dataset, to include vital sft config attributes.
         """
-        return ["random_seed", "sequence_length", "split", "split_matrix", "tokenizer", "sft_pack_samples"]
+        return ["random_seed", "sequence_length", "split", "split_matrix", "tokenizer", "sft_pack_samples", "sft_load_loss_mask"]
 
     def _log_packing_statistics(self, document_index, sample_index, from_cache=False):
         """
@@ -118,67 +133,36 @@ class SFTIndexedDataset(GPTDataset):
         log_single_rank(logger, logging.INFO, f"> Total tokens in samples: {total_tokens_in_samples:,}")
         log_single_rank(logger, logging.INFO, f"> Average tokens per sample: {avg_tokens_per_sample:.1f}")
         log_single_rank(logger, logging.INFO, f"> Average documents per sample: {avg_documents_per_sample:.2f}")
-        log_single_rank(logger, logging.INFO, f"> Token utilization: {100 * num_tokens_per_epoch / total_tokens_in_samples:.2f}%")
-        if from_cache:
-            log_single_rank(logger, logging.INFO, f"> ========================================================")
-        else:
-            log_single_rank(logger, logging.INFO, f"> ===================================")
+        log_single_rank(logger, logging.INFO, f"> Token utilization: {100 * num_tokens_per_epoch / total_tokens_in_samples:.2f}%\n\n")
 
     def _build_packing_document_to_sample_indices(self):
         """
-        Build indices for packed document sampling. Packs whole documents into sequences without splitting.
-        Uses only ONE epoch of documents (no replication across epochs). Training steps should match
-        the number of packed samples available.
+        Build indices for packed document sampling. Packs whole documents into sequences without splitting docs across sequences.
+        Multiple epochs and margin samples supported (Megatron requests 5% more samples than actually given as arg).
+        Approximate upperbound of number of epochs to get enough documents to create samples with.
 
         Returns a tuple of three indices:
         - document_index: Shuffled document IDs for one epoch
         - sample_index: Maps sample boundaries to (document_index position, offset) pairs
         - shuffle_index: Random permutation for shuffling sample order during training
 
-        Caches the generated indices to disk if path_to_cache is specified.
-
         Returns:
             Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]:
-                - document_index: Shape (num_documents,) - shuffled document IDs for one epoch
+                - document_index: Shape (num_documents,) - shuffled document IDs (as many shuffled copies of orig document id's)
                 - sample_index: Shape (num_samples + 1, 2) - sample boundaries as [doc_idx_index, offset=0]
                 - shuffle_index: Shape (num_samples,) - permutation indices for shuffling
         """
         from megatron.core.datasets.gpt_dataset import _build_shuffle_index
         from megatron.core.datasets import helpers
 
-        path_to_cache = self.config.path_to_cache
-        if path_to_cache is None and not self.config.mock:
-            path_to_cache = os.path.join(
-                self.dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
-            )
+        # Check cache
+        index_names = ["document_index", "sample_index", "shuffle_index"]
+        cache_hit = self.cache_manager.cache_exists(index_names)
 
-        if path_to_cache:
-            log_single_rank(
-                logger,
-                logging.WARNING,
-                f"path_to_cache exists! Search for indices in: {path_to_cache}",
-            )
-            base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}-packed"
-            get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
-            path_to_description = get_path_to("description.txt")
-            path_to_document_index = get_path_to("document_index.npy")
-            path_to_sample_index = get_path_to("sample_index.npy")
-            path_to_shuffle_index = get_path_to("shuffle_index.npy")
-            cache_hit = all(
-                map(
-                    os.path.isfile,
-                    [
-                        path_to_description,
-                        path_to_document_index,
-                        path_to_sample_index,
-                        path_to_shuffle_index,
-                    ],
-                )
-            )
-        else:
-            cache_hit = False
+        if self.cache_manager.get_cache_path():
+            log_single_rank(logger, logging.WARNING, f"path_to_cache exists! Search for indices in: {self.cache_manager.get_cache_path()}")
 
-        if not path_to_cache or (
+        if not self.cache_manager.get_cache_path() or (
             not cache_hit
             and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0)
         ):
@@ -219,15 +203,15 @@ class SFTIndexedDataset(GPTDataset):
 
             num_samples_available = sample_index.shape[0] - 1
             # Validate: if num_samples requested exceeds what's available, abort
-            if self.num_samples is not None and self.num_samples > num_samples_available:
+            if self.num_samples and self.num_samples > num_samples_available:
                 error_msg = (
                     f"ERROR: Requested {self.num_samples} training samples but only "
                     f"{num_samples_available} packed samples available from dataset. "
                 )
                 log_single_rank(logger, logging.ERROR, error_msg)
                 raise ValueError(error_msg)
-            else:
-                # only keep samples needed
+            elif self.num_samples:
+                # only keep samples needed if max num is defined
                 sample_index = sample_index[:self.num_samples+1]
 
             # Build the shuffle index (sample level)
@@ -235,20 +219,13 @@ class SFTIndexedDataset(GPTDataset):
                 sample_index.shape[0] - 1, sample_index.shape[0] - 1, numpy_random_state
             )
 
-            # Store to cache
-            if path_to_cache:
-                os.makedirs(path_to_cache, exist_ok=True)
-                with open(path_to_description, "wt") as writer:
-                    writer.write(self.unique_description)
-                np.save(path_to_document_index, document_index, allow_pickle=True)
-                np.save(path_to_sample_index, sample_index, allow_pickle=True)
-                np.save(path_to_shuffle_index, shuffle_index, allow_pickle=True)
-            else:
-                log_single_rank(
-                    logger,
-                    logging.WARNING,
-                    f"Unable to save {type(self).__name__} indexes because path_to_cache is None",
-                )
+            # Save to cache
+            self.cache_manager.save_indices({
+                "description": self.unique_description,
+                "document_index": document_index,
+                "sample_index": sample_index,
+                "shuffle_index": shuffle_index
+            })
 
             t_end = time.time()
             log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
@@ -260,23 +237,10 @@ class SFTIndexedDataset(GPTDataset):
             logger, logging.INFO, f"Load the {type(self).__name__} {self.index_split.name} packed indices"
         )
 
-        log_single_rank(logger, logging.INFO, f"\tLoad the document index from {os.path.basename(path_to_document_index)}")
-        t_beg = time.time()
-        document_index = np.load(path_to_document_index, allow_pickle=True, mmap_mode='r')
-        t_end = time.time()
-        log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
-
-        log_single_rank(logger, logging.INFO, f"\tLoad the sample index from {os.path.basename(path_to_sample_index)}")
-        t_beg = time.time()
-        sample_index = np.load(path_to_sample_index, allow_pickle=True, mmap_mode='r')
-        t_end = time.time()
-        log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
-
-        log_single_rank(logger, logging.INFO, f"\tLoad the shuffle index from {os.path.basename(path_to_shuffle_index)}")
-        t_beg = time.time()
-        shuffle_index = np.load(path_to_shuffle_index, allow_pickle=True, mmap_mode='r')
-        t_end = time.time()
-        log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+        indices = self.cache_manager.load_indices(index_names)
+        document_index = indices["document_index"]
+        sample_index = indices["sample_index"]
+        shuffle_index = indices["shuffle_index"]
 
         num_samples_available = sample_index.shape[0] - 1
 
@@ -298,7 +262,10 @@ class SFTIndexedDataset(GPTDataset):
         """
         Calculate approximative upperbound of number of epochs based on requested samples and number of documents per epoch.
         Assume a constant sample packing efficiency: ex. On avg 1.5 docs per sequence.
+        If no number of samples given just use one set/epoch of documents.
         """
+        if not self.num_samples:
+            return 1
         n_docs = self.numel_low_level_dataset(self.dataset)
         approx_sample_per_epoch = n_docs / self.APPROX_NUM_PACKED_DOCS_PER_SEQ
         return int(np.ceil(self.num_samples / approx_sample_per_epoch))
@@ -311,36 +278,15 @@ class SFTIndexedDataset(GPTDataset):
         Returns:
             numpy.ndarray: The document index (Shape: (num_samples,))
         """
-        path_to_cache = self.config.path_to_cache
-        if path_to_cache is None and not self.config.mock:
-            path_to_cache = os.path.join(
-                self.dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
-            )
+        # Check cache
+        index_names = ["document_index"]
+        cache_hit = self.cache_manager.cache_exists(index_names)
 
-        if path_to_cache:
-            log_single_rank(
-                logger,
-                logging.WARNING,
-                f"path_to_cache exists! Search for indices in: {path_to_cache}",
-            )
-            base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}"
-            get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
-            path_to_description = get_path_to("description.txt")
-            path_to_document_index = get_path_to("document_index.npy")
-            cache_hit = all(
-                map(
-                    os.path.isfile,
-                    [
-                        path_to_description,
-                        path_to_document_index,
-                    ],
-                )
-            )
-        else:
-            cache_hit = False
+        if self.cache_manager.get_cache_path():
+            log_single_rank(logger, logging.WARNING, f"path_to_cache exists! Search for indices in: {self.cache_manager.get_cache_path()}")
 
-        # if index files not cached, create indices and save to cache
-        if not path_to_cache or (
+        # Build indices if cache miss
+        if not self.cache_manager.get_cache_path() or (
                 not cache_hit
                 and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0)
         ):
@@ -357,32 +303,24 @@ class SFTIndexedDataset(GPTDataset):
             # Each document maps to exactly one sample
             if self.num_samples is None:
                 # Use all documents once
-                num_samples = len(self.indices)
+                self.num_samples = len(self.indices)
                 num_epochs = 1
             else:
                 # Calculate how many epochs needed
-                num_samples = self.num_samples
                 docs_per_epoch = len(self.indices)
-                num_epochs = (num_samples + docs_per_epoch - 1) // docs_per_epoch
+                num_epochs = (self.num_samples + docs_per_epoch - 1) // docs_per_epoch
 
             # Build document index by repeating indices for each epoch (shuffle per epoch)
             document_index = _build_document_index(num_epochs, self.indices.copy().astype(np.int32), numpy_random_state)
 
             # Truncate to exact number of samples if specified (ex. If last epoch is partial)
-            if self.num_samples is not None:
-                document_index = document_index[:self.num_samples]
+            document_index = document_index[:self.num_samples]
 
-            if path_to_cache:
-                os.makedirs(path_to_cache, exist_ok=True)
-                with open(path_to_description, "wt") as writer:
-                    writer.write(self.unique_description)
-                np.save(path_to_document_index, document_index, allow_pickle=True)
-            else:
-                log_single_rank(
-                    logger,
-                    logging.WARNING,
-                    f"Unable to save {type(self).__name__} indexes because path_to_cache is None",
-                )
+            # Save to cache
+            self.cache_manager.save_indices({
+                "description": self.unique_description,
+                "document_index": document_index
+            })
 
             t_end = time.time()
             log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
@@ -396,14 +334,12 @@ class SFTIndexedDataset(GPTDataset):
             logger, logging.INFO, f"Load the {type(self).__name__} {self.index_split.name} indices"
         )
 
-        t_beg = time.time()
-        document_index = np.load(path_to_document_index, allow_pickle=True, mmap_mode='r')
-        t_end = time.time()
-        log_single_rank(logger, logging.DEBUG, f"\t> document index load time: {t_end - t_beg:4f} seconds")
+        indices = self.cache_manager.load_indices(index_names)
+        document_index = indices["document_index"]
 
         return document_index
 
-    def _get_packed_sample(self, idx: int) -> Tuple[np.ndarray, np.ndarray]:
+    def _get_packed_sample(self, idx: int) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
         """
         Load and concatenate multiple whole documents for a packed sample.
         Similar to GPT dataset's _query_document_sample_shuffle_indices but only handles whole documents.
@@ -412,7 +348,10 @@ class SFTIndexedDataset(GPTDataset):
             idx (int): The sample index
 
         Returns:
-            np.ndarray: Concatenated tokens from multiple documents, padded to sequence length
+            Tuple containing:
+                - np.ndarray: Concatenated tokens from multiple documents, padded to sequence length
+                - np.ndarray: End-of-sequence indices for each document
+                - Optional[np.ndarray]: Preloaded loss masks if sft_load_loss_mask is True, else None
         """
         shuffled_idx = self.shuffle_index[idx]
 
@@ -421,42 +360,64 @@ class SFTIndexedDataset(GPTDataset):
         doc_index_end, _ = self.sample_index[shuffled_idx + 1]
         assert doc_index_beg < doc_index_end  # the way we create the index, the end idx doc is always excluded => for same doc begin & end idx are different
 
-
-        target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
+        target_length = self.model_seq_length + self.config.add_extra_token_to_sequence
 
         document_tokens = []
+        document_loss_masks = [] if self.config.sft_load_loss_mask else None
         doc_end_indices = [] # store positions of sample ends (use to reset pos id and attn mask)
 
         for i in range(doc_index_beg, doc_index_end):
-            # Get the actual document ID from document_index
+            # Get the actual document ID from document_index & load whole document
             doc_id = self.document_index[i]
-
-            # Load the full document (offset is always 0 for whole-document packing)
             document = self.dataset.get(doc_id)
 
-            # Check if document is too long and truncate if yes (as in single document index)
-            if len(document) > target_length:
-                # Truncate and add EOD
-                logger.warning(
-                    f"Document {doc_id} in packed sample is too long ({len(document)} > {target_length}), truncating")
-                document = np.concatenate([document[:target_length - 1], np.array([self._eod_token_id])])
+            # If loading loss masks from disk, split the document into tokens and loss_mask
+            if self.config.sft_load_loss_mask:
+                # Dataset stores [tokens, loss_mask] concatenated
+                doc_len = len(document) // 2
+                doc_tokens = document[:doc_len]
+                doc_loss_mask = document[doc_len:]
 
-            document_tokens.append(document)
-            doc_end_indices.append(document.size)
+                # Truncate document and end with EOD if too long
+                if len(doc_tokens) > target_length:
+                    logger.warning(
+                        f"Document {doc_id} in packed sample is too long ({len(doc_tokens)} > {target_length}), truncating")
+                    doc_tokens = np.concatenate([doc_tokens[:target_length - 1], np.array([self._eod_token_id], dtype=np.int64)])
+                    doc_loss_mask = doc_loss_mask[:target_length - 1]
+                    # Append 0.0 for the EOD token in loss_mask
+                    doc_loss_mask = np.concatenate([doc_loss_mask, np.array([0.0], dtype=np.float32)])
+
+                document_tokens.append(doc_tokens)
+                document_loss_masks.append(doc_loss_mask)
+                doc_end_indices.append(doc_tokens.size)
+            else:
+                # Original behavior: no loss mask splitting
+                if len(document) > target_length:
+                    logger.warning(
+                        f"Document {doc_id} in packed sample is too long ({len(document)} > {target_length}), truncating")
+                    document = np.concatenate([document[:target_length - 1], np.array([self._eod_token_id], dtype=np.int64)])
+
+                document_tokens.append(document)
+                doc_end_indices.append(document.size)
 
         # Concatenate all documents
         if len(document_tokens) > 0:
             text = np.concatenate(document_tokens)
             eos_idx = np.concatenate(doc_end_indices).cumsum() - 1
+            if self.config.sft_load_loss_mask:
+                loss_mask_data = np.concatenate(document_loss_masks)
+            else:
+                loss_mask_data = None
         else:
-            # Edge case: empty sample (shouldn't happen)
-            text = np.array([], dtype=np.int64)
-            eos_idx = np.array([], dtype=np.int64)
+            raise RuntimeError("Encountered empty packed sample. This should not happen!")
 
         # Pad to target length
         if len(text) < target_length:
             padding_length = target_length - len(text)
             text = np.concatenate([text, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+            if self.config.sft_load_loss_mask:
+                # Pad loss_mask with 0.0 (padding tokens should have 0 loss)
+                loss_mask_data = np.concatenate([loss_mask_data, np.zeros(padding_length, dtype=np.float32)])
         elif len(text) > target_length:
             # This should never happen with correct packing - raise error
             raise RuntimeError(
@@ -465,13 +426,71 @@ class SFTIndexedDataset(GPTDataset):
                 f"Sample contains {len(document_tokens)} documents."
             )
 
-        return text, eos_idx
+        return text, eos_idx, loss_mask_data
 
     def __len__(self) -> int:
         if self._using_packed_samples:
             return self.sample_index.shape[0] - 1
         else:
             return len(self.document_index)
+
+    def _get_single_sample(self, idx: Optional[int]) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
+        """
+        Retrieve a single sample as raw numpy arrays.
+
+        Args:
+            idx (Optional[int]): The sample index. If None, returns a padding sequence.
+
+        Returns:
+            Tuple containing:
+                - np.ndarray: Token sequence
+                - np.ndarray: End-of-sequence indices
+                - Optional[np.ndarray]: Preloaded loss masks if sft_load_loss_mask is True, else None
+        """
+        actual_doc_id = self.document_index[idx]
+        document = self.dataset.get(actual_doc_id)
+        preloaded_loss_mask = None
+
+        # If loading loss masks from disk, split document into tokens and loss_mask
+        if self.config.sft_load_loss_mask:
+            # Dataset stores [tokens, loss_mask] concatenated
+            doc_len = len(document) // 2
+            doc_tokens = document[:doc_len]
+            doc_loss_mask = document[doc_len:]
+            eos_idx = np.array([doc_tokens.size - 1], dtype=np.int64)
+
+            # Truncate or pad to sequence_length
+            target_length = self.model_seq_length + self.config.add_extra_token_to_sequence
+            if len(doc_tokens) >= target_length:
+                # End truncated document with end-of-document token
+                logger.warning(f"Document {actual_doc_id} is longer than model sequence length {target_length} and gets trunc")
+                trunc_doc = doc_tokens[:target_length-1]
+                text = np.concatenate([trunc_doc, np.array([self._eod_token_id], dtype=np.int64)])
+                preloaded_loss_mask = doc_loss_mask[:target_length-1]
+                # Add 0.0 for the EOD token in loss_mask
+                preloaded_loss_mask = np.concatenate([preloaded_loss_mask, np.array([0.0], dtype=np.float32)])
+            else:
+                padding_length = target_length - len(doc_tokens)
+                # Pad on right side with pad token and add 0 for respective loss mask
+                text = np.concatenate([doc_tokens, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+                preloaded_loss_mask = np.concatenate([doc_loss_mask, np.zeros(padding_length, dtype=np.float32)])
+        else:
+            # Normal mode: no loss mask splitting
+            eos_idx = np.array([document.size - 1], dtype=np.int64)
+
+            # Truncate or pad to sequence_length
+            target_length = self.model_seq_length + self.config.add_extra_token_to_sequence
+            if len(document) >= target_length:
+                # End truncated document with end-of-document token
+                logger.warning(f"Document {actual_doc_id} is longer than model sequence length {target_length} and gets trunc")
+                trunc_doc = document[:target_length-1]
+                text = np.concatenate([trunc_doc, np.array([self._eod_token_id], dtype=np.int64)])
+            else:
+                padding_length = target_length - len(document)
+                # Pad on right side with pad token
+                text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+
+        return text, eos_idx, preloaded_loss_mask
 
     def __getitem__(self, idx: Optional[int]) -> Dict[str, torch.Tensor]:
         """
@@ -488,28 +507,15 @@ class SFTIndexedDataset(GPTDataset):
         if idx is None:
             # Batch padding sequence
             text = np.array(
-                [self._pad_token_id] * (self.config.sequence_length + self.config.add_extra_token_to_sequence),
+                [self._pad_token_id] * (self.model_seq_length + self.config.add_extra_token_to_sequence),
                 dtype=np.int64)
+            eos_idx = np.array([], dtype=np.int64)
         elif self._using_packed_samples:
             # Packed mode: load and concatenate multiple whole documents, return indices of document borders additionally
-            text, eos_idx = self._get_packed_sample(idx)
+            text, eos_idx, preloaded_loss_mask = self._get_packed_sample(idx)
         else:
             # Single-document mode: Get document. index is already shuffled
-            actual_doc_id = self.document_index[idx]
-            document = self.dataset.get(actual_doc_id)
-            eos_idx = np.ndarray([document.size - 1], dtype=np.int64)
-
-            # Truncate or pad to sequence_length
-            target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
-            if len(document) >= target_length:
-                # End truncated document with end-of-document token
-                logger.warning(f"Document {actual_doc_id} is longer than model sequence length {target_length} and gets trunc")
-                trunc_doc = document[:target_length-1]
-                text = np.concatenate([trunc_doc, np.array([self._eod_token_id])])
-            else:
-                padding_length = target_length - len(document)
-                # Pad on right side with pad token
-                text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+            text, eos_idx, preloaded_loss_mask = self._get_single_sample(idx)
 
         text = torch.from_numpy(text).long()
 
@@ -525,43 +531,9 @@ class SFTIndexedDataset(GPTDataset):
         # Generate mask and position ids. If PLW activated, loss mask will have partial weight for user input tokens
         attention_mask, loss_mask, position_ids, assistant_mask = self._get_ltor_masks_and_position_ids(
             labels,
-            eos_idx - 1 # -1 as eos_idx is based on tokens not labels, and we use labels as reference in mask creation
+            eos_idx - 1, # -1 as eos_idx is based on tokens not labels, and we use labels as reference in mask creation
+            torch.from_numpy(preloaded_loss_mask).float() if preloaded_loss_mask else None
         )
-
-        # DEBUG: if activated, log every 100 samples
-        if self.config.sft_debug and idx is not None and idx % 100 == 0:  # Log every 100 samples
-            num_unmasked = loss_mask.sum().item()
-            total_tokens = loss_mask.numel()
-
-            logger.warning(f"Sample {idx} - DOC {actual_doc_id}: {num_unmasked}/{total_tokens} tokens unmasked "
-                            f"({100*num_unmasked/total_tokens:.1f}%), "
-                            f"doc_length={len(torch.from_numpy(document))}, "
-                            f"num_pad_tokens={(labels == self._pad_token_id).sum().item()}")
-            
-            # Store to files
-            self.debug_writer.append_sample(
-                idx=idx,
-                actual_doc_id=actual_doc_id,
-                tokens=tokens,
-                loss_mask=loss_mask,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                labels=labels,
-                document_length=len(torch.from_numpy(document)),
-                pad_token_id=self._pad_token_id
-            )
-            
-            # Continue with existing logging
-            user_begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
-            logger.warning(f"Sample {idx}: Looking for user_begin pattern: {user_begin_seq.tolist()}")
-            logger.warning(f"Sample {idx}: Token sequence sample: {tokens[:100].tolist()}")
-            logger.warning(f"Sample {idx}: Loss mask sample: {loss_mask[:100].tolist()}")
-            logger.warning(f"Sample {idx}: Loss mask sample last 100: {loss_mask[-100:].tolist()}")
-            logger.warning(f"Sample {idx}: Position ids sample: {position_ids[:100].tolist()}")
-            if attention_mask is not None:
-                logger.warning(f"Sample {idx}: Attention mask sample (1=masked): {attention_mask[0,0,:100].long().tolist()}")
-        # END DEBUG
-
 
         # Map pad tokens to valid embedding indices
         tokens[tokens == self._pad_token_id] = 0
@@ -586,7 +558,7 @@ class SFTIndexedDataset(GPTDataset):
                 "assistant_mask": assistant_mask,
             }
 
-    def _get_ltor_masks_and_position_ids(self, data: torch.Tensor, eos_indices: np.ndarray) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    def _get_ltor_masks_and_position_ids(self, data: torch.Tensor, eos_indices: np.ndarray, preloaded_loss_mask: Optional[torch.Tensor] = None) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """
         Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
             1. Can mask full user prompts or with prompt-loss-weight (plw)
@@ -602,13 +574,15 @@ class SFTIndexedDataset(GPTDataset):
         Also creates an assistant_mask to identify assistant response tokens for separate loss tracking.
 
         Args:
-            data:           labels
-            eos_indices:    indices of document boundaries (calculated based on sample loading from low level dataset as
-                            sft data can be contaminated with eod).
+            data:                   labels
+            eos_indices:            indices of document boundaries (calculated based on sample loading from low level dataset as
+                                    sft data can be contaminated with eod).
+            preloaded_loss_mask:    Optional pre-computed loss mask loaded from disk. If provided, user prompt masking
+                                    and special token masking are skipped for loss_mask.
         """
 
-        position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
-        loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
+        position_ids = torch.arange(self.model_seq_length, dtype=torch.long)
+        loss_mask = preloaded_loss_mask.to(device=data.device) if preloaded_loss_mask is not None else torch.ones(self.model_seq_length, dtype=torch.float, device=data.device)
 
         # 0) For packed samples: reset position IDs at document boundaries
         if self._using_packed_samples:
@@ -620,33 +594,45 @@ class SFTIndexedDataset(GPTDataset):
                         to_subtract = position_ids[eod_idx].clone() + 1
                         position_ids[(eod_idx + 1):] -= to_subtract
 
-        # 1) Mask user sequences for loss
-        begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
-        end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
+        # 1) Compute assistant_mask (unless disabled)
+        if not self.config.sft_disable_assistant_mask:
+            # Compute user sequences to derive assistant mask
+            begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
+            end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
+            user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
+            assistant_mask = (~user_seq_mask).float()
 
-        user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
-        loss_mask[user_seq_mask] = self.sft_plw_value # value is 0 by default for full masking
+            # Only apply to loss_mask if NOT loading from disk
+            if preloaded_loss_mask is None:
+                loss_mask[user_seq_mask] = self.sft_plw_value # value is 0 by default for full masking
+        else:
+            # Disable assistant_mask tracking
+            assistant_mask = None
+            user_seq_mask = None
 
-        # 1b) Create assistant mask: everything that is not user sequences
-        assistant_mask = (~user_seq_mask).float()
+            # Still need to compute user_seq_mask for loss_mask if not loading from disk
+            if preloaded_loss_mask is None:
+                begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
+                end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
+                user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
+                loss_mask[user_seq_mask] = self.sft_plw_value
 
-        # 2) Mask other token(sequences) fully(set weight to 0) as configured in init (might contain BOS, EOS, assistant begin)
-        for t in self.tokens_to_mask:
-            # Use pre-computed tensor, just move to correct device/dtype
-            t_tensor = t.to(dtype=data.dtype, device=data.device)
-            if len(t_tensor) == 1:
-                mask = (data == t_tensor[0])
-            elif len(t_tensor) > 1:
-                mask = get_matching_mask(data, t_tensor, only_begin=False)
-            else:
-                raise ValueError(f"Invalid token to mask: {t}")
-            loss_mask[mask] = 0.0
-            assistant_mask[mask] = 0.0
+        # 2) Mask other token(sequences) - only for loss_mask if NOT loading from disk
+        if preloaded_loss_mask is None:
+            for t in self.tokens_to_mask:
+                t_tensor = t.to(dtype=data.dtype, device=data.device)
+                if len(t_tensor) == 1:
+                    mask = (data == t_tensor[0])
+                elif len(t_tensor) > 1:
+                    mask = get_matching_mask(data, t_tensor, only_begin=False)
+                else:
+                    raise ValueError(f"Invalid token to mask: {t}")
+                loss_mask[mask] = 0.0
 
         # 3) Create attention mask: mask attention from/to padding tokens
         if self.config.create_attention_mask:
             attention_mask = torch.tril(
-                torch.ones((self.config.sequence_length, self.config.sequence_length), device=data.device)
+                torch.ones((self.model_seq_length, self.model_seq_length), device=data.device)
             )
             no_padding_mask = (data != self._pad_token_id).float() # 1=real, 0=padding
 
@@ -659,7 +645,7 @@ class SFTIndexedDataset(GPTDataset):
             if self._using_packed_samples:
                 if eos_indices.size > 0:
                     for eod_idx in eos_indices:
-                        if eod_idx + 1 < self.config.sequence_length:
+                        if eod_idx + 1 < self.model_seq_length:
                             # Zero out attention from all tokens after EOD to all tokens up to and including EOD
                             attention_mask[(eod_idx + 1):, :(eod_idx + 1)] = 0.0
 
@@ -671,7 +657,8 @@ class SFTIndexedDataset(GPTDataset):
 
         # 4) Mask padding tokens (must be done BEFORE equalization to ensure correct normalization)
         loss_mask[data == self._pad_token_id] = 0.0
-        assistant_mask[data == self._pad_token_id] = 0.0
+        if assistant_mask is not None:
+            assistant_mask[data == self._pad_token_id] = 0.0
 
         # 5) Equalize sample loss
         if self.config.sft_equalize_sample_loss:
@@ -784,6 +771,105 @@ def get_matching_mask_by_start_end(sequence, begin_seq: torch.Tensor, end_seq: t
     return mask
 
 
+class IndexCacheManager:
+    """Manages cache file I/O for dataset indices."""
+
+    def __init__(
+        self,
+        config,
+        dataset_path_prefix: str,
+        unique_description: str,
+        unique_description_hash: str,
+        dataset_class_name: str,
+        split_name: str
+    ):
+        self.config = config
+        self.dataset_path_prefix = dataset_path_prefix
+        self.unique_description = unique_description
+        self.unique_description_hash = unique_description_hash
+        self.dataset_class_name = dataset_class_name
+        self.split_name = split_name
+
+        self._cache_dir = self._determine_cache_path()
+
+        if self._cache_dir:
+            base = f"{unique_description_hash}-{dataset_class_name}-{split_name}"
+            self._get_path_to = lambda affix: os.path.join(self._cache_dir, f"{base}-{affix}")
+
+    def _determine_cache_path(self) -> Optional[str]:
+        """Determine cache directory path from config."""
+        path_to_cache = self.config.path_to_cache
+        if path_to_cache is None and not self.config.mock:
+            path_to_cache = os.path.join(
+                self.dataset_path_prefix, "cache", f"{self.dataset_class_name}_indices"
+            )
+        return path_to_cache
+
+    def get_cache_path(self) -> Optional[str]:
+        """Return cache directory path."""
+        return self._cache_dir
+
+    def get_index_path(self, index_name: str) -> str:
+        """Return full path for an index file."""
+        if not self._cache_dir:
+            raise ValueError("Cache path is not configured")
+
+        if index_name == "description":
+            return self._get_path_to("description.txt")
+        else:
+            return self._get_path_to(f"{index_name}.npy")
+
+    def cache_exists(self, index_names: List[str]) -> bool:
+        """Check if all required cache files exist."""
+        if not self._cache_dir:
+            return False
+
+        files_to_check = [self.get_index_path("description")]
+        for index_name in index_names:
+            if index_name != "description":
+                files_to_check.append(self.get_index_path(index_name))
+
+        return all(os.path.isfile(f) for f in files_to_check)
+
+    def save_indices(self, indices: Dict[str, np.ndarray]) -> None:
+        """Save indices to cache files."""
+        if not self._cache_dir:
+            log_single_rank(
+                logger,
+                logging.WARNING,
+                f"Unable to save {self.dataset_class_name} indices because path_to_cache is None",
+            )
+            return
+
+        os.makedirs(self._cache_dir, exist_ok=True)
+
+        if "description" in indices:
+            with open(self.get_index_path("description"), "wt") as writer:
+                writer.write(indices["description"])
+
+        for index_name, index_data in indices.items():
+            if index_name != "description" and index_data is not None:
+                np.save(self.get_index_path(index_name), index_data, allow_pickle=True)
+
+    def load_indices(self, index_names: List[str]) -> Dict[str, np.ndarray]:
+        """Load indices from cache files."""
+        if not self._cache_dir:
+            raise ValueError("Cannot load indices: cache path is not configured")
+
+        indices = {}
+        for index_name in index_names:
+            index_path = self.get_index_path(index_name)
+            log_single_rank(logger, logging.INFO, f"\tLoad the {index_name} from {os.path.basename(index_path)}")
+
+            t_beg = time.time()
+            indices[index_name] = np.load(index_path, allow_pickle=True, mmap_mode='r')
+            t_end = time.time()
+
+            log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+
+        return indices
+
+
 def _build_document_index(num_epochs: int,
                                  documents: np.ndarray,
                                  numpy_random_state: np.random.RandomState
@@ -801,84 +887,3 @@ def _build_document_index(num_epochs: int,
 
     document_index = document_index.reshape(-1)
     return document_index
-
-
-class DebugDataWriter:
-    """Helper class to write debug data to files."""
-    
-    def __init__(self, output_dir="debug_data"):
-        self.output_dir = Path(output_dir)
-        self.output_dir.mkdir(exist_ok=True)
-        self.metadata_file = self.output_dir / "metadata.jsonl"
-        self.tokens_file = self.output_dir / "tokens.npy"
-        self.loss_mask_file = self.output_dir / "loss_mask.npy"
-        self.attention_mask_file = self.output_dir / "attention_mask.npy"
-        
-        # Initialize files if they don't exist
-        if not self.tokens_file.exists():
-            self._init_array_file(self.tokens_file)
-        if not self.loss_mask_file.exists():
-            self._init_array_file(self.loss_mask_file)
-        if not self.attention_mask_file.exists():
-            self._init_array_file(self.attention_mask_file)
-    
-    def _init_array_file(self, filepath):
-        """Initialize an empty numpy array file."""
-        np.save(filepath, np.array([]))
-    
-    def append_sample(self, idx, actual_doc_id, tokens, loss_mask, 
-                     attention_mask=None, position_ids=None, 
-                     labels=None, document_length=None, pad_token_id=None):
-        """Append a sample to the debug files."""
-        
-        # Convert tensors to numpy
-        tokens_np = tokens.cpu().numpy() if torch.is_tensor(tokens) else tokens
-        loss_mask_np = loss_mask.cpu().numpy() if torch.is_tensor(loss_mask) else loss_mask
-        
-        # Load existing data
-        tokens_data = np.load(self.tokens_file, allow_pickle=True)
-        loss_mask_data = np.load(self.loss_mask_file, allow_pickle=True)
-        
-        # Append new data
-        if tokens_data.size == 0:
-            tokens_data = np.array([tokens_np], dtype=object)
-            loss_mask_data = np.array([loss_mask_np], dtype=object)
-        else:
-            tokens_data = np.append(tokens_data, [tokens_np])
-            loss_mask_data = np.append(loss_mask_data, [loss_mask_np])
-        
-        # Save updated arrays
-        np.save(self.tokens_file, tokens_data)
-        np.save(self.loss_mask_file, loss_mask_data)
-        
-        # Handle attention mask
-        if attention_mask is not None:
-            attention_mask_np = attention_mask.cpu().numpy() if torch.is_tensor(attention_mask) else attention_mask
-            attention_mask_data = np.load(self.attention_mask_file, allow_pickle=True)
-            
-            if attention_mask_data.size == 0:
-                attention_mask_data = np.array([attention_mask_np], dtype=object)
-            else:
-                attention_mask_data = np.append(attention_mask_data, [attention_mask_np])
-            
-            np.save(self.attention_mask_file, attention_mask_data)
-        
-        # Save metadata
-        num_unmasked = loss_mask_np.sum()
-        total_tokens = loss_mask_np.size
-        
-        metadata = {
-            "sample_idx": int(idx) if idx is not None else None,
-            "doc_id": int(actual_doc_id) if actual_doc_id is not None else None,
-            "num_unmasked": int(num_unmasked),
-            "total_tokens": int(total_tokens),
-            "unmasked_percentage": float(100 * num_unmasked / total_tokens),
-            "document_length": int(document_length) if document_length is not None else None,
-            "num_pad_tokens": int((labels == pad_token_id).sum()) if labels is not None and pad_token_id is not None else None,
-            "sequence_length": int(len(tokens_np)),
-            "has_attention_mask": attention_mask is not None
-        }
-        
-        # Append metadata as JSONL
-        with open(self.metadata_file, 'a') as f:
-            f.write(json.dumps(metadata) + '\n')

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -35,7 +35,8 @@ class SFTIndexedDataset(GPTDataset):
         # Call Megatron Dataset init instead of direct parent, as we initialize index differently
         MegatronDataset.__init__(self, dataset, dataset_path, indexed_indices, num_samples, index_split, config)
 
-        self.debug_writer = DebugDataWriter(output_dir="/users/rkreft/debug_data")  # Initialize once, outside the loop
+        if self.config.sft_debug:
+            self.debug_writer = DebugDataWriter(output_dir="/users/rkreft/debug_data")  # Initialize once, outside the loop
 
         self.tokenizer = config.tokenizer
         # Set pad token
@@ -57,10 +58,10 @@ class SFTIndexedDataset(GPTDataset):
         self._img_begin_sequence = self.tokenizer.tokenize('<|img_start|>', add_special_tokens=False)
         self._img_end_sequence = self.tokenizer.tokenize('<|img_end|>', add_special_tokens=False)
 
-        # Configure token(sequences to remove from loss calculations)
-        self.tokens_to_mask = [] # a list of: token ids or sequences of token ids to mask
+        # Configure token (sequences) to remove from loss calculation
+        self.tokens_to_mask = []
         if self.config.sft_mask_special_tokens:
-            # add tokenizer special tokens like EOS, BOS to be masked
+            # add tokenizer special tokens like EOS, BOS and assistant begin to be masked. Never mask End of turn.
             self.tokens_to_mask.append([self._eod_token_id])
             self.tokens_to_mask.append([self._bos_token_id])
             self.tokens_to_mask.append(self._sft_assistant_begin_sequence)
@@ -75,20 +76,12 @@ class SFTIndexedDataset(GPTDataset):
                 self.config.reset_position_ids,
                 self.config.reset_attention_mask,
                 self.config.eod_mask_loss,
-                self.config.goldfish_loss,
             ]
         )
         self.masks_and_position_ids_are_cached = False
         self.cached_attention_mask = None
         self.cached_loss_mask = None
         self.cached_position_ids = None
-
-        # Goldfish loss setup
-        if self.config.goldfish_loss:
-            self._goldfish_k = self.config.goldfish_k
-            self._goldfish_h = self.config.goldfish_h
-            self._goldfish_token_id = _GOLDFISH_TOKEN_ID
-            self._goldfish_hash_table = None
 
 
     def _build_single_document_indices(self) -> np.ndarray:
@@ -221,8 +214,8 @@ class SFTIndexedDataset(GPTDataset):
                 text = np.concatenate([trunc_doc, np.array([self._eod_token_id])])
             else:
                 padding_length = target_length - len(document)
-                # Pad on left side with pad token
-                text = np.concatenate([np.full(padding_length, self._pad_token_id, dtype=np.int64), document])
+                # Pad on right side with pad token
+                text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
 
         text = torch.from_numpy(text).long()
 
@@ -241,10 +234,7 @@ class SFTIndexedDataset(GPTDataset):
                 or not self.masks_and_position_ids_are_cached
         ):
             attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
-                labels,
-                self.config.reset_position_ids,
-                self.config.reset_attention_mask,
-                self.config.create_attention_mask,
+                labels
             )
             if self.masks_and_position_ids_are_cacheable:
                 self.cached_attention_mask = attention_mask
@@ -259,11 +249,11 @@ class SFTIndexedDataset(GPTDataset):
         # Mask loss for padded tokens (this also masks batch padding if idx is None)
         loss_mask[labels == self._pad_token_id] = 0.0
 
-        # DEBUG: Log how many tokens are actually being trained on
-        num_unmasked = loss_mask.sum().item()
-        total_tokens = loss_mask.numel()
+        # DEBUG: if activated, log every 100 samples
+        if self.config.sft_debug and idx is not None and idx % 100 == 0:  # Log every 100 samples
+            num_unmasked = loss_mask.sum().item()
+            total_tokens = loss_mask.numel()
 
-        if False and idx is not None and idx % 100 == 0:  # Log every 100 samples
             logger.warning(f"Sample {idx} - DOC {actual_doc_id}: {num_unmasked}/{total_tokens} tokens unmasked "
                             f"({100*num_unmasked/total_tokens:.1f}%), "
                             f"doc_length={len(torch.from_numpy(document))}, "
@@ -298,20 +288,6 @@ class SFTIndexedDataset(GPTDataset):
         tokens[tokens == self._pad_token_id] = 0
         labels[labels == self._pad_token_id] = 0
 
-        # Apply goldfish loss masking if enabled
-        if self.config.goldfish_loss:
-            if self._goldfish_hash_table is None:
-                self._goldfish_hash_table = self._create_hash_table(device=labels.device)
-
-            goldfish_labels = self.apply_goldfish(
-                labels,
-                goldfish_token_id=self._goldfish_token_id,
-                k=self._goldfish_k,
-                goldfish_hash_table=self._goldfish_hash_table,
-                goldfish_context_width=self._goldfish_h,
-            )
-            loss_mask[goldfish_labels == self._goldfish_token_id] = 0.0
-
         # Return sample dict
         if self.config.create_attention_mask:
             return {
@@ -329,16 +305,15 @@ class SFTIndexedDataset(GPTDataset):
                 "position_ids": position_ids,
             }
 
-    def _get_ltor_masks_and_position_ids(self, data,
-                                         reset_position_ids,
-                                         reset_attention_mask,
-                                         create_attention_mask):
+    def _get_ltor_masks_and_position_ids(self, data):
         """
         Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
-            1. Find user messages in conversation list
-            2. Mask prompts
+            1. Can mask full user prompts including or not including the images in the user prompt
+            2. Can mask arbitrary token sequences (e.g. assistant begin, assistant end, BOS, EOS)
+        Both options can be Configured in the init.
+        Finally, creates an attention mask if configured. The attention mask will exclude padding tokens from attention.
         """
-        assert not reset_position_ids and not reset_attention_mask
+        assert not self.config.reset_position_ids and not self.config.reset_attention_mask
 
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
@@ -369,7 +344,7 @@ class SFTIndexedDataset(GPTDataset):
             loss_mask[img_seq_mask] = 1.0
 
         # 4) Create attention mask, excluding padding tokens from attention
-        if create_attention_mask:
+        if self.config.create_attention_mask:
             # Here me mask attention from all padding tokens to all other tokens and vice versa
             attention_mask = torch.tril(
                 torch.ones((self.config.sequence_length, self.config.sequence_length), device=data.device)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, override
+from typing import Dict, Optional
 
 import time
 import os
@@ -36,18 +36,26 @@ class SFTIndexedDataset(GPTDataset):
         self.tokenizer = config.tokenizer
         # Set pad token
         try:
-            self._pad_token_id = self.config.tokenizer.pad
+            self._pad_token_id = self.tokenizer.pad
         except Exception:
             self._pad_token_id = _PAD_TOKEN_ID
 
         # End of Document token to add end to truncated samples
-        self._eod_token_id = self.config.tokenizer.eod
-
-        # TODO: Add options to mask all special tokens?
-
+        self._eod_token_id = self.tokenizer.eod
+        self._bos_token_id = self.tokenizer.bos
         # TODO: Pass sequences dynamically
-        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>', add_special_tokens=False)
+        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>',
+                                                                add_special_tokens=False)
         self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>', add_special_tokens=False)
+        self._sft_assistant_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>assistant<|end_header_id|>',
+                                                                add_special_tokens=False)
+        # Configure token(sequences to remove from loss calculations)
+        self.tokens_to_mask = [] # a list of: token ids or sequences of token ids to mask
+        if self.config.sft_mask_special_tokens:
+            # add tokenizer special tokens like EOS, BOS to be masked
+            self.tokens_to_mask += list(self.tokenizer.special_tokens)
+            self.tokens_to_mask.append(self._sft_user_assistant_sequence)
+        logger.warning(f"Masking the following tokens/token-sequences: {self.tokens_to_mask}")
 
         # Build shuffle indices
         self.document_index = self._build_single_document_indices()
@@ -74,13 +82,12 @@ class SFTIndexedDataset(GPTDataset):
             self._goldfish_hash_table = None
 
 
-    def _build_single_document_indices(self):
+    def _build_single_document_indices(self) -> np.ndarray:
         """
-        Build document index and shuffle index for single-document sampling. Only one document is used per sample.
-
+        Build a document index for single-document sampling. Only one document is used per sample.
 
         Returns:
-            Tuple[numpy.ndarray, numpy.ndarray]: The document index and shuffle index
+            numpy.ndarray: The document index
         """
         path_to_cache = self.config.path_to_cache
         if path_to_cache is None and not self.config.mock:
@@ -176,8 +183,9 @@ class SFTIndexedDataset(GPTDataset):
         return len(self.document_index)
 
     def __getitem__(self, idx: Optional[int]) -> Dict[str, torch.Tensor]:
-        """Get a single sample from the dataset. 
-        Each sample is a single document padded to sequence length. OR truncated if too long.
+        """
+        Get a single sample from the dataset.
+        Each sample is a single document padded to sequence length OR truncated if too long.
 
         Args:
             idx (Optional[int]): The index into the dataset
@@ -224,10 +232,8 @@ class SFTIndexedDataset(GPTDataset):
         ):
             attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
                 tokens,
-                self.config.tokenizer.eod,
                 self.config.reset_position_ids,
                 self.config.reset_attention_mask,
-                self.config.eod_mask_loss,
                 self.config.create_attention_mask,
             )
             if self.masks_and_position_ids_are_cacheable:
@@ -291,64 +297,79 @@ class SFTIndexedDataset(GPTDataset):
                 "position_ids": position_ids,
             }
 
-    @override
     def _get_ltor_masks_and_position_ids(self, tokens,
-                tokenizer_eod_id,
                 reset_position_ids,
                 reset_attention_mask,
-                eod_mask_loss,
                 create_attention_mask):
-        """Build masks and position id for left to right model for SFT
-            1. find user messages in conversation list
-            2. mask prompts
+        """
+        Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
+            1. Find user messages in conversation list
+            2. Mask prompts
         """
         assert not reset_position_ids and not reset_attention_mask
 
-        # Position ids.
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
-
-        # Loss mask.
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
-        # Mask user sequences for loss
+        # 1) Mask user sequences for loss
         begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
         end_seq = torch.tensor(self._sft_turn_end_sequence, dtype=tokens.dtype, device=tokens.device)
 
         begin_len = len(begin_seq)
         end_len = len(end_seq)
 
-        if begin_len > 0 and len(tokens) >= begin_len:
-            # Vectorized pattern matching using unfold
-            if begin_len == 1:
-                matches_begin = (tokens == begin_seq[0])
-            else:
-                # Create sliding windows
-                windows = tokens.unfold(0, begin_len, 1)
-                # Compare all windows at once
-                matches_begin = (windows == begin_seq).all(dim=1)
-                # Pad to original length
-                matches_begin = F.pad(matches_begin, (0, begin_len - 1), value=False)
+        if 0 < begin_len <= len(tokens):
+            matches_begin = get_matching_mask(tokens, begin_seq, only_begin=True)
 
             if end_len > 0:
-                if end_len == 1:
-                    matches_end = (tokens == end_seq[0])
-                else:
-                    windows = tokens.unfold(0, end_len, 1)
-                    matches_end = (windows == end_seq).all(dim=1)
-                    matches_end = F.pad(matches_end, (0, end_len - 1), value=False)
+                matches_end = get_matching_mask(tokens, end_seq, only_begin=True)
 
                 begin_indices = torch.where(matches_begin)[0]
                 end_indices = torch.where(matches_end)[0]
 
                 # Vectorized masking
-                for begin_idx in begin_indices:
-                    next_ends = end_indices[end_indices > begin_idx]
-                    end = next_ends[0].item() + end_len if len(next_ends) > 0 else len(loss_mask)
-                    loss_mask[begin_idx.item():end] = 0.0
+                if len(begin_indices) > 0 and len(end_indices) > 0:
+                    # For each begin, find the next ends (vectorized)
+                    end_matrix = end_indices.unsqueeze(0) > begin_indices.unsqueeze(1)
+                    has_valid_end = end_matrix.any(dim=1)
+                    first_end_idx = end_matrix.int().argmax(dim=1)
 
-        # Mask eod if wanted
-        if eod_mask_loss:
-            loss_mask[tokens == tokenizer_eod_id] = 0.0
+                    # Compute end positions for each begin
+                    end_positions = torch.where(
+                        has_valid_end,
+                        end_indices[first_end_idx] + end_len,
+                        len(loss_mask)
+                    )
+
+                    # Create ranges and mask in one go, Shape: (num_begins, max_range_len)
+                    max_len = (end_positions - begin_indices).max().item()
+                    ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
+                    lengths = (end_positions - begin_indices).unsqueeze(1)
+
+                    # Get all indices to mask
+                    mask_positions = begin_indices.unsqueeze(1) + ranges
+                    valid_mask = ranges < lengths
+                    indices_to_mask = mask_positions[valid_mask]
+
+                    loss_mask[indices_to_mask] = 0.0
+                elif len(begin_indices) > 0:
+                    # No end sequences, mask from each begin to the end
+                    max_len = len(loss_mask) - begin_indices.min().item()
+                    ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
+                    mask_positions = begin_indices.unsqueeze(1) + ranges
+                    valid = mask_positions < len(loss_mask)
+                    loss_mask[mask_positions[valid]] = 0.0
+
+        # 2) Mask other token(sequences) as configured in init (might contain BOS, EOS, assistant begin)
+        for t in self.tokens_to_mask:
+            t_tensor = torch.tensor(t, dtype=tokens.dtype, device=tokens.device)
+            if len(t_tensor) == 1:
+                mask = (tokens == t_tensor[0])
+            elif len(t_tensor) > 1:
+                mask = get_matching_mask(tokens, t_tensor, only_begin=False)
+            else:
+                raise ValueError(f"Invalid token to mask: {t}")
+            loss_mask[mask] = 0.0
 
         if create_attention_mask:
             # Here me mask attention from all padding tokens to all other tokens and vice versa
@@ -371,3 +392,30 @@ class SFTIndexedDataset(GPTDataset):
             attention_mask = None
 
         return attention_mask, loss_mask, position_ids
+
+
+def get_matching_mask(sequence, query: torch.Tensor, only_begin:bool=True):
+    """
+    Given a sequence and a query, return a mask indicating which positions in the sequence match the query.
+    If the query has len > 1, only_begin arg will determine whether the mask is true only where
+    the query begins in the sequence. Otherwise, full query is masked.
+    """
+    query_len = len(query)
+    # Vectorized pattern matching using unfold
+    if query_len == 1:
+        matches = (sequence == query[0])
+    else:
+        # Create sliding windows
+        windows = sequence.unfold(0, query_len, 1)
+        # Compare all windows at once
+        matches = (windows == query).all(dim=1)
+        # Pad to original length
+        matches = F.pad(matches, (0, query_len - 1), value=False)
+        if not only_begin:
+            matches_float = matches.float().unsqueeze(0).unsqueeze(0)  # (1, 1, N)
+            kernel = torch.ones(1, 1, query_len, device=sequence.device)
+            expanded = F.conv1d(matches_float, kernel, padding=query_len - 1)
+            matches = (expanded.squeeze(0).squeeze(0)[:len(sequence)] > 0)
+    return matches
+
+

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Tuple
 
 import time
 import os
@@ -403,7 +403,7 @@ class SFTIndexedDataset(GPTDataset):
 
         return document_index
 
-    def _get_packed_sample(self, idx: int) -> np.ndarray:
+    def _get_packed_sample(self, idx: int) -> Tuple[np.ndarray, np.ndarray]:
         """
         Load and concatenate multiple whole documents for a packed sample.
         Similar to GPT dataset's _query_document_sample_shuffle_indices but only handles whole documents.
@@ -414,21 +414,19 @@ class SFTIndexedDataset(GPTDataset):
         Returns:
             np.ndarray: Concatenated tokens from multiple documents, padded to sequence length
         """
-        # Apply shuffle
         shuffled_idx = self.shuffle_index[idx]
 
-        # Get sample boundaries from sample_index
+        # Get sample boundaries from sample_index (first(inclusive) and last(exclusive) sample to be packed)
         doc_index_beg, _ = self.sample_index[shuffled_idx]
         doc_index_end, _ = self.sample_index[shuffled_idx + 1]
+        assert doc_index_beg < doc_index_end  # the way we create the index, the end idx doc is always excluded => for same doc begin & end idx are different
 
-        # Target length
+
         target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
 
-        # Collect document tokens
         document_tokens = []
+        doc_end_indices = [] # store positions of sample ends (use to reset pos id and attn mask)
 
-        # Iterate through documents in this sample
-        assert doc_index_beg < doc_index_end  # the way we create the index, the end idx doc is always excluded, so even for same doc begin end end idx are different
         for i in range(doc_index_beg, doc_index_end):
             # Get the actual document ID from document_index
             doc_id = self.document_index[i]
@@ -436,7 +434,7 @@ class SFTIndexedDataset(GPTDataset):
             # Load the full document (offset is always 0 for whole-document packing)
             document = self.dataset.get(doc_id)
 
-            # Check if document is too long and truncate if yes (as in single document index) TODO: add option to discard here and for single doc case?
+            # Check if document is too long and truncate if yes (as in single document index)
             if len(document) > target_length:
                 # Truncate and add EOD
                 logger.warning(
@@ -444,13 +442,16 @@ class SFTIndexedDataset(GPTDataset):
                 document = np.concatenate([document[:target_length - 1], np.array([self._eod_token_id])])
 
             document_tokens.append(document)
+            doc_end_indices.append(document.size)
 
         # Concatenate all documents
         if len(document_tokens) > 0:
             text = np.concatenate(document_tokens)
+            eos_idx = np.concatenate(doc_end_indices).cumsum() - 1
         else:
             # Edge case: empty sample (shouldn't happen)
             text = np.array([], dtype=np.int64)
+            eos_idx = np.array([], dtype=np.int64)
 
         # Pad to target length
         if len(text) < target_length:
@@ -464,7 +465,7 @@ class SFTIndexedDataset(GPTDataset):
                 f"Sample contains {len(document_tokens)} documents."
             )
 
-        return text
+        return text, eos_idx
 
     def __len__(self) -> int:
         if self._using_packed_samples:
@@ -490,12 +491,13 @@ class SFTIndexedDataset(GPTDataset):
                 [self._pad_token_id] * (self.config.sequence_length + self.config.add_extra_token_to_sequence),
                 dtype=np.int64)
         elif self._using_packed_samples:
-            # Packed mode: load and concatenate multiple whole documents
-            text = self._get_packed_sample(idx)
+            # Packed mode: load and concatenate multiple whole documents, return indices of document borders additionally
+            text, eos_idx = self._get_packed_sample(idx)
         else:
             # Single-document mode: Get document. index is already shuffled
             actual_doc_id = self.document_index[idx]
             document = self.dataset.get(actual_doc_id)
+            eos_idx = np.ndarray([document.size - 1], dtype=np.int64)
 
             # Truncate or pad to sequence_length
             target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
@@ -522,7 +524,8 @@ class SFTIndexedDataset(GPTDataset):
 
         # Generate mask and position ids. If PLW activated, loss mask will have partial weight for user input tokens
         attention_mask, loss_mask, position_ids, assistant_mask = self._get_ltor_masks_and_position_ids(
-            labels
+            labels,
+            eos_idx - 1 # -1 as eos_idx is based on tokens not labels, and we use labels as reference in mask creation
         )
 
         # DEBUG: if activated, log every 100 samples
@@ -583,33 +586,35 @@ class SFTIndexedDataset(GPTDataset):
                 "assistant_mask": assistant_mask,
             }
 
-    def _get_ltor_masks_and_position_ids(self, data):
+    def _get_ltor_masks_and_position_ids(self, data: torch.Tensor, eos_indices: np.ndarray) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
             1. Can mask full user prompts or with prompt-loss-weight (plw)
             2. Can mask arbitrary token sequences (e.g. assistant begin, assistant end, BOS, EOS)
             3. Creates attention mask if configured. The attention mask will exclude padding tokens from attention.
-            4. Can equalize sample loss for packed and non-packed sequences
+            4. Can equalize sample loss for packed and non-packed sequences (loss = 1 for each sample in seq)
 
         For packed samples (when sft_pack_samples=True):
             - Position IDs are reset at each EOD token (document boundary)
             - Attention mask blocks cross-document attention at EOD boundaries
+            - ASSUMES NO WRONG PLACED EOD (=ONLY PROPERLY BOUNDARY OF SAMPLES)
 
         Also creates an assistant_mask to identify assistant response tokens for separate loss tracking.
+
+        Args:
+            data:           labels
+            eos_indices:    indices of document boundaries (calculated based on sample loading from low level dataset as
+                            sft data can be contaminated with eod).
         """
 
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
-        # only compute eod indices if necessary
-        if self._using_packed_samples or self.config.sft_equalize_sample_loss:
-            eod_indices = torch.where(data == self._eod_token_id)[0]
-
-        # 0) For packed samples: reset position IDs at document boundaries (EOD tokens)
+        # 0) For packed samples: reset position IDs at document boundaries
         if self._using_packed_samples:
-            if len(eod_indices) > 0:
+            if eos_indices.size > 0:
                 # Reset position IDs after each EOD token
-                for eod_idx in eod_indices:
+                for eod_idx in eos_indices:
                     if eod_idx + 1 < len(position_ids):
                         # Subtract the position value at EOD+1 from all subsequent positions
                         to_subtract = position_ids[eod_idx].clone() + 1
@@ -652,8 +657,8 @@ class SFTIndexedDataset(GPTDataset):
 
             # For packed samples: block cross-document attention at EOD boundaries
             if self._using_packed_samples:
-                if len(eod_indices) > 0:
-                    for eod_idx in eod_indices:
+                if eos_indices.size > 0:
+                    for eod_idx in eos_indices:
                         if eod_idx + 1 < self.config.sequence_length:
                             # Zero out attention from all tokens after EOD to all tokens up to and including EOD
                             attention_mask[(eod_idx + 1):, :(eod_idx + 1)] = 0.0
@@ -673,10 +678,10 @@ class SFTIndexedDataset(GPTDataset):
             # Add small epsilon to prevent division by very small numbers
             eps = 1e-10
 
-            if len(eod_indices) > 0:
+            if eos_indices.size > 0:
                 # Process each sample segment (between EOD tokens)
                 start_idx = 0
-                for eod_idx in eod_indices:
+                for eod_idx in eos_indices:
                     segment_mask = loss_mask[start_idx:eod_idx+1]
                     segment_loss_sum = segment_mask.sum()
 

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -41,8 +41,8 @@ class SFTIndexedDataset(GPTDataset):
             self._pad_token_id = _PAD_TOKEN_ID
 
         # TODO: Pass sequences dynamically
-        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>\n\n')
-        self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>')
+        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>', add_special_tokens=False)
+        self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>', add_special_tokens=False)
 
         # Build shuffle indices
         self.document_index = self._build_single_document_indices()
@@ -168,7 +168,7 @@ class SFTIndexedDataset(GPTDataset):
         return document_index
 
     def __len__(self) -> int:
-        return self.document_index.shape[0] - 1
+        return len(self.document_index)
 
     def __getitem__(self, idx: Optional[int]) -> Dict[str, torch.Tensor]:
         """Get a single sample from the dataset. 
@@ -235,6 +235,19 @@ class SFTIndexedDataset(GPTDataset):
 
         # Mask loss for padded tokens (this also masks batch padding if idx is None)
         loss_mask[labels == self._pad_token_id] = 0.0
+
+        # DEBUG: Log how many tokens are actually being trained on
+        #num_unmasked = loss_mask.sum().item()
+        #total_tokens = loss_mask.numel()
+        #if idx is not None and idx % 100 == 0:  # Log every 100 samples
+        #    logger.warning(f"Sample {idx}: {num_unmasked}/{total_tokens} tokens unmasked "
+        #                 f"({100*num_unmasked/total_tokens:.1f}%), "
+        #                 f"doc_length={len(torch.from_numpy(document))}, "
+        #                 f"num_pad_tokens={(labels == self._pad_token_id).sum().item()}")
+        #    user_begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
+        #    logger.warning(f"Sample {idx}: Looking for user_begin pattern: {user_begin_seq.tolist()}")
+        #    logger.warning(f"Sample {idx}: Token sequence sample: {tokens[:100].tolist()}")
+        #    logger.warning(f"Sample {idx}: Loss mask sample: {loss_mask[:100].tolist()}")
 
         # Map pad tokens to valid embedding indices
         tokens[tokens == self._pad_token_id] = 0
@@ -336,13 +349,13 @@ class SFTIndexedDataset(GPTDataset):
                 torch.ones((self.config.sequence_length, self.config.sequence_length), device=tokens.device)
             )
             # Mask padding tokens in attention mask:
-            no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
+            #no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
             
             # Mask both rows (queries from padding) and columns (keys to padding)
             # Row masking: padding tokens shouldn't attend to anything
-            attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
+            #attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
             # Column masking: nothing should attend to padding tokens
-            attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
+            #attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
             
             # Convert attention mask to binary:
             attention_mask = attention_mask.unsqueeze(0)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 class SFTIndexedDataset(GPTDataset):
     """
     The dataset used during SFT. Uses Low Level Indexed Dataset to load from pre-tokenized SFT data.
-    Each original document/dataset-sample is loaded one by one and padded to fill the sequence length.
+    Supports loading tokens + mask from disk and loading only tokens = loss mask creation on the fly.
+    If not loading from disk: assumes tokenizer also defines user/assistant begin/end sequences.
+    See megatron/training/tokenizer/tokenizer.py (HuggingFaceTokenizer) how they are loaded.
     """
     APPROX_NUM_PACKED_DOCS_PER_SEQ = 3
 
@@ -532,10 +534,10 @@ class SFTIndexedDataset(GPTDataset):
             labels = torch.roll(text, shifts=-1, dims=0)
             labels[-1] = self._pad_token_id
 
-        # Generate mask and position ids. If PLW activated, loss mask will have partial weight for user input tokens
+        # Generate loss-mask, position-ids, assistant mask and optionally attention mask. If PLW activated, loss mask will have partial weight for user input tokens
         attention_mask, loss_mask, position_ids, assistant_mask = self._get_ltor_masks_and_position_ids(
-            labels,
-            eos_idx - 1, # -1 as eos_idx is based on tokens not labels, and we use labels as reference in mask creation
+            labels, # labels are used to create the loss and assistant mask
+            eos_idx, # eos_idx is based on tokens(NOT labels) and controls position-ids and attn mask reset
             torch.from_numpy(preloaded_loss_mask).float() if preloaded_loss_mask else None
         )
 

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -52,24 +52,24 @@ class SFTIndexedDataset(GPTDataset):
         # End of Document token to add end to truncated samples TODO: currently works with HF tokenizers only
         self._eod_token_id = self.tokenizer.eod
         self._bos_token_id = self.tokenizer.bos
-        # TODO: Pass sequences dynamically
-        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>',
-                                                                add_special_tokens=False)
-        self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>', add_special_tokens=False)
-        self._sft_assistant_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>assistant<|end_header_id|>',
-                                                                add_special_tokens=False)
-        # TODO: Make multimodality optional - configurable or just leave this as long as there is only one option?
-        self._img_begin_sequence = self.tokenizer.tokenize('<|img_start|>', add_special_tokens=False)
-        self._img_end_sequence = self.tokenizer.tokenize('<|img_end|>', add_special_tokens=False)
+
+        # Load pre-computed sequences from tokenizer config and convert to tensors
+        # These are pre-tokenized in the tokenizer_config.json by add_emu3_tokens_llama3_vision_instruct.py
+        self._sft_user_begin_sequence = torch.tensor(self.tokenizer.sft_user_begin_sequence, dtype=torch.long)
+        self._sft_turn_end_sequence = torch.tensor(self.tokenizer.sft_eot_token, dtype=torch.long)
+        self._sft_assistant_begin_sequence = torch.tensor(self.tokenizer.sft_assistant_begin_sequence, dtype=torch.long)
+        self._img_begin_sequence = torch.tensor(self.tokenizer.img_begin_token, dtype=torch.long)
+        self._img_end_sequence = torch.tensor(self.tokenizer.img_end_token, dtype=torch.long)
 
         # Configure token (sequences) to remove from loss calculation
+        # Pre-compute as tensors for efficiency
         self.tokens_to_mask = []
         if self.config.sft_mask_special_tokens:
             # add tokenizer special tokens like EOS, BOS and assistant begin to be masked. Never mask End of turn.
-            self.tokens_to_mask.append([self._eod_token_id])
-            self.tokens_to_mask.append([self._bos_token_id])
-            self.tokens_to_mask.append(self._sft_assistant_begin_sequence)
-        log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {self.tokens_to_mask}", )
+            self.tokens_to_mask.append(torch.tensor([self._eod_token_id], dtype=torch.long))
+            self.tokens_to_mask.append(torch.tensor([self._bos_token_id], dtype=torch.long))
+            self.tokens_to_mask.append(self._sft_assistant_begin_sequence)  # already a tensor
+        log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
 
         # Build shuffle indices
         self.document_index = self._build_single_document_indices()
@@ -299,15 +299,16 @@ class SFTIndexedDataset(GPTDataset):
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
         # 1) Mask user sequences for loss
-        begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=data.dtype, device=data.device)
-        end_seq = torch.tensor(self._sft_turn_end_sequence, dtype=data.dtype, device=data.device)
+        begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
+        end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
 
         user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
         loss_mask[user_seq_mask] = 0.0
 
         # 2) Mask other token(sequences) as configured in init (might contain BOS, EOS, assistant begin)
         for t in self.tokens_to_mask:
-            t_tensor = torch.tensor(t, dtype=data.dtype, device=data.device)
+            # Use pre-computed tensor, just move to correct device/dtype
+            t_tensor = t.to(dtype=data.dtype, device=data.device)
             if len(t_tensor) == 1:
                 mask = (data == t_tensor[0])
             elif len(t_tensor) > 1:
@@ -318,8 +319,9 @@ class SFTIndexedDataset(GPTDataset):
 
         # 3) Unmask Image tokens if configured
         if self.config.sft_do_not_mask_image_tokens:
-            img_begin_tensor = torch.tensor(self._img_begin_sequence, dtype=data.dtype, device=data.device)
-            img_end_tensor = torch.tensor(self._img_end_sequence, dtype=data.dtype, device=data.device)
+            # Use pre-computed tensors, just move to correct device/dtype
+            img_begin_tensor = self._img_begin_sequence.to(dtype=data.dtype, device=data.device)
+            img_end_tensor = self._img_end_sequence.to(dtype=data.dtype, device=data.device)
             img_seq_mask = get_matching_mask_by_start_end(data, img_begin_tensor, img_end_tensor)
             loss_mask[img_seq_mask] = 1.0
 

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -1,0 +1,191 @@
+from typing import Any, Dict, Optional
+
+import logging
+import numpy as np
+import torch
+
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID
+from megatron.core.datasets.indexed_dataset import IndexedDataset
+from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
+from megatron.core.datasets.utils import Split
+from megatron.core.datasets.utils_s3 import is_s3_path, S3Config
+
+logger = logging.getLogger(__name__)
+
+
+class SFTIndexedDataset(MegatronDataset):
+    """
+    The dataset used during SFT. Uses Low Level Indexed Dataset to load from pre-tokenized SFT data.
+    Each original document/dataset-sample is loaded one by one and padded to fill the sequence length.
+    """
+
+    def __init__(
+        self,
+        dataset: LowLevelDataset,
+        dataset_path: Optional[str],
+        indices: np.ndarray,
+        num_samples: Optional[int],
+        index_split: Split,
+        config: GPTDatasetConfig,
+    ) -> None:
+        super().__init__(dataset, dataset_path, indices, num_samples, index_split, config)
+        # TODO[Raphael] Add support for goldfish loss & caching here as well (as in the original GPTDataset)?
+        try:
+            self._pad_token_id = self.config.tokenizer.pad
+        except Exception:
+            self._pad_token_id = _PAD_TOKEN_ID
+        self.max_seq_len = self.config.sequence_length
+        self.num_samples = self.dataset.sequence_lengths.shape[0]
+        self._eod_token_id = self.config.tokenizer.eod
+
+    @staticmethod
+    def numel_low_level_dataset(low_level_dataset: IndexedDataset) -> int:
+        """Abstract method implementation
+
+        For GPT, the underlying IndexedDataset should be split by sequence, as opposed to, say,
+        BERT, which should be split by document
+
+        Args:
+            low_level_dataset (IndexedDataset): The underlying IndexedDataset
+
+        Returns:
+            int: The number of unique elements in the underlying IndexedDataset
+        """
+        return low_level_dataset.sequence_lengths.shape[0]
+
+    @staticmethod
+    def build_low_level_dataset(dataset_path: str, config: GPTDatasetConfig) -> IndexedDataset:
+        """Abstract method implementation
+
+        Args:
+            dataset_path (str): The real path prefix to the IndexedDataset .bin and .idx files
+
+            config (GPTDatasetConfig): The config
+
+        Returns:
+            IndexedDataset: The underlying IndexedDataset
+        """
+        if is_s3_path(dataset_path):
+            return IndexedDataset(
+                dataset_path,
+                multimodal=False,
+                mmap=config.mmap_bin_files,
+                s3_config=S3Config(path_to_idx_cache=config.s3_cache_path),
+            )
+        return IndexedDataset(dataset_path, multimodal=False, mmap=config.mmap_bin_files)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """
+        Get item from dataset.
+        1) retrieve raw tokens from indexed dataset
+        2) padding added
+        3) apply masking to loss and attention
+        """
+
+        # Load sample (tokens and labels)
+        if idx is None:
+            tokens_raw = self.dataset[0]
+        else:
+            tokens_raw = self.dataset[int(idx % self.num_samples)]
+        tokens_raw = torch.from_numpy(tokens_raw).long()
+
+        if self.config.add_extra_token_to_sequence:
+            tokens = tokens_raw[:-1].contiguous()
+            labels = tokens_raw[1:].contiguous()
+        else:
+            tokens = tokens_raw
+            labels = torch.roll(tokens_raw, shifts=-1, dims=0)
+            labels[-1] = self._pad_token_id
+
+        # TODO[Raphael]: can we assume that eod token is already in data if needed ?
+        #force_eod_length = int(tokenizer.force_eod)
+
+        if len(tokens) > self.max_seq_len:
+            logger.warning(f"Tokens exceed max_seq_len: {len(tokens)}!! Cut off tokens!")
+            tokens = tokens[: self.max_seq_len] # - force_eod_length]
+            labels = labels[: self.max_seq_len] # - force_eod_length]
+
+        # Add padding
+        padding_len = self.max_seq_len - len(tokens)
+        assert padding_len >= 0
+        #filler = [tokenizer.eod] * force_eod_length + [self._pad_token_id] * (padding_len + 1)
+        filler = [self._pad_token_id] * padding_len
+
+        tokens = np.array(tokens.tolist() + filler, dtype=np.int64)
+        labels = np.array(labels.tolist() + filler, dtype=np.int64)
+
+        tokens = torch.tensor(tokens)
+        labels = torch.tensor(labels)
+
+        tokens = tokens[:-1].contiguous()
+        target = labels[1:].contiguous()
+
+        # create attn & loss mask
+        loss_mask, position_ids, attention_mask = self._get_ltor_masks_and_position_ids(
+            target, self.max_seq_len, self._pad_token_id, self.config.eod_mask_loss, self._eod_token_id
+        )
+
+        # For padded sequences, ensure the embedding layer can map the token ID
+        tokens[tokens == self._pad_token_id] = 0
+        labels[labels == self._pad_token_id] = 0
+
+
+        if self.config.create_attention_mask:
+            ret = {
+                'tokens': tokens,
+                'labels': target,
+                'attention_mask': attention_mask,
+                'loss_mask': loss_mask,
+                'position_ids': position_ids,
+            }
+        else:
+            ret = {
+                'tokens': tokens,
+                'labels': target,
+                'loss_mask': loss_mask,
+                'position_ids': position_ids,
+            }
+
+        return ret
+
+    def _get_ltor_masks_and_position_ids(self, labels, max_seq_len, pad_token_id, do_mask_eod, eod_token_id):
+        """Build masks and position id for left to right model for SFT
+            1. find user messages in conversation list
+            2. mask prompts and paddings
+        """
+        assert not self.config.reset_position_ids and not self.config.reset_attention_mask
+
+        # Position ids.
+        position_ids = torch.arange(max_seq_len, dtype=torch.long)
+
+        # Loss mask.
+        loss_mask = torch.ones(max_seq_len, dtype=torch.float)
+        loss_mask[labels == pad_token_id] = 0.0  # mask paddings
+
+        # TODO[Raphael]: find prompts and mask them
+
+        # Mask eod if wanted
+        if do_mask_eod:
+            loss_mask[labels == eod_token_id] = 0.0
+
+        # loss mask on batch padding
+        if idx is None:
+            loss_mask = torch.zeros_like(labels)
+
+        if self.config.create_attention_mask:
+            attention_mask = torch.tril(
+                torch.ones((max_seq_len, max_seq_len), device=labels.device)
+            )
+            # Mask padding tokens in attention mask:
+            no_padding_mask = (labels != pad_token_id).float() # 1=real, 0=padding
+            attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
+            # Convert attention mask to binary:
+            attention_mask = attention_mask.unsqueeze(0)
+            attention_mask = attention_mask < 0.5
+        else:
+            attention_mask = None
+
+        return loss_mask, position_ids, attention_mask

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import torch
 import torch.nn.functional as F
 
-from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID, GPTDataset, _GOLDFISH_TOKEN_ID
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID, GPTDataset
 from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
 from megatron.core.datasets.utils import Split
 from megatron.core.utils import log_single_rank
@@ -37,6 +37,10 @@ class SFTIndexedDataset(GPTDataset):
 
         if self.config.sft_debug:
             self.debug_writer = DebugDataWriter(output_dir="/users/rkreft/debug_data")  # Initialize once, outside the loop
+
+        # Set and log plw weight
+        self.sft_plw_value = config.sft_plw
+        log_single_rank(logger, logging.INFO, f"SFT PLW: {self.sft_plw_value}", )
 
         self.tokenizer = config.tokenizer
         # Set pad token
@@ -70,18 +74,7 @@ class SFTIndexedDataset(GPTDataset):
         # Build shuffle indices
         self.document_index = self._build_single_document_indices()
 
-        # Initialize caching variables
-        self.masks_and_position_ids_are_cacheable = not any(
-            [
-                self.config.reset_position_ids,
-                self.config.reset_attention_mask,
-                self.config.eod_mask_loss,
-            ]
-        )
-        self.masks_and_position_ids_are_cached = False
-        self.cached_attention_mask = None
-        self.cached_loss_mask = None
-        self.cached_position_ids = None
+        # TODO: might add caching of masks and ids later again when implement sample packing?
 
 
     def _build_single_document_indices(self) -> np.ndarray:
@@ -228,23 +221,10 @@ class SFTIndexedDataset(GPTDataset):
             labels = torch.roll(text, shifts=-1, dims=0)
             labels[-1] = self._pad_token_id
 
-        # Generate or use cached masks and position ids
-        if (
-                not self.masks_and_position_ids_are_cacheable
-                or not self.masks_and_position_ids_are_cached
-        ):
-            attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
-                labels
-            )
-            if self.masks_and_position_ids_are_cacheable:
-                self.cached_attention_mask = attention_mask
-                self.cached_loss_mask = loss_mask
-                self.cached_position_ids = position_ids
-                self.masks_and_position_ids_are_cached = True
-        else:
-            attention_mask = self.cached_attention_mask
-            loss_mask = self.cached_loss_mask
-            position_ids = self.cached_position_ids
+        # Generate mask and position ids
+        attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
+            labels
+        )
 
         # Mask loss for padded tokens (this also masks batch padding if idx is None)
         loss_mask[labels == self._pad_token_id] = 0.0

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -213,10 +213,8 @@ class SFTIndexedDataset(GPTDataset):
                 error_msg = (
                     f"ERROR: Requested {self.num_samples} training samples but only "
                     f"{num_samples_available} packed samples available from dataset. "
-                    f"With SFT packing, only one epoch is used. Either:\n"
-                    f"  1. Reduce --train-samples to {num_samples_available} or less, OR\n"
-                    f"  2. Add more documents to your dataset, OR\n"
-                    f"  3. Increase --seq-length to fit more documents per sample"
+                    f"This would lead to crashed training in the end." 
+                    "To mitigate this multi-epoch support would have to be supported!"
                 )
                 log_single_rank(logger, logging.ERROR, error_msg)
                 raise ValueError(error_msg)
@@ -278,7 +276,8 @@ class SFTIndexedDataset(GPTDataset):
             error_msg = (
                 f"ERROR: Requested {self.num_samples} training samples but only "
                 f"{num_samples_available} packed samples available from dataset. "
-                f"Reduce --train-samples to {num_samples_available} or less."
+                f"This would lead to crashed training in the end." 
+                "To mitigate this multi-epoch support would have to be supported!"
             )
             log_single_rank(logger, logging.ERROR, error_msg)
             raise ValueError(error_msg)
@@ -398,8 +397,8 @@ class SFTIndexedDataset(GPTDataset):
         shuffled_idx = self.shuffle_index[idx]
 
         # Get sample boundaries from sample_index
-        doc_index_beg, doc_index_beg_offset = self.sample_index[shuffled_idx]
-        doc_index_end, doc_index_end_offset = self.sample_index[shuffled_idx + 1]
+        doc_index_beg, _ = self.sample_index[shuffled_idx]
+        doc_index_end, _ = self.sample_index[shuffled_idx + 1]
 
         # Target length
         target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
@@ -585,7 +584,7 @@ class SFTIndexedDataset(GPTDataset):
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
-        # For packed samples: reset position IDs at document boundaries (EOD tokens)
+        # 0) For packed samples: reset position IDs at document boundaries (EOD tokens)
         if self._using_packed_samples:
             eod_indices = torch.where(data == self._eod_token_id)[0]
             if len(eod_indices) > 0:
@@ -593,7 +592,8 @@ class SFTIndexedDataset(GPTDataset):
                 for eod_idx in eod_indices:
                     if eod_idx + 1 < len(position_ids):
                         # Subtract the position value at EOD+1 from all subsequent positions
-                        position_ids[(eod_idx + 1):] -= (position_ids[eod_idx + 1])
+                        to_subtract = position_ids[eod_idx].clone() + 1
+                        position_ids[(eod_idx + 1):] -= to_subtract
 
         # 1) Mask user sequences for loss
         begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -55,18 +55,22 @@ class SFTIndexedDataset(GPTDataset):
 
         # Load pre-computed sequences from tokenizer config and convert to tensors
         # These are pre-tokenized in the tokenizer_config.json by add_emu3_tokens_llama3_vision_instruct.py
+        # some models have separate assistant/user end sequences, some a common eot token.
+        # user/assistant end default to same eot if there is a common eot token
         self._sft_user_begin_sequence = torch.tensor(self.tokenizer.sft_user_begin_sequence, dtype=torch.long)
-        self._sft_turn_end_sequence = torch.tensor(self.tokenizer.sft_eot_token, dtype=torch.long)
+        self._sft_user_end_sequence = torch.tensor(self.tokenizer.sft_user_end_sequence, dtype=torch.long)
+        self._sft_assistant_end_sequence = torch.tensor(self.tokenizer.sft_assistant_end_sequence, dtype=torch.long)
         self._sft_assistant_begin_sequence = torch.tensor(self.tokenizer.sft_assistant_begin_sequence, dtype=torch.long)
 
         # Configure token (sequences) to remove from loss calculation
         self.tokens_to_mask = []
         if self.config.sft_mask_special_tokens and not self.config.sft_load_loss_mask:
             # add tokenizer special tokens like EOS, BOS and assistant begin to be masked. Never mask End of turn.
+            # TODO: in current apertus tokenizer eod is eot by default!!
             self.tokens_to_mask.append(torch.tensor([self._eod_token_id], dtype=torch.long))
             self.tokens_to_mask.append(torch.tensor([self._bos_token_id], dtype=torch.long))
             self.tokens_to_mask.append(self._sft_assistant_begin_sequence)  # already a tensor
-            self.tokens_to_mask.append(self._sft_user_begin_sequence)
+            # user begin and end are masked by default as only assistant unmasked
         log_single_rank(logger, logging.WARNING, f"On the fly masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
 
         # Set actual model sequence length (config.sequence_length is doubled if loading loss masks from disk)
@@ -350,7 +354,7 @@ class SFTIndexedDataset(GPTDataset):
         Returns:
             Tuple containing:
                 - np.ndarray: Concatenated tokens from multiple documents, padded to sequence length
-                - np.ndarray: End-of-sequence indices for each document
+                - np.ndarray: End-of-sequence indices for each document (list of size n for n docs in sequence, so min size = 1)
                 - Optional[np.ndarray]: Preloaded loss masks if sft_load_loss_mask is True, else None
         """
         shuffled_idx = self.shuffle_index[idx]
@@ -444,7 +448,7 @@ class SFTIndexedDataset(GPTDataset):
         Returns:
             Tuple containing:
                 - np.ndarray: Token sequence
-                - np.ndarray: End-of-sequence indices
+                - np.ndarray: End-of-sequence indices (single number for case of single sample)
                 - Optional[np.ndarray]: Preloaded loss masks if sft_load_loss_mask is True, else None
         """
         actual_doc_id = self.document_index[idx]
@@ -576,13 +580,13 @@ class SFTIndexedDataset(GPTDataset):
         Args:
             data:                   labels
             eos_indices:            indices of document boundaries (calculated based on sample loading from low level dataset as
-                                    sft data can be contaminated with eod).
+                                    sft data can be contaminated with eod or eod missing).
             preloaded_loss_mask:    Optional pre-computed loss mask loaded from disk. If provided, user prompt masking
                                     and special token masking are skipped for loss_mask.
         """
 
         position_ids = torch.arange(self.model_seq_length, dtype=torch.long)
-        loss_mask = preloaded_loss_mask.to(device=data.device) if preloaded_loss_mask is not None else torch.ones(self.model_seq_length, dtype=torch.float, device=data.device)
+        loss_mask = preloaded_loss_mask.to(device=data.device) if preloaded_loss_mask is not None else torch.zeros(self.model_seq_length, dtype=torch.float, device=data.device)
 
         # 0) For packed samples: reset position IDs at document boundaries
         if self._using_packed_samples:
@@ -594,30 +598,21 @@ class SFTIndexedDataset(GPTDataset):
                         to_subtract = position_ids[eod_idx].clone() + 1
                         position_ids[(eod_idx + 1):] -= to_subtract
 
-        # 1) Compute assistant_mask (unless disabled)
-        if not self.config.sft_disable_assistant_mask:
-            # Compute user sequences to derive assistant mask
-            begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
-            end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
-            user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
-            assistant_mask = (~user_seq_mask).float()
+        # 1) unmask assistant parts and set rest to plw value (if not loaded from disk) otherwise assistant loss needed
+        #    to keep track of assistant loss
+        begin_seq = self._sft_assistant_begin_sequence.to(dtype=data.dtype, device=data.device)
+        end_seq = self._sft_assistant_end_sequence.to(dtype=data.dtype, device=data.device)
+        assistant_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
+        prompt_mask = (~assistant_mask).float()
 
-            # Only apply to loss_mask if NOT loading from disk
-            if preloaded_loss_mask is None:
-                loss_mask[user_seq_mask] = self.sft_plw_value # value is 0 by default for full masking
-        else:
-            # Disable assistant_mask tracking
-            assistant_mask = None
-            user_seq_mask = None
+        # Only apply to loss_mask if NOT loading from disk
+        if preloaded_loss_mask is None:
+            loss_mask[assistant_mask] = 1
+            if self.sft_plw_value > 0:
+                loss_mask[prompt_mask] = self.sft_plw_value # value is 0 by default for full masking
 
-            # Still need to compute user_seq_mask for loss_mask if not loading from disk
-            if preloaded_loss_mask is None:
-                begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
-                end_seq = self._sft_turn_end_sequence.to(dtype=data.dtype, device=data.device)
-                user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
-                loss_mask[user_seq_mask] = self.sft_plw_value
 
-        # 2) Mask other token(sequences) - only for loss_mask if NOT loading from disk
+        # 2) Mask loss for special tokens (if activated) - only if not load loss from disk
         if preloaded_loss_mask is None:
             for t in self.tokens_to_mask:
                 t_tensor = t.to(dtype=data.dtype, device=data.device)
@@ -655,7 +650,7 @@ class SFTIndexedDataset(GPTDataset):
         else:
             attention_mask = None
 
-        # 4) Mask padding tokens (must be done BEFORE equalization to ensure correct normalization)
+        # 4) Make sure padding tokens are masked even if they are part of an assistant answer somehow TODO: check!
         loss_mask[data == self._pad_token_id] = 0.0
         if assistant_mask is not None:
             assistant_mask[data == self._pad_token_id] = 0.0
@@ -665,7 +660,7 @@ class SFTIndexedDataset(GPTDataset):
             # Add small epsilon to prevent division by very small numbers
             eps = 1e-10
 
-            if eos_indices.size > 0:
+            if eos_indices.size > 0: # in sane data this should always be the case as every sample packed or not has >=1 doc
                 # Process each sample segment (between EOD tokens)
                 start_idx = 0
                 for eod_idx in eos_indices:
@@ -682,13 +677,9 @@ class SFTIndexedDataset(GPTDataset):
                 if start_idx < len(loss_mask):
                     segment_mask = loss_mask[start_idx:]
                     segment_loss_sum = segment_mask.sum()
+                    # only do if not just padding (sum = 0)
                     if segment_loss_sum > eps:
                         loss_mask[start_idx:] = segment_mask / segment_loss_sum
-            else:
-                # No EOD tokens found - treat entire sequence as one sample
-                total_sum = loss_mask.sum()
-                if total_sum > eps:
-                    loss_mask[:] = loss_mask / total_sum  # In-place update to ensure it's returned
 
         return attention_mask, loss_mask, position_ids, assistant_mask
 

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -1,19 +1,22 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, override
 
+import time
+import os
 import logging
 import numpy as np
 import torch
 
-from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID, GPTDataset, _GOLDFISH_TOKEN_ID
 from megatron.core.datasets.indexed_dataset import IndexedDataset
 from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
 from megatron.core.datasets.utils import Split
 from megatron.core.datasets.utils_s3 import is_s3_path, S3Config
+from megatron.core.utils import log_single_rank
 
 logger = logging.getLogger(__name__)
 
 
-class SFTIndexedDataset(MegatronDataset):
+class SFTIndexedDataset(GPTDataset):
     """
     The dataset used during SFT. Uses Low Level Indexed Dataset to load from pre-tokenized SFT data.
     Each original document/dataset-sample is loaded one by one and padded to fill the sequence length.
@@ -28,15 +31,38 @@ class SFTIndexedDataset(MegatronDataset):
         index_split: Split,
         config: GPTDatasetConfig,
     ) -> None:
-        super().__init__(dataset, dataset_path, indices, num_samples, index_split, config)
-        # TODO[Raphael] Add support for goldfish loss & caching here as well (as in the original GPTDataset)?
+        # Call Megatron Dataset init instead of direct parent, as we initialize index differently
+        MegatronDataset.__init__(self, dataset, dataset_path, indices, num_samples, index_split, config)
+
+        # Set pad token
         try:
             self._pad_token_id = self.config.tokenizer.pad
         except Exception:
             self._pad_token_id = _PAD_TOKEN_ID
-        self.max_seq_len = self.config.sequence_length
-        self.num_samples = self.dataset.sequence_lengths.shape[0]
-        self._eod_token_id = self.config.tokenizer.eod
+
+        # Build shuffle indices
+        self.document_index, self.shuffle_index = self._build_single_document_indices()
+
+        # Initialize caching variables
+        self.masks_and_position_ids_are_cacheable = not any(
+            [
+                self.config.reset_position_ids,
+                self.config.reset_attention_mask,
+                self.config.eod_mask_loss,
+                self.config.goldfish_loss,
+            ]
+        )
+        self.masks_and_position_ids_are_cached = False
+        self.cached_attention_mask = None
+        self.cached_loss_mask = None
+        self.cached_position_ids = None
+
+        # Goldfish loss setup
+        if self.config.goldfish_loss:
+            self._goldfish_k = self.config.goldfish_k
+            self._goldfish_h = self.config.goldfish_h
+            self._goldfish_token_id = _GOLDFISH_TOKEN_ID
+            self._goldfish_hash_table = None
 
     @staticmethod
     def numel_low_level_dataset(low_level_dataset: IndexedDataset) -> int:
@@ -74,113 +100,258 @@ class SFTIndexedDataset(MegatronDataset):
             )
         return IndexedDataset(dataset_path, multimodal=False, mmap=config.mmap_bin_files)
 
-    def __len__(self) -> int:
-        return self.num_samples
+    def _build_single_document_indices(self):
+        """Build document index and shuffle index for single-document sampling
 
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        Returns:
+            Tuple[numpy.ndarray, numpy.ndarray]: The document index and shuffle index
         """
-        Get item from dataset.
-        1) retrieve raw tokens from indexed dataset
-        2) padding added
-        3) apply masking to loss and attention
-        """
+        path_to_cache = self.config.path_to_cache
+        if path_to_cache is None and not self.config.mock:
+            path_to_cache = os.path.join(
+                self.indexed_dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
+            )
 
-        # Load sample (tokens and labels)
-        if idx is None:
-            tokens_raw = self.dataset[0]
+        if path_to_cache:
+            base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}"
+            get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
+            path_to_description = get_path_to("description.txt")
+            path_to_document_index = get_path_to("document_index.npy")
+            path_to_shuffle_index = get_path_to("shuffle_index.npy")
+            cache_hit = all(
+                map(
+                    os.path.isfile,
+                    [path_to_description, path_to_document_index, path_to_shuffle_index],
+                )
+            )
         else:
-            tokens_raw = self.dataset[int(idx % self.num_samples)]
-        tokens_raw = torch.from_numpy(tokens_raw).long()
+            cache_hit = False
 
-        if self.config.add_extra_token_to_sequence:
-            tokens = tokens_raw[:-1].contiguous()
-            labels = tokens_raw[1:].contiguous()
-        else:
-            tokens = tokens_raw
-            labels = torch.roll(tokens_raw, shifts=-1, dims=0)
-            labels[-1] = self._pad_token_id
+        if not path_to_cache or (
+                not cache_hit
+                and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0)
+        ):
+            log_single_rank(
+                logger,
+                logging.INFO,
+                f"Build and save the {type(self).__name__} {self.index_split.name} indices",
+            )
 
-        # TODO[Raphael]: can we assume that eod token is already in data if needed ?
-        #force_eod_length = int(tokenizer.force_eod)
+            t_beg = time.time()
 
-        if len(tokens) > self.max_seq_len:
-            logger.warning(f"Tokens exceed max_seq_len: {len(tokens)}!! Cut off tokens!")
-            tokens = tokens[: self.max_seq_len] # - force_eod_length]
-            labels = labels[: self.max_seq_len] # - force_eod_length]
+            numpy_random_state = np.random.RandomState(self.config.random_seed)
 
-        # Add padding
-        padding_len = self.max_seq_len - len(tokens)
-        assert padding_len >= 0
-        #filler = [tokenizer.eod] * force_eod_length + [self._pad_token_id] * (padding_len + 1)
-        filler = [self._pad_token_id] * padding_len
+            # Each document maps to exactly one sample
+            if self.num_samples_requested is None:
+                # Use all documents once
+                num_samples = len(self.indexed_indices)
+                num_epochs = 1
+            else:
+                # Calculate how many epochs needed
+                num_samples = self.num_samples_requested
+                docs_per_epoch = len(self.indexed_indices)
+                num_epochs = (num_samples + docs_per_epoch - 1) // docs_per_epoch
 
-        tokens = np.array(tokens.tolist() + filler, dtype=np.int64)
-        labels = np.array(labels.tolist() + filler, dtype=np.int64)
+            # Build document index by repeating indices for each epoch
+            document_index = np.tile(self.indexed_indices, num_epochs).astype(np.int32)
 
-        tokens = torch.tensor(tokens)
-        labels = torch.tensor(labels)
+            # Shuffle all documents
+            numpy_random_state.shuffle(document_index)
 
-        tokens = tokens[:-1].contiguous()
-        target = labels[1:].contiguous()
+            # Truncate to exact number of samples if specified
+            if self.num_samples_requested is not None:
+                document_index = document_index[:self.num_samples_requested]
 
-        # create attn & loss mask
-        loss_mask, position_ids, attention_mask = self._get_ltor_masks_and_position_ids(
-            target, self.max_seq_len, self._pad_token_id, self.config.eod_mask_loss, self._eod_token_id
+            # Build shuffle index (identity mapping since we already shuffled documents)
+            shuffle_index = np.arange(len(document_index), dtype=np.int32)
+
+            if path_to_cache:
+                os.makedirs(path_to_cache, exist_ok=True)
+                with open(path_to_description, "wt") as writer:
+                    writer.write(self.unique_description)
+                np.save(path_to_document_index, document_index, allow_pickle=True)
+                np.save(path_to_shuffle_index, shuffle_index, allow_pickle=True)
+            else:
+                log_single_rank(
+                    logger,
+                    logging.WARNING,
+                    f"Unable to save {type(self).__name__} indexes because path_to_cache is None",
+                )
+
+            t_end = time.time()
+            log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+            log_single_rank(logger, logging.INFO, f"> total number of samples: {len(document_index)}")
+            log_single_rank(logger, logging.INFO, f"> total number of epochs: {num_epochs}")
+
+            return document_index, shuffle_index
+
+        # Load from cache
+        log_single_rank(
+            logger, logging.INFO, f"Load the {type(self).__name__} {self.index_split.name} indices"
         )
 
-        # For padded sequences, ensure the embedding layer can map the token ID
+        t_beg = time.time()
+        document_index = np.load(path_to_document_index, allow_pickle=True, mmap_mode='r')
+        t_end = time.time()
+        log_single_rank(logger, logging.DEBUG, f"\t> document index load time: {t_end - t_beg:4f} seconds")
+
+        t_beg = time.time()
+        shuffle_index = np.load(path_to_shuffle_index, allow_pickle=True, mmap_mode='r')
+        t_end = time.time()
+        log_single_rank(logger, logging.DEBUG, f"\t> shuffle index load time: {t_end - t_beg:4f} seconds")
+
+        log_single_rank(logger, logging.INFO, f"> total number of samples: {len(document_index)}")
+
+        return document_index, shuffle_index
+
+    def __len__(self) -> int:
+        return self.document_index.shape[0] - 1
+
+    def __getitem__(self, idx: Optional[int]) -> Dict[str, torch.Tensor]:
+        """Get a single sample from the dataset
+
+        Args:
+            idx (Optional[int]): The index into the dataset
+
+        Returns:
+            Dict[str, torch.Tensor]: The sample information wrapped in a dictionary
+        """
+        if idx is None:
+            # Batch padding sequence
+            text = np.array(
+                [self._pad_token_id] * (self.config.sequence_length + self.config.add_extra_token_to_sequence),
+                dtype=np.int64)
+        else:
+            # Get the shuffled document index
+            doc_idx = self.shuffle_index[idx]
+            actual_doc_id = self.document_index[doc_idx]
+
+            # Get the entire document
+            document = self.indexed_dataset.get(actual_doc_id)
+
+            # Truncate or pad to sequence_length
+            target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
+
+            if len(document) >= target_length:
+                # Truncate
+                logger.warning(f"Document {actual_doc_id} is longer than model sequence length {target_length} and gets trunc")
+                text = document[:target_length]
+            else:
+                # Pad
+                padding_length = target_length - len(document)
+                text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+
+        text = torch.from_numpy(text).long()
+
+        # Create tokens and labels
+        if self.config.add_extra_token_to_sequence:
+            tokens = text[:-1].contiguous()
+            labels = text[1:].contiguous()
+        else:
+            tokens = text
+            labels = torch.roll(text, shifts=-1, dims=0)
+            labels[-1] = self._pad_token_id
+
+        # Generate or use cached masks and position ids
+        if (
+                not self.masks_and_position_ids_are_cacheable
+                or not self.masks_and_position_ids_are_cached
+        ):
+            attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
+                tokens,
+                self.config.tokenizer.eod,
+                self.config.reset_position_ids,
+                self.config.reset_attention_mask,
+                self.config.eod_mask_loss,
+                self.config.create_attention_mask,
+            )
+            if self.masks_and_position_ids_are_cacheable:
+                self.cached_attention_mask = attention_mask
+                self.cached_loss_mask = loss_mask
+                self.cached_position_ids = position_ids
+                self.masks_and_position_ids_are_cached = True
+        else:
+            attention_mask = self.cached_attention_mask
+            loss_mask = self.cached_loss_mask
+            position_ids = self.cached_position_ids
+
+        # Mask loss for padded tokens
+        loss_mask[labels == self._pad_token_id] = 0.0
+
+        # Map pad tokens to valid embedding indices
         tokens[tokens == self._pad_token_id] = 0
         labels[labels == self._pad_token_id] = 0
 
+        # Apply goldfish loss masking if enabled
+        if self.config.goldfish_loss:
+            if self._goldfish_hash_table is None:
+                self._goldfish_hash_table = self._create_hash_table(device=labels.device)
 
+            goldfish_labels = self.apply_goldfish(
+                labels,
+                goldfish_token_id=self._goldfish_token_id,
+                k=self._goldfish_k,
+                goldfish_hash_table=self._goldfish_hash_table,
+                goldfish_context_width=self._goldfish_h,
+            )
+            loss_mask[goldfish_labels == self._goldfish_token_id] = 0.0
+
+        # Mask loss for batch padding sequences
+        if idx is None:
+            loss_mask = torch.zeros_like(loss_mask)
+
+        # Return sample dict
         if self.config.create_attention_mask:
-            ret = {
-                'tokens': tokens,
-                'labels': target,
-                'attention_mask': attention_mask,
-                'loss_mask': loss_mask,
-                'position_ids': position_ids,
+            return {
+                "tokens": tokens,
+                "labels": labels,
+                "attention_mask": attention_mask,
+                "loss_mask": loss_mask,
+                "position_ids": position_ids,
             }
         else:
-            ret = {
-                'tokens': tokens,
-                'labels': target,
-                'loss_mask': loss_mask,
-                'position_ids': position_ids,
+            return {
+                "tokens": tokens,
+                "labels": labels,
+                "loss_mask": loss_mask,
+                "position_ids": position_ids,
             }
 
-        return ret
-
-    def _get_ltor_masks_and_position_ids(self, labels, max_seq_len, pad_token_id, do_mask_eod, eod_token_id):
+    @override
+    def _get_ltor_masks_and_position_ids(self, tokens,
+                tokenizer_eod_id,
+                reset_position_ids,
+                reset_attention_mask,
+                eod_mask_loss,
+                create_attention_mask):
         """Build masks and position id for left to right model for SFT
             1. find user messages in conversation list
-            2. mask prompts and paddings
+            2. mask prompts
         """
-        assert not self.config.reset_position_ids and not self.config.reset_attention_mask
+        assert not reset_position_ids and not reset_attention_mask
 
         # Position ids.
-        position_ids = torch.arange(max_seq_len, dtype=torch.long)
+        position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
 
         # Loss mask.
-        loss_mask = torch.ones(max_seq_len, dtype=torch.float)
-        loss_mask[labels == pad_token_id] = 0.0  # mask paddings
+        loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
         # TODO[Raphael]: find prompts and mask them
 
         # Mask eod if wanted
-        if do_mask_eod:
-            loss_mask[labels == eod_token_id] = 0.0
+        if eod_mask_loss:
+            loss_mask[tokens == tokenizer_eod_id] = 0.0
 
         # loss mask on batch padding
         if idx is None:
-            loss_mask = torch.zeros_like(labels)
+            loss_mask = torch.zeros_like(tokens)
 
-        if self.config.create_attention_mask:
+        if create_attention_mask:
             attention_mask = torch.tril(
-                torch.ones((max_seq_len, max_seq_len), device=labels.device)
+                torch.ones((self.config.sequence_length, self.config.sequence_length), device=tokens.device)
             )
             # Mask padding tokens in attention mask:
-            no_padding_mask = (labels != pad_token_id).float() # 1=real, 0=padding
+            no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
             attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
             # Convert attention mask to binary:
             attention_mask = attention_mask.unsqueeze(0)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import time
 import os
@@ -84,6 +84,13 @@ class SFTIndexedDataset(GPTDataset):
             # Use simple single-document indexing
             self.document_index = self._build_single_document_indices()
             self._using_packed_samples = False
+
+    @staticmethod
+    def _key_config_attributes() -> List[str]:
+        """
+        Extend key attributes from Megatron dataset, to include vital sft config attributes.
+        """
+        return ["random_seed", "sequence_length", "split", "split_matrix", "tokenizer", "sft_pack_samples"]
 
     def _log_packing_statistics(self, document_index, sample_index, from_cache=False):
         """

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -8,10 +8,8 @@ import torch
 import torch.nn.functional as F
 
 from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, _PAD_TOKEN_ID, GPTDataset, _GOLDFISH_TOKEN_ID
-from megatron.core.datasets.indexed_dataset import IndexedDataset
 from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
 from megatron.core.datasets.utils import Split
-from megatron.core.datasets.utils_s3 import is_s3_path, S3Config
 from megatron.core.utils import log_single_rank
 
 logger = logging.getLogger(__name__)
@@ -333,12 +331,19 @@ class SFTIndexedDataset(GPTDataset):
             loss_mask[tokens == tokenizer_eod_id] = 0.0
 
         if create_attention_mask:
+            # Here me mask attention from all padding tokens to all other tokens and vice versa
             attention_mask = torch.tril(
                 torch.ones((self.config.sequence_length, self.config.sequence_length), device=tokens.device)
             )
             # Mask padding tokens in attention mask:
             no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
+            
+            # Mask both rows (queries from padding) and columns (keys to padding)
+            # Row masking: padding tokens shouldn't attend to anything
+            attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
+            # Column masking: nothing should attend to padding tokens
             attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
+            
             # Convert attention mask to binary:
             attention_mask = attention_mask.unsqueeze(0)
             attention_mask = attention_mask < 0.5

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, override
+from typing import Dict, Optional, override
 
 import time
 import os
@@ -39,6 +39,11 @@ class SFTIndexedDataset(GPTDataset):
             self._pad_token_id = self.config.tokenizer.pad
         except Exception:
             self._pad_token_id = _PAD_TOKEN_ID
+
+        # End of Document token to add end to truncated samples
+        self._eod_token_id = self.config.tokenizer.eod
+
+        # TODO: Add options to mask all special tokens?
 
         # TODO: Pass sequences dynamically
         self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>', add_special_tokens=False)
@@ -193,8 +198,10 @@ class SFTIndexedDataset(GPTDataset):
             # Truncate or pad to sequence_length
             target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
             if len(document) >= target_length:
+                # End truncated document with end-of-document token
                 logger.warning(f"Document {actual_doc_id} is longer than model sequence length {target_length} and gets trunc")
-                text = document[:target_length]
+                trunc_doc = document[:target_length-1]
+                text = np.concatenate([trunc_doc, np.array([self._eod_token_id])])
             else:
                 padding_length = target_length - len(document)
                 text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -670,6 +670,9 @@ class SFTIndexedDataset(GPTDataset):
 
         # 5) Equalize sample loss
         if self.config.sft_equalize_sample_loss:
+            # Add small epsilon to prevent division by very small numbers
+            eps = 1e-10
+
             if len(eod_indices) > 0:
                 # Process each sample segment (between EOD tokens)
                 start_idx = 0
@@ -678,7 +681,7 @@ class SFTIndexedDataset(GPTDataset):
                     segment_loss_sum = segment_mask.sum()
 
                     # Normalize so total sample contribution = 1.0
-                    if segment_loss_sum > 0:
+                    if segment_loss_sum > eps:
                         loss_mask[start_idx:eod_idx+1] = segment_mask / segment_loss_sum
 
                     start_idx = eod_idx + 1
@@ -687,13 +690,13 @@ class SFTIndexedDataset(GPTDataset):
                 if start_idx < len(loss_mask):
                     segment_mask = loss_mask[start_idx:]
                     segment_loss_sum = segment_mask.sum()
-                    if segment_loss_sum > 0:
+                    if segment_loss_sum > eps:
                         loss_mask[start_idx:] = segment_mask / segment_loss_sum
             else:
                 # No EOD tokens found - treat entire sequence as one sample
                 total_sum = loss_mask.sum()
-                if total_sum > 0:
-                    loss_mask = loss_mask / total_sum
+                if total_sum > eps:
+                    loss_mask[:] = loss_mask / total_sum  # In-place update to ensure it's returned
 
         return attention_mask, loss_mask, position_ids, assistant_mask
 

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -168,7 +168,6 @@ class SFTIndexedDataset(GPTDataset):
                 sequence_lengths_for_cpp,
                 document_index,
                 sequence_length,
-                drop_last_partial_sequence=True,
                 add_extra_token_to_sequence=self.config.add_extra_token_to_sequence,
             )
 

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -83,6 +83,38 @@ class SFTIndexedDataset(GPTDataset):
             self.document_index = self._build_single_document_indices()
             self._using_packed_samples = False
 
+    def _log_packing_statistics(self, document_index, sample_index, from_cache=False):
+        """
+        Log statistics about packed samples.
+
+        Args:
+            document_index: Array of document IDs
+            sample_index: Array of sample boundaries
+            from_cache: Whether the indices were loaded from cache
+        """
+        num_samples_available = sample_index.shape[0] - 1
+        sequence_length = self.config.sequence_length
+        num_tokens_per_epoch = int(np.sum(self.dataset.sequence_lengths[self.indices]))
+        total_tokens_in_samples = num_samples_available * sequence_length
+        avg_tokens_per_sample = num_tokens_per_epoch / num_samples_available if num_samples_available > 0 else 0
+        avg_documents_per_sample = len(document_index) / num_samples_available if num_samples_available > 0 else 0
+
+        # Log packing statistics
+        cache_suffix = " (loaded from cache)" if from_cache else ""
+        log_single_rank(logger, logging.INFO, f"> ===== SFT Packing Statistics{cache_suffix} =====")
+        log_single_rank(logger, logging.INFO, f"> Total documents in epoch: {len(document_index)}")
+        log_single_rank(logger, logging.INFO, f"> Total tokens in documents: {num_tokens_per_epoch:,}")
+        log_single_rank(logger, logging.INFO, f"> Sequence length: {sequence_length}")
+        log_single_rank(logger, logging.INFO, f"> Number of packed samples: {num_samples_available:,}")
+        log_single_rank(logger, logging.INFO, f"> Total tokens in samples: {total_tokens_in_samples:,}")
+        log_single_rank(logger, logging.INFO, f"> Average tokens per sample: {avg_tokens_per_sample:.1f}")
+        log_single_rank(logger, logging.INFO, f"> Average documents per sample: {avg_documents_per_sample:.2f}")
+        log_single_rank(logger, logging.INFO, f"> Token utilization: {100 * num_tokens_per_epoch / total_tokens_in_samples:.2f}%")
+        if from_cache:
+            log_single_rank(logger, logging.INFO, f"> ========================================================")
+        else:
+            log_single_rank(logger, logging.INFO, f"> ===================================")
+
     def _build_packing_document_to_sample_indices(self):
         """
         Build indices for packed document sampling. Packs whole documents into sequences without splitting.
@@ -173,22 +205,8 @@ class SFTIndexedDataset(GPTDataset):
 
             num_samples_available = sample_index.shape[0] - 1
 
-            # Calculate statistics for logging
-            total_tokens_in_samples = num_samples_available * sequence_length
-            avg_tokens_per_sample = num_tokens_per_epoch / num_samples_available if num_samples_available > 0 else 0
-            avg_documents_per_sample = len(document_index) / num_samples_available if num_samples_available > 0 else 0
-
             # Log packing statistics
-            log_single_rank(logger, logging.INFO, f"> ===== SFT Packing Statistics =====")
-            log_single_rank(logger, logging.INFO, f"> Total documents in epoch: {len(document_index)}")
-            log_single_rank(logger, logging.INFO, f"> Total tokens in documents: {num_tokens_per_epoch:,}")
-            log_single_rank(logger, logging.INFO, f"> Sequence length: {sequence_length}")
-            log_single_rank(logger, logging.INFO, f"> Number of packed samples: {num_samples_available:,}")
-            log_single_rank(logger, logging.INFO, f"> Total tokens in samples: {total_tokens_in_samples:,}")
-            log_single_rank(logger, logging.INFO, f"> Average tokens per sample: {avg_tokens_per_sample:.1f}")
-            log_single_rank(logger, logging.INFO, f"> Average documents per sample: {avg_documents_per_sample:.2f}")
-            log_single_rank(logger, logging.INFO, f"> Token utilization: {100 * num_tokens_per_epoch / total_tokens_in_samples:.2f}%")
-            log_single_rank(logger, logging.INFO, f"> ===================================")
+            self._log_packing_statistics(document_index, sample_index, from_cache=False)
 
             # Validate: if num_samples requested exceeds what's available, abort
             if self.num_samples is not None and self.num_samples > num_samples_available:
@@ -251,7 +269,9 @@ class SFTIndexedDataset(GPTDataset):
         log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
 
         num_samples_available = sample_index.shape[0] - 1
-        log_single_rank(logger, logging.INFO, f"> total number of packed samples: {num_samples_available:,}")
+
+        # Log packing statistics
+        self._log_packing_statistics(document_index, sample_index, from_cache=True)
 
         # Validate again when loading from cache
         if self.num_samples is not None and self.num_samples > num_samples_available:

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -297,7 +297,6 @@ class SFTIndexedDataset(GPTDataset):
         Finally, creates an attention mask if configured. The attention mask will exclude padding tokens from attention.
         Also creates an assistant_mask to identify assistant response tokens for separate loss tracking.
         """
-        assert not self.config.reset_position_ids and not self.config.reset_attention_mask
 
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -71,18 +71,208 @@ class SFTIndexedDataset(GPTDataset):
             self.tokens_to_mask.append(self._sft_user_begin_sequence)
         log_single_rank(logger, logging.WARNING, f"Masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}", )
 
-        # Build shuffle indices
-        self.document_index = self._build_single_document_indices()
+        # Build indices based on packing mode
+        if self.config.sft_pack_samples:
+            # Use multi-document packing with sample_index
+            (self.document_index, self.sample_index, self.shuffle_index) = (
+                self._build_packing_document_to_sample_indices()
+            )
+            self._using_packed_samples = True
+        else:
+            # Use simple single-document indexing
+            self.document_index = self._build_single_document_indices()
+            self._using_packed_samples = False
 
-        # TODO: might add caching of masks and ids later again when implement sample packing?
+    def _build_packing_document_to_sample_indices(self):
+        """
+        Build indices for packed document sampling. Packs whole documents into sequences without splitting.
+        Uses only ONE epoch of documents (no replication across epochs). Training steps should match
+        the number of packed samples available.
 
+        Returns a tuple of three indices:
+        - document_index: Shuffled document IDs for one epoch
+        - sample_index: Maps sample boundaries to (document_index position, offset) pairs
+        - shuffle_index: Random permutation for shuffling sample order during training
+
+        Caches the generated indices to disk if path_to_cache is specified.
+
+        Returns:
+            Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]:
+                - document_index: Shape (num_documents,) - shuffled document IDs for one epoch
+                - sample_index: Shape (num_samples + 1, 2) - sample boundaries as [doc_idx_index, offset=0]
+                - shuffle_index: Shape (num_samples,) - permutation indices for shuffling
+        """
+        from megatron.core.datasets.gpt_dataset import _build_shuffle_index
+        from megatron.core.datasets import helpers
+
+        path_to_cache = self.config.path_to_cache
+        if path_to_cache is None and not self.config.mock:
+            path_to_cache = os.path.join(
+                self.dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
+            )
+
+        if path_to_cache:
+            base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}-packed"
+            get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
+            path_to_description = get_path_to("description.txt")
+            path_to_document_index = get_path_to("document_index.npy")
+            path_to_sample_index = get_path_to("sample_index.npy")
+            path_to_shuffle_index = get_path_to("shuffle_index.npy")
+            cache_hit = all(
+                map(
+                    os.path.isfile,
+                    [
+                        path_to_description,
+                        path_to_document_index,
+                        path_to_sample_index,
+                        path_to_shuffle_index,
+                    ],
+                )
+            )
+        else:
+            cache_hit = False
+
+        if not path_to_cache or (
+            not cache_hit
+            and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0)
+        ):
+            log_single_rank(
+                logger,
+                logging.INFO,
+                f"Build and save the {type(self).__name__} {self.index_split.name} packed indices",
+            )
+
+            t_beg = time.time()
+
+            sequence_length = self.config.sequence_length
+            num_tokens_per_epoch = int(np.sum(self.dataset.sequence_lengths[self.indices]))
+
+            # SFT packing: use only ONE epoch (no document replication)
+            numpy_random_state = np.random.RandomState(self.config.random_seed)
+
+            # Build document index: shuffled documents for ONE epoch only
+            document_index = self.indices.copy().astype(np.int32)
+            numpy_random_state.shuffle(document_index)
+
+            # Build the sample index using whole-document packing
+            assert document_index.dtype == np.int32
+            assert self.dataset.sequence_lengths.dtype == np.int32
+
+            # Copy sequence lengths for C++ if access density is high
+            if len(document_index) * 2 > len(self.dataset.sequence_lengths):
+                sequence_lengths_for_cpp = self.dataset.sequence_lengths.copy()
+            else:
+                sequence_lengths_for_cpp = self.dataset.sequence_lengths
+
+            sample_index = helpers.build_sample_idx_packed_whole_docs(
+                sequence_lengths_for_cpp,
+                document_index,
+                sequence_length,
+                drop_last_partial_sequence=True,
+                add_extra_token_to_sequence=self.config.add_extra_token_to_sequence,
+            )
+
+            num_samples_available = sample_index.shape[0] - 1
+
+            # Calculate statistics for logging
+            total_tokens_in_samples = num_samples_available * sequence_length
+            avg_tokens_per_sample = num_tokens_per_epoch / num_samples_available if num_samples_available > 0 else 0
+            avg_documents_per_sample = len(document_index) / num_samples_available if num_samples_available > 0 else 0
+
+            # Log packing statistics
+            log_single_rank(logger, logging.INFO, f"> ===== SFT Packing Statistics =====")
+            log_single_rank(logger, logging.INFO, f"> Total documents in epoch: {len(document_index)}")
+            log_single_rank(logger, logging.INFO, f"> Total tokens in documents: {num_tokens_per_epoch:,}")
+            log_single_rank(logger, logging.INFO, f"> Sequence length: {sequence_length}")
+            log_single_rank(logger, logging.INFO, f"> Number of packed samples: {num_samples_available:,}")
+            log_single_rank(logger, logging.INFO, f"> Total tokens in samples: {total_tokens_in_samples:,}")
+            log_single_rank(logger, logging.INFO, f"> Average tokens per sample: {avg_tokens_per_sample:.1f}")
+            log_single_rank(logger, logging.INFO, f"> Average documents per sample: {avg_documents_per_sample:.2f}")
+            log_single_rank(logger, logging.INFO, f"> Token utilization: {100 * num_tokens_per_epoch / total_tokens_in_samples:.2f}%")
+            log_single_rank(logger, logging.INFO, f"> ===================================")
+
+            # Validate: if num_samples requested exceeds what's available, abort
+            if self.num_samples is not None and self.num_samples > num_samples_available:
+                error_msg = (
+                    f"ERROR: Requested {self.num_samples} training samples but only "
+                    f"{num_samples_available} packed samples available from dataset. "
+                    f"With SFT packing, only one epoch is used. Either:\n"
+                    f"  1. Reduce --train-samples to {num_samples_available} or less, OR\n"
+                    f"  2. Add more documents to your dataset, OR\n"
+                    f"  3. Increase --seq-length to fit more documents per sample"
+                )
+                log_single_rank(logger, logging.ERROR, error_msg)
+                raise ValueError(error_msg)
+
+            # Build the shuffle index (random permutation for sample order during training)
+            shuffle_index = _build_shuffle_index(
+                sample_index.shape[0] - 1, sample_index.shape[0] - 1, numpy_random_state
+            )
+
+            if path_to_cache:
+                os.makedirs(path_to_cache, exist_ok=True)
+                with open(path_to_description, "wt") as writer:
+                    writer.write(self.unique_description)
+                np.save(path_to_document_index, document_index, allow_pickle=True)
+                np.save(path_to_sample_index, sample_index, allow_pickle=True)
+                np.save(path_to_shuffle_index, shuffle_index, allow_pickle=True)
+            else:
+                log_single_rank(
+                    logger,
+                    logging.WARNING,
+                    f"Unable to save {type(self).__name__} indexes because path_to_cache is None",
+                )
+
+            t_end = time.time()
+            log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+
+            return document_index, sample_index, shuffle_index
+
+        # Load from cache
+        log_single_rank(
+            logger, logging.INFO, f"Load the {type(self).__name__} {self.index_split.name} packed indices"
+        )
+
+        log_single_rank(logger, logging.INFO, f"\tLoad the document index from {os.path.basename(path_to_document_index)}")
+        t_beg = time.time()
+        document_index = np.load(path_to_document_index, allow_pickle=True, mmap_mode='r')
+        t_end = time.time()
+        log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+
+        log_single_rank(logger, logging.INFO, f"\tLoad the sample index from {os.path.basename(path_to_sample_index)}")
+        t_beg = time.time()
+        sample_index = np.load(path_to_sample_index, allow_pickle=True, mmap_mode='r')
+        t_end = time.time()
+        log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+
+        log_single_rank(logger, logging.INFO, f"\tLoad the shuffle index from {os.path.basename(path_to_shuffle_index)}")
+        t_beg = time.time()
+        shuffle_index = np.load(path_to_shuffle_index, allow_pickle=True, mmap_mode='r')
+        t_end = time.time()
+        log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
+
+        num_samples_available = sample_index.shape[0] - 1
+        log_single_rank(logger, logging.INFO, f"> total number of packed samples: {num_samples_available:,}")
+
+        # Validate again when loading from cache
+        if self.num_samples is not None and self.num_samples > num_samples_available:
+            error_msg = (
+                f"ERROR: Requested {self.num_samples} training samples but only "
+                f"{num_samples_available} packed samples available from dataset. "
+                f"Reduce --train-samples to {num_samples_available} or less."
+            )
+            log_single_rank(logger, logging.ERROR, error_msg)
+            raise ValueError(error_msg)
+
+        return document_index, sample_index, shuffle_index
 
     def _build_single_document_indices(self) -> np.ndarray:
         """
         Build a document index for single-document sampling. Only one document is used per sample.
+        Caches the generated index to disk if path_to_cache is specified.
 
         Returns:
-            numpy.ndarray: The document index
+            numpy.ndarray: The document index (Shape: (num_samples,))
         """
         path_to_cache = self.config.path_to_cache
         if path_to_cache is None and not self.config.mock:
@@ -174,13 +364,80 @@ class SFTIndexedDataset(GPTDataset):
 
         return document_index
 
+    def _get_packed_sample(self, idx: int) -> np.ndarray:
+        """
+        Load and concatenate multiple whole documents for a packed sample.
+        Similar to GPT dataset's _query_document_sample_shuffle_indices but only handles whole documents.
+
+        Args:
+            idx (int): The sample index
+
+        Returns:
+            np.ndarray: Concatenated tokens from multiple documents, padded to sequence length
+        """
+        # Apply shuffle
+        shuffled_idx = self.shuffle_index[idx]
+
+        # Get sample boundaries from sample_index
+        doc_index_beg, doc_index_beg_offset = self.sample_index[shuffled_idx]
+        doc_index_end, doc_index_end_offset = self.sample_index[shuffled_idx + 1]
+
+        # Target length
+        target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
+
+        # Collect document tokens
+        document_tokens = []
+
+        # Iterate through documents in this sample
+        assert doc_index_beg < doc_index_end  # the way we create the index, the end idx doc is always excluded, so even for same doc begin end end idx are different
+        for i in range(doc_index_beg, doc_index_end):
+            # Get the actual document ID from document_index
+            doc_id = self.document_index[i]
+
+            # Load the full document (offset is always 0 for whole-document packing)
+            document = self.dataset.get(doc_id)
+
+            # Check if document is too long and truncate if yes (as in single document index) TODO: add option to discard here and for single doc case?
+            if len(document) > target_length:
+                # Truncate and add EOD
+                logger.warning(
+                    f"Document {doc_id} in packed sample is too long ({len(document)} > {target_length}), truncating")
+                document = np.concatenate([document[:target_length - 1], np.array([self._eod_token_id])])
+
+            document_tokens.append(document)
+
+        # Concatenate all documents
+        if len(document_tokens) > 0:
+            text = np.concatenate(document_tokens)
+        else:
+            # Edge case: empty sample (shouldn't happen)
+            text = np.array([], dtype=np.int64)
+
+        # Pad to target length
+        if len(text) < target_length:
+            padding_length = target_length - len(text)
+            text = np.concatenate([text, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
+        elif len(text) > target_length:
+            # This should never happen with correct packing - raise error
+            raise RuntimeError(
+                f"Packed sample {idx} exceeded target length ({len(text)} > {target_length}). "
+                f"This indicates a bug in build_sample_idx_packed_whole_docs. "
+                f"Sample contains {len(document_tokens)} documents."
+            )
+
+        return text
+
     def __len__(self) -> int:
-        return len(self.document_index)
+        if self._using_packed_samples:
+            return self.sample_index.shape[0] - 1
+        else:
+            return len(self.document_index)
 
     def __getitem__(self, idx: Optional[int]) -> Dict[str, torch.Tensor]:
         """
         Get a single sample from the dataset.
-        Each sample is a single document padded to sequence length OR truncated if too long.
+        For non-packed mode: Each sample is a single document padded to sequence length OR truncated if too long.
+        For packed mode: Each sample contains multiple whole documents concatenated together.
 
         Args:
             idx (Optional[int]): The index into the dataset
@@ -193,8 +450,11 @@ class SFTIndexedDataset(GPTDataset):
             text = np.array(
                 [self._pad_token_id] * (self.config.sequence_length + self.config.add_extra_token_to_sequence),
                 dtype=np.int64)
+        elif self._using_packed_samples:
+            # Packed mode: load and concatenate multiple whole documents
+            text = self._get_packed_sample(idx)
         else:
-            # Get document. index is already shuffled
+            # Single-document mode: Get document. index is already shuffled
             actual_doc_id = self.document_index[idx]
             document = self.dataset.get(actual_doc_id)
 
@@ -295,11 +555,26 @@ class SFTIndexedDataset(GPTDataset):
             2. Can mask arbitrary token sequences (e.g. assistant begin, assistant end, BOS, EOS)
         Both options can be Configured in the init.
         Finally, creates an attention mask if configured. The attention mask will exclude padding tokens from attention.
+
+        For packed samples (when sft_pack_samples=True):
+            - Position IDs are reset at each EOD token (document boundary)
+            - Attention mask blocks cross-document attention at EOD boundaries
+
         Also creates an assistant_mask to identify assistant response tokens for separate loss tracking.
         """
 
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
+
+        # For packed samples: reset position IDs at document boundaries (EOD tokens)
+        if self._using_packed_samples:
+            eod_indices = torch.where(data == self._eod_token_id)[0]
+            if len(eod_indices) > 0:
+                # Reset position IDs after each EOD token
+                for eod_idx in eod_indices:
+                    if eod_idx + 1 < len(position_ids):
+                        # Subtract the position value at EOD+1 from all subsequent positions
+                        position_ids[(eod_idx + 1):] -= (position_ids[eod_idx + 1])
 
         # 1) Mask user sequences for loss
         begin_seq = self._sft_user_begin_sequence.to(dtype=data.dtype, device=data.device)
@@ -347,6 +622,16 @@ class SFTIndexedDataset(GPTDataset):
             attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
             # Column masking: nothing should attend to padding tokens
             attention_mask = attention_mask * no_padding_mask.unsqueeze(0)
+
+            # For packed samples: block cross-document attention at EOD boundaries
+            if self._using_packed_samples:
+                eod_indices = torch.where(data == self._eod_token_id)[0]
+                if len(eod_indices) > 0:
+                    # Block attention from tokens after EOD to tokens before and including EOD
+                    for eod_idx in eod_indices:
+                        if eod_idx + 1 < self.config.sequence_length:
+                            # Zero out attention from all tokens after EOD to all tokens up to and including EOD
+                            attention_mask[(eod_idx + 1):, :(eod_idx + 1)] = 0.0
 
             # Convert attention mask to binary:
             attention_mask = attention_mask.unsqueeze(0)

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -27,13 +27,13 @@ class SFTIndexedDataset(GPTDataset):
         self,
         dataset: LowLevelDataset,
         dataset_path: Optional[str],
-        indices: np.ndarray,
+        indexed_indices: np.ndarray,
         num_samples: Optional[int],
         index_split: Split,
         config: GPTDatasetConfig,
     ) -> None:
         # Call Megatron Dataset init instead of direct parent, as we initialize index differently
-        MegatronDataset.__init__(self, dataset, dataset_path, indices, num_samples, index_split, config)
+        MegatronDataset.__init__(self, dataset, dataset_path, indexed_indices, num_samples, index_split, config)
 
         self.tokenizer = config.tokenizer
         # Set pad token
@@ -43,11 +43,11 @@ class SFTIndexedDataset(GPTDataset):
             self._pad_token_id = _PAD_TOKEN_ID
 
         # TODO: Pass sequences dynamically
-        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>assistant<|end_header_id|>\n\n')
+        self._sft_user_begin_sequence = self.tokenizer.tokenize('<|start_header_id|>user<|end_header_id|>\n\n')
         self._sft_turn_end_sequence = self.tokenizer.tokenize('<|eot_id|>')
 
         # Build shuffle indices
-        self.document_index, self.shuffle_index = self._build_single_document_indices()
+        self.document_index = self._build_single_document_indices()
 
         # Initialize caching variables
         self.masks_and_position_ids_are_cacheable = not any(
@@ -70,44 +70,11 @@ class SFTIndexedDataset(GPTDataset):
             self._goldfish_token_id = _GOLDFISH_TOKEN_ID
             self._goldfish_hash_table = None
 
-    @staticmethod
-    def numel_low_level_dataset(low_level_dataset: IndexedDataset) -> int:
-        """Abstract method implementation
-
-        For GPT, the underlying IndexedDataset should be split by sequence, as opposed to, say,
-        BERT, which should be split by document
-
-        Args:
-            low_level_dataset (IndexedDataset): The underlying IndexedDataset
-
-        Returns:
-            int: The number of unique elements in the underlying IndexedDataset
-        """
-        return low_level_dataset.sequence_lengths.shape[0]
-
-    @staticmethod
-    def build_low_level_dataset(dataset_path: str, config: GPTDatasetConfig) -> IndexedDataset:
-        """Abstract method implementation
-
-        Args:
-            dataset_path (str): The real path prefix to the IndexedDataset .bin and .idx files
-
-            config (GPTDatasetConfig): The config
-
-        Returns:
-            IndexedDataset: The underlying IndexedDataset
-        """
-        if is_s3_path(dataset_path):
-            return IndexedDataset(
-                dataset_path,
-                multimodal=False,
-                mmap=config.mmap_bin_files,
-                s3_config=S3Config(path_to_idx_cache=config.s3_cache_path),
-            )
-        return IndexedDataset(dataset_path, multimodal=False, mmap=config.mmap_bin_files)
 
     def _build_single_document_indices(self):
-        """Build document index and shuffle index for single-document sampling
+        """
+        Build document index and shuffle index for single-document sampling. Only one document is used per sample.
+
 
         Returns:
             Tuple[numpy.ndarray, numpy.ndarray]: The document index and shuffle index
@@ -115,7 +82,7 @@ class SFTIndexedDataset(GPTDataset):
         path_to_cache = self.config.path_to_cache
         if path_to_cache is None and not self.config.mock:
             path_to_cache = os.path.join(
-                self.indexed_dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
+                self.dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
             )
 
         if path_to_cache:
@@ -123,16 +90,19 @@ class SFTIndexedDataset(GPTDataset):
             get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
             path_to_description = get_path_to("description.txt")
             path_to_document_index = get_path_to("document_index.npy")
-            path_to_shuffle_index = get_path_to("shuffle_index.npy")
             cache_hit = all(
                 map(
                     os.path.isfile,
-                    [path_to_description, path_to_document_index, path_to_shuffle_index],
+                    [
+                        path_to_description,
+                        path_to_document_index,
+                    ],
                 )
             )
         else:
             cache_hit = False
 
+        # if index files not cached, create indices and save to cache
         if not path_to_cache or (
                 not cache_hit
                 and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0)
@@ -148,35 +118,31 @@ class SFTIndexedDataset(GPTDataset):
             numpy_random_state = np.random.RandomState(self.config.random_seed)
 
             # Each document maps to exactly one sample
-            if self.num_samples_requested is None:
+            if self.num_samples is None:
                 # Use all documents once
-                num_samples = len(self.indexed_indices)
+                num_samples = len(self.indices)
                 num_epochs = 1
             else:
                 # Calculate how many epochs needed
-                num_samples = self.num_samples_requested
-                docs_per_epoch = len(self.indexed_indices)
+                num_samples = self.num_samples
+                docs_per_epoch = len(self.indices)
                 num_epochs = (num_samples + docs_per_epoch - 1) // docs_per_epoch
 
             # Build document index by repeating indices for each epoch
-            document_index = np.tile(self.indexed_indices, num_epochs).astype(np.int32)
+            document_index = np.tile(self.indices, num_epochs).astype(np.int32)
 
             # Shuffle all documents
             numpy_random_state.shuffle(document_index)
 
-            # Truncate to exact number of samples if specified
-            if self.num_samples_requested is not None:
-                document_index = document_index[:self.num_samples_requested]
-
-            # Build shuffle index (identity mapping since we already shuffled documents)
-            shuffle_index = np.arange(len(document_index), dtype=np.int32)
+            # Truncate to exact number of samples if specified (ex. If last epoch is partial)
+            if self.num_samples is not None:
+                document_index = document_index[:self.num_samples]
 
             if path_to_cache:
                 os.makedirs(path_to_cache, exist_ok=True)
                 with open(path_to_description, "wt") as writer:
                     writer.write(self.unique_description)
                 np.save(path_to_document_index, document_index, allow_pickle=True)
-                np.save(path_to_shuffle_index, shuffle_index, allow_pickle=True)
             else:
                 log_single_rank(
                     logger,
@@ -189,7 +155,7 @@ class SFTIndexedDataset(GPTDataset):
             log_single_rank(logger, logging.INFO, f"> total number of samples: {len(document_index)}")
             log_single_rank(logger, logging.INFO, f"> total number of epochs: {num_epochs}")
 
-            return document_index, shuffle_index
+            return document_index
 
         # Load from cache
         log_single_rank(
@@ -201,20 +167,14 @@ class SFTIndexedDataset(GPTDataset):
         t_end = time.time()
         log_single_rank(logger, logging.DEBUG, f"\t> document index load time: {t_end - t_beg:4f} seconds")
 
-        t_beg = time.time()
-        shuffle_index = np.load(path_to_shuffle_index, allow_pickle=True, mmap_mode='r')
-        t_end = time.time()
-        log_single_rank(logger, logging.DEBUG, f"\t> shuffle index load time: {t_end - t_beg:4f} seconds")
-
-        log_single_rank(logger, logging.INFO, f"> total number of samples: {len(document_index)}")
-
-        return document_index, shuffle_index
+        return document_index
 
     def __len__(self) -> int:
         return self.document_index.shape[0] - 1
 
     def __getitem__(self, idx: Optional[int]) -> Dict[str, torch.Tensor]:
-        """Get a single sample from the dataset
+        """Get a single sample from the dataset. 
+        Each sample is a single document padded to sequence length. OR truncated if too long.
 
         Args:
             idx (Optional[int]): The index into the dataset
@@ -228,22 +188,16 @@ class SFTIndexedDataset(GPTDataset):
                 [self._pad_token_id] * (self.config.sequence_length + self.config.add_extra_token_to_sequence),
                 dtype=np.int64)
         else:
-            # Get the shuffled document index
-            doc_idx = self.shuffle_index[idx]
-            actual_doc_id = self.document_index[doc_idx]
-
-            # Get the entire document
-            document = self.indexed_dataset.get(actual_doc_id)
+            # Get document. index is already shuffled
+            actual_doc_id = self.document_index[idx]
+            document = self.dataset.get(actual_doc_id)
 
             # Truncate or pad to sequence_length
             target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
-
             if len(document) >= target_length:
-                # Truncate
                 logger.warning(f"Document {actual_doc_id} is longer than model sequence length {target_length} and gets trunc")
                 text = document[:target_length]
             else:
-                # Pad
                 padding_length = target_length - len(document)
                 text = np.concatenate([document, np.full(padding_length, self._pad_token_id, dtype=np.int64)])
 
@@ -281,7 +235,7 @@ class SFTIndexedDataset(GPTDataset):
             loss_mask = self.cached_loss_mask
             position_ids = self.cached_position_ids
 
-        # Mask loss for padded tokens
+        # Mask loss for padded tokens (this also masks batch padding if idx is None)
         loss_mask[labels == self._pad_token_id] = 0.0
 
         # Map pad tokens to valid embedding indices
@@ -301,10 +255,6 @@ class SFTIndexedDataset(GPTDataset):
                 goldfish_context_width=self._goldfish_h,
             )
             loss_mask[goldfish_labels == self._goldfish_token_id] = 0.0
-
-        # Mask loss for batch padding sequences
-        if idx is None:
-            loss_mask = torch.zeros_like(loss_mask)
 
         # Return sample dict
         if self.config.create_attention_mask:
@@ -382,10 +332,6 @@ class SFTIndexedDataset(GPTDataset):
         if eod_mask_loss:
             loss_mask[tokens == tokenizer_eod_id] = 0.0
 
-        # loss mask on batch padding
-        if idx is None:
-            loss_mask = torch.zeros_like(tokens)
-
         if create_attention_mask:
             attention_mask = torch.tril(
                 torch.ones((self.config.sequence_length, self.config.sequence_length), device=tokens.device)
@@ -399,4 +345,4 @@ class SFTIndexedDataset(GPTDataset):
         else:
             attention_mask = None
 
-        return loss_mask, position_ids, attention_mask
+        return attention_mask, loss_mask, position_ids

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -241,7 +241,7 @@ class SFTIndexedDataset(GPTDataset):
                 or not self.masks_and_position_ids_are_cached
         ):
             attention_mask, loss_mask, position_ids = self._get_ltor_masks_and_position_ids(
-                tokens,
+                labels,
                 self.config.reset_position_ids,
                 self.config.reset_attention_mask,
                 self.config.create_attention_mask,
@@ -329,10 +329,10 @@ class SFTIndexedDataset(GPTDataset):
                 "position_ids": position_ids,
             }
 
-    def _get_ltor_masks_and_position_ids(self, tokens,
-                reset_position_ids,
-                reset_attention_mask,
-                create_attention_mask):
+    def _get_ltor_masks_and_position_ids(self, data,
+                                         reset_position_ids,
+                                         reset_attention_mask,
+                                         create_attention_mask):
         """
         Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
             1. Find user messages in conversation list
@@ -344,38 +344,38 @@ class SFTIndexedDataset(GPTDataset):
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
         # 1) Mask user sequences for loss
-        begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=tokens.dtype, device=tokens.device)
-        end_seq = torch.tensor(self._sft_turn_end_sequence, dtype=tokens.dtype, device=tokens.device)
+        begin_seq = torch.tensor(self._sft_user_begin_sequence, dtype=data.dtype, device=data.device)
+        end_seq = torch.tensor(self._sft_turn_end_sequence, dtype=data.dtype, device=data.device)
 
-        user_seq_mask = get_matching_mask_by_start_end(tokens, begin_seq, end_seq)
+        user_seq_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
         loss_mask[user_seq_mask] = 0.0
 
         # 2) Mask other token(sequences) as configured in init (might contain BOS, EOS, assistant begin)
         for t in self.tokens_to_mask:
-            t_tensor = torch.tensor(t, dtype=tokens.dtype, device=tokens.device)
+            t_tensor = torch.tensor(t, dtype=data.dtype, device=data.device)
             if len(t_tensor) == 1:
-                mask = (tokens == t_tensor[0])
+                mask = (data == t_tensor[0])
             elif len(t_tensor) > 1:
-                mask = get_matching_mask(tokens, t_tensor, only_begin=False)
+                mask = get_matching_mask(data, t_tensor, only_begin=False)
             else:
                 raise ValueError(f"Invalid token to mask: {t}")
             loss_mask[mask] = 0.0
 
         # 3) Unmask Image tokens if configured
         if self.config.sft_do_not_mask_image_tokens:
-            img_begin_tensor = torch.tensor(self._img_begin_sequence, dtype=tokens.dtype, device=tokens.device)
-            img_end_tensor = torch.tensor(self._img_end_sequence, dtype=tokens.dtype, device=tokens.device)
-            img_seq_mask = get_matching_mask_by_start_end(tokens, img_begin_tensor, img_end_tensor)
+            img_begin_tensor = torch.tensor(self._img_begin_sequence, dtype=data.dtype, device=data.device)
+            img_end_tensor = torch.tensor(self._img_end_sequence, dtype=data.dtype, device=data.device)
+            img_seq_mask = get_matching_mask_by_start_end(data, img_begin_tensor, img_end_tensor)
             loss_mask[img_seq_mask] = 1.0
 
         # 4) Create attention mask, excluding padding tokens from attention
         if create_attention_mask:
             # Here me mask attention from all padding tokens to all other tokens and vice versa
             attention_mask = torch.tril(
-                torch.ones((self.config.sequence_length, self.config.sequence_length), device=tokens.device)
+                torch.ones((self.config.sequence_length, self.config.sequence_length), device=data.device)
             )
             # Mask padding tokens in attention mask:
-            no_padding_mask = (tokens != self._pad_token_id).float() # 1=real, 0=padding
+            no_padding_mask = (data != self._pad_token_id).float() # 1=real, 0=padding
             
             # Mask both rows (queries from padding) and columns (keys to padding)
             # Row masking: padding tokens shouldn't attend to anything
@@ -417,20 +417,20 @@ def get_matching_mask(sequence, query: torch.Tensor, only_begin:bool=True):
     return matches
 
 
-def get_matching_mask_by_start_end(tokens, begin_seq: torch.Tensor, end_seq: torch.Tensor):
+def get_matching_mask_by_start_end(sequence, begin_seq: torch.Tensor, end_seq: torch.Tensor):
     """
     Given a sequence and a start and end query, return a mask indicating which positions in the sequence
     are between the start and end queries (inclusive).
     """
-    mask = torch.zeros(len(tokens), dtype=torch.bool, device=tokens.device)
+    mask = torch.zeros(len(sequence), dtype=torch.bool, device=sequence.device)
     begin_len = len(begin_seq)
     end_len = len(end_seq)
 
-    if 0 < begin_len <= len(tokens):
-        matches_begin = get_matching_mask(tokens, begin_seq, only_begin=True)
+    if 0 < begin_len <= len(sequence):
+        matches_begin = get_matching_mask(sequence, begin_seq, only_begin=True)
 
         if end_len > 0:
-            matches_end = get_matching_mask(tokens, end_seq, only_begin=True)
+            matches_end = get_matching_mask(sequence, end_seq, only_begin=True)
 
             begin_indices = torch.where(matches_begin)[0]
             end_indices = torch.where(matches_end)[0]
@@ -451,7 +451,7 @@ def get_matching_mask_by_start_end(tokens, begin_seq: torch.Tensor, end_seq: tor
 
                 # Create ranges and mask in one go, Shape: (num_begins, max_range_len)
                 max_len = (end_positions - begin_indices).max().item()
-                ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
+                ranges = torch.arange(max_len, device=sequence.device).unsqueeze(0)
                 lengths = (end_positions - begin_indices).unsqueeze(1)
 
                 # Get all indices to mask
@@ -463,7 +463,7 @@ def get_matching_mask_by_start_end(tokens, begin_seq: torch.Tensor, end_seq: tor
             elif len(begin_indices) > 0:
                 # No end sequences, mask from each begin to the end
                 max_len = len(mask) - begin_indices.min().item()
-                ranges = torch.arange(max_len, device=tokens.device).unsqueeze(0)
+                ranges = torch.arange(max_len, device=sequence.device).unsqueeze(0)
                 mask_positions = begin_indices.unsqueeze(1) + ranges
                 valid = mask_positions < len(mask)
                 mask[mask_positions[valid]] = True

--- a/megatron/core/datasets/sft_dataset.py
+++ b/megatron/core/datasets/sft_dataset.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional
 import time
 import os
 import logging
+
 import numpy as np
 import json
 from pathlib import Path
@@ -22,6 +23,7 @@ class SFTIndexedDataset(GPTDataset):
     The dataset used during SFT. Uses Low Level Indexed Dataset to load from pre-tokenized SFT data.
     Each original document/dataset-sample is loaded one by one and padded to fill the sequence length.
     """
+    APPROX_NUM_PACKED_DOCS_PER_SEQ = 1.4
 
     def __init__(
         self,
@@ -177,14 +179,13 @@ class SFTIndexedDataset(GPTDataset):
             t_beg = time.time()
 
             sequence_length = self.config.sequence_length
-            num_tokens_per_epoch = int(np.sum(self.dataset.sequence_lengths[self.indices]))
+            num_epochs = self._get_num_epochs_packed()
 
             # SFT packing: use only ONE epoch (no document replication)
             numpy_random_state = np.random.RandomState(self.config.random_seed)
 
-            # Build document index: shuffled documents for ONE epoch only
-            document_index = self.indices.copy().astype(np.int32)
-            numpy_random_state.shuffle(document_index)
+            # Copy of base document indices (num_epochs times). Shuffled within each copy.
+            document_index = _build_document_index_packed(num_epochs, self.indices.copy().astype(np.int32), numpy_random_state)
 
             # Build the sample index using whole-document packing
             assert document_index.dtype == np.int32
@@ -213,17 +214,16 @@ class SFTIndexedDataset(GPTDataset):
                 error_msg = (
                     f"ERROR: Requested {self.num_samples} training samples but only "
                     f"{num_samples_available} packed samples available from dataset. "
-                    f"This would lead to crashed training in the end." 
-                    "To mitigate this multi-epoch support would have to be supported!"
                 )
                 log_single_rank(logger, logging.ERROR, error_msg)
                 raise ValueError(error_msg)
 
-            # Build the shuffle index (random permutation for sample order during training)
+            # Build the shuffle index (sample level)
             shuffle_index = _build_shuffle_index(
                 sample_index.shape[0] - 1, sample_index.shape[0] - 1, numpy_random_state
             )
 
+            # Store to cache
             if path_to_cache:
                 os.makedirs(path_to_cache, exist_ok=True)
                 with open(path_to_description, "wt") as writer:
@@ -271,7 +271,7 @@ class SFTIndexedDataset(GPTDataset):
         # Log packing statistics
         self._log_packing_statistics(document_index, sample_index, from_cache=True)
 
-        # Validate again when loading from cache
+        # Validate enough samples are available when loading from cache
         if self.num_samples is not None and self.num_samples > num_samples_available:
             error_msg = (
                 f"ERROR: Requested {self.num_samples} training samples but only "
@@ -283,6 +283,16 @@ class SFTIndexedDataset(GPTDataset):
             raise ValueError(error_msg)
 
         return document_index, sample_index, shuffle_index
+
+    def _get_num_epochs_packed(self) -> int:
+        """
+        Calculate approximative upperbound of number of epochs based on requested samples and number of tokens per epoch.
+        Assume a constant sample packing efficiency: ex. On avg 1.5 docs per sequence.
+        """
+        n_docs = self.numel_low_level_dataset(self.dataset)
+        approx_sample_per_epoch = n_docs / self.APPROX_NUM_PACKED_DOCS_PER_SEQ
+        num_epochs = int(np.ceil(self.num_samples / approx_sample_per_epoch))
+        return num_epochs
 
     def _build_single_document_indices(self) -> np.ndarray:
         """
@@ -569,10 +579,10 @@ class SFTIndexedDataset(GPTDataset):
     def _get_ltor_masks_and_position_ids(self, data):
         """
         Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
-            1. Can mask full user prompts including or not including the images in the user prompt
+            1. Can mask full user prompts or with prompt-loss-weight (plw)
             2. Can mask arbitrary token sequences (e.g. assistant begin, assistant end, BOS, EOS)
-        Both options can be Configured in the init.
-        Finally, creates an attention mask if configured. The attention mask will exclude padding tokens from attention.
+            3. Creates attention mask if configured. The attention mask will exclude padding tokens from attention.
+            4. Can equalize sample loss for packed and non-packed sequences
 
         For packed samples (when sft_pack_samples=True):
             - Position IDs are reset at each EOD token (document boundary)
@@ -584,9 +594,12 @@ class SFTIndexedDataset(GPTDataset):
         position_ids = torch.arange(self.config.sequence_length, dtype=torch.long)
         loss_mask = torch.ones(self.config.sequence_length, dtype=torch.float)
 
+        # only compute eod indices if necessary
+        if self._using_packed_samples or self.config.sft_equalize_sample_loss:
+            eod_indices = torch.where(data == self._eod_token_id)[0]
+
         # 0) For packed samples: reset position IDs at document boundaries (EOD tokens)
         if self._using_packed_samples:
-            eod_indices = torch.where(data == self._eod_token_id)[0]
             if len(eod_indices) > 0:
                 # Reset position IDs after each EOD token
                 for eod_idx in eod_indices:
@@ -616,27 +629,15 @@ class SFTIndexedDataset(GPTDataset):
             else:
                 raise ValueError(f"Invalid token to mask: {t}")
             loss_mask[mask] = 0.0
-            # Also mask special tokens from assistant_mask
             assistant_mask[mask] = 0.0
 
-        # 3) Unmask Image tokens if configured
-        if self.config.sft_do_not_mask_image_tokens:
-            # Use pre-computed tensors, just move to correct device/dtype
-            img_begin_tensor = self._img_begin_sequence.to(dtype=data.dtype, device=data.device)
-            img_end_tensor = self._img_end_sequence.to(dtype=data.dtype, device=data.device)
-            img_seq_mask = get_matching_mask_by_start_end(data, img_begin_tensor, img_end_tensor)
-            loss_mask[img_seq_mask] = 1.0
-
-        # 4) Create attention mask, excluding padding tokens from attention
+        # 3) Create attention mask: mask attention from/to padding tokens
         if self.config.create_attention_mask:
-            # Here me mask attention from all padding tokens to all other tokens and vice versa
             attention_mask = torch.tril(
                 torch.ones((self.config.sequence_length, self.config.sequence_length), device=data.device)
             )
-            # Mask padding tokens in attention mask:
             no_padding_mask = (data != self._pad_token_id).float() # 1=real, 0=padding
 
-            # Mask both rows (queries from padding) and columns (keys to padding)
             # Row masking: padding tokens shouldn't attend to anything
             attention_mask = attention_mask * no_padding_mask.unsqueeze(1)
             # Column masking: nothing should attend to padding tokens
@@ -644,9 +645,7 @@ class SFTIndexedDataset(GPTDataset):
 
             # For packed samples: block cross-document attention at EOD boundaries
             if self._using_packed_samples:
-                eod_indices = torch.where(data == self._eod_token_id)[0]
                 if len(eod_indices) > 0:
-                    # Block attention from tokens after EOD to tokens before and including EOD
                     for eod_idx in eod_indices:
                         if eod_idx + 1 < self.config.sequence_length:
                             # Zero out attention from all tokens after EOD to all tokens up to and including EOD
@@ -657,6 +656,33 @@ class SFTIndexedDataset(GPTDataset):
             attention_mask = attention_mask < 0.5
         else:
             attention_mask = None
+
+        # 4) Equalize sample loss
+        if self.config.sft_equalize_sample_loss:
+            if len(eod_indices) > 0:
+                # Process each sample segment (between EOD tokens)
+                start_idx = 0
+                for eod_idx in eod_indices:
+                    segment_mask = loss_mask[start_idx:eod_idx+1]
+                    segment_loss_sum = segment_mask.sum()
+
+                    # Normalize so total sample contribution = 1.0
+                    if segment_loss_sum > 0:
+                        loss_mask[start_idx:eod_idx+1] = segment_mask / segment_loss_sum
+
+                    start_idx = eod_idx + 1
+
+                # Handle the last segment (from last EOD to end of sequence, can be truncated or padding)
+                if start_idx < len(loss_mask):
+                    segment_mask = loss_mask[start_idx:]
+                    segment_loss_sum = segment_mask.sum()
+                    if segment_loss_sum > 0:
+                        loss_mask[start_idx:] = segment_mask / segment_loss_sum
+            else:
+                # No EOD tokens found - treat entire sequence as one sample
+                total_sum = loss_mask.sum()
+                if total_sum > 0:
+                    loss_mask = loss_mask / total_sum
 
         return attention_mask, loss_mask, position_ids, assistant_mask
 
@@ -737,6 +763,25 @@ def get_matching_mask_by_start_end(sequence, begin_seq: torch.Tensor, end_seq: t
                 valid = mask_positions < len(mask)
                 mask[mask_positions[valid]] = True
     return mask
+
+
+def _build_document_index_packed(num_epochs: int,
+                                 documents: np.ndarray,
+                                 numpy_random_state: np.random.RandomState
+) -> np.ndarray:
+    """
+    Build document-index with size: num_epochs * len(documents)
+    Shuffle within each epoch of documents independently.
+    """
+    document_index = np.mgrid[0:num_epochs, 0: len(documents)][1]
+    document_index[:] = documents
+    document_index = document_index.astype(np.int32)
+
+    for epoch in range(num_epochs):
+        numpy_random_state.shuffle(document_index[epoch])
+
+    document_index = document_index.reshape(-1)
+    return document_index
 
 
 class DebugDataWriter:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2068,6 +2068,11 @@ def _add_data_args(parser):
                        'json file with `train`, `valid, `test` keys')
     group.add_argument('--data-cache-path', default=None,
                        help='Path to a directory to hold cached index files.')
+    group.add_argument('--data-skip-margin-samples', action='store_true',
+                       help='Skip the 0.5%% margin when calculating dataset sizes. '
+                       'When enabled, requests exactly the number of samples needed '
+                       'without buffer. Use this for datasets with fixed size (e.g., '
+                       'SFT packed datasets) where samples cannot be regenerated.')
     group.add_argument('--no-mmap-bin-files', action='store_false',
                        help='Disable mmap-ing of .bin files.',
                        dest='mmap_bin_files')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1595,6 +1595,14 @@ def _add_training_args(parser):
     group.add_argument('--sft_do_not_mask_image_tokens', action='store_true', help="Do not mask image tokens, even if part of user input")
     group.add_argument('--sft_debug', action='store_true', help='Store and print debug data and information from the SFT dataset')
     group.add_argument('--sft_plw', type=float, default=0, help="Prompt loss weight to apply to user input tokens in general. Default is 0 (no loss calculated on img tokens)")
+    group.add_argument('--sft-pack-samples', action='store_true',
+                       help='Enable document packing for SFT. Packs whole documents into sequences '
+                       'until next document does not fit. Automatically enables position ID reset '
+                       'and cross-document attention masking.')
+    group.add_argument('--dummy-data-packing', action='store_true',
+                       help='Build sample index for packed SFT data, print the number of resulting '
+                       'samples, and exit. Use this to determine how many training steps are available '
+                       'with the current dataset and packing configuration.')
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1604,10 +1604,6 @@ def _add_training_args(parser):
                        'When enabled, expect tokens concatenated with loss_mask (2x length), '
                        'and user prompt masking and special token masking are skipped. '
                        'The loaded loss_mask is used directly with only padding masking and optional equalization applied.')
-    group.add_argument('--sft-disable-assistant-mask', action='store_true',
-                       help='Disable assistant mask computation and tracking. '
-                       'When enabled, assistant_mask will be set to None.'
-                       'This disables separate tracking of assistant token loss.')
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1599,10 +1599,6 @@ def _add_training_args(parser):
                        help='Enable document packing for SFT. Packs whole documents into sequences '
                        'until next document does not fit. Automatically enables position ID reset '
                        'and cross-document attention masking.')
-    group.add_argument('--dummy-data-packing', action='store_true',
-                       help='Build sample index for packed SFT data, print the number of resulting '
-                       'samples, and exit. Use this to determine how many training steps are available '
-                       'with the current dataset and packing configuration.')
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1592,7 +1592,6 @@ def _add_training_args(parser):
                                                                                   " Assistant Start tokens. User tokens"
                                                                                   " are masked overall including end-of-turn"
                                                                                   " and user-start sequence in any case")
-    group.add_argument('--sft_debug', action='store_true', help='Store and print debug data and information from the SFT dataset')
     group.add_argument('--sft_plw', type=float, default=0, help="Prompt loss weight to apply to user input tokens in general. Default is 0 (no loss calculated on img tokens)")
     group.add_argument('--sft-pack-samples', action='store_true',
                        help='Enable document packing for SFT. Packs whole documents into sequences '
@@ -1600,6 +1599,15 @@ def _add_training_args(parser):
                        'and cross-document attention masking.')
     group.add_argument('--sft-equalize-sample-loss', action='store_true',
                        help='When enabled, equalizes loss across samples. In packed or non-packed setting')
+    group.add_argument('--sft-load-loss-mask', action='store_true',
+                       help='Load pre-computed loss masks from disk alongside tokens. '
+                       'When enabled, expect tokens concatenated with loss_mask (2x length), '
+                       'and user prompt masking and special token masking are skipped. '
+                       'The loaded loss_mask is used directly with only padding masking and optional equalization applied.')
+    group.add_argument('--sft-disable-assistant-mask', action='store_true',
+                       help='Disable assistant mask computation and tracking. '
+                       'When enabled, assistant_mask will be set to None.'
+                       'This disables separate tracking of assistant token loss.')
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -844,7 +844,7 @@ def validate_args(args, defaults={}):
     if args.goldfish_loss:
         assert args.goldfish_k > 0, f"goldfish_k (frequency) must be a positive integer. ({args.goldfish_k})"
         assert args.goldfish_h > 0, f"goldfish_h (context width) must be a positive integer. ({args.goldfish_h})"
-    
+
     # Print arguments.
     _print_args("arguments", args)
 
@@ -1592,13 +1592,14 @@ def _add_training_args(parser):
                                                                                   " Assistant Start tokens. User tokens"
                                                                                   " are masked overall including end-of-turn"
                                                                                   " and user-start sequence in any case")
-    group.add_argument('--sft_do_not_mask_image_tokens', action='store_true', help="Do not mask image tokens, even if part of user input")
     group.add_argument('--sft_debug', action='store_true', help='Store and print debug data and information from the SFT dataset')
     group.add_argument('--sft_plw', type=float, default=0, help="Prompt loss weight to apply to user input tokens in general. Default is 0 (no loss calculated on img tokens)")
     group.add_argument('--sft-pack-samples', action='store_true',
                        help='Enable document packing for SFT. Packs whole documents into sequences '
                        'until next document does not fit. Automatically enables position ID reset '
                        'and cross-document attention masking.')
+    group.add_argument('--sft-equalize-sample-loss', action='store_true',
+                       help='When enabled, equalizes loss across samples. In packed or non-packed setting')
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1586,6 +1586,8 @@ def _add_training_args(parser):
     group.add_argument('--disable-tp-comm-split-rs', action='store_false',
                        help='Disables the Reduce-Scatter overlap with fprop GEMM.',
                        dest='tp_comm_split_rs')
+    group.add_argument('--sft', action='store_true', help='Perform SFT training. Will use the SFTDataset to load pre-tokenized'
+                                                          ' data sample by sample, with padding and prompt-masking.')
 
     return parser
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1594,7 +1594,7 @@ def _add_training_args(parser):
                                                                                   " and user-start sequence in any case")
     group.add_argument('--sft_do_not_mask_image_tokens', action='store_true', help="Do not mask image tokens, even if part of user input")
     group.add_argument('--sft_debug', action='store_true', help='Store and print debug data and information from the SFT dataset')
-
+    group.add_argument('--sft_plw', type=float, default=0, help="Prompt loss weight to apply to user input tokens in general. Default is 0 (no loss calculated on img tokens)")
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1593,6 +1593,7 @@ def _add_training_args(parser):
                                                                                   " are masked overall including end-of-turn"
                                                                                   " and user-start sequence in any case")
     group.add_argument('--sft_do_not_mask_image_tokens', action='store_true', help="Do not mask image tokens, even if part of user input")
+    group.add_argument('--sft_debug', action='store_true', help='Store and print debug data and information from the SFT dataset')
 
     return parser
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1588,6 +1588,11 @@ def _add_training_args(parser):
                        dest='tp_comm_split_rs')
     group.add_argument('--sft', action='store_true', help='Perform SFT training. Will use the SFTDataset to load pre-tokenized'
                                                           ' data sample by sample, with padding and prompt-masking.')
+    group.add_argument('--sft_mask_special_tokens', type=bool, default=True, help="Mask special tokens like BOS, EOS and"
+                                                                                  " Assistant Start tokens. User tokens"
+                                                                                  " are masked overall including end-of-turn"
+                                                                                  " and user-start sequence in any case")
+    group.add_argument('--sft_do_not_mask_image_tokens', action='store_true', help="Do not mask image tokens, even if part of user input")
 
     return parser
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1706,6 +1706,9 @@ def _add_checkpointing_args(parser):
                        help='Output directory to save checkpoints to.')
     group.add_argument('--save-interval', '--persistent-save-interval', type=int, default=None,
                        help='Number of iterations between persistent checkpoint saves.')
+    group.add_argument('--final-checkpoint', action='store_true', default=False,
+                       help='Save a checkpoint after the final training iteration, even if it does not '
+                       'align with the save-interval. Useful to ensure a final checkpoint is always stored.')
     group.add_argument('--no-save-optim', action='store_true', default=None,
                        help='Do not save current optimizer.')
     group.add_argument('--no-save-rng', action='store_true', default=None,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1306,7 +1306,7 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
                 model[i].load_state_dict(state_dict['model%d' % i], strict=strict)
 
     # Expand the embedding size to make the model multimodal
-    if model[0].vocab_size != args.total_multimodal_vocab_size:
+    if hasattr(args, 'total_multimodal_vocab_size') and model[0].vocab_size != args.total_multimodal_vocab_size:
         print_rank_0(f"Expanding model vocab size from {model[0].vocab_size} to {args.total_multimodal_vocab_size}")
         model[0].vocab_size = args.total_multimodal_vocab_size
         extend_vocab_and_load_weights(model, state_dict, args.base_vocab_size, mpu)
@@ -1320,6 +1320,12 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
         # After this you can start a new training with the extended model, just remove the --extend-model-vocab flag
         # And specify the correct load path
         # TODO (nirmiger): would it be possible to continue training directly?
+
+        # FIX: Update padded_vocab_size to match the extended model's actual vocab size. Otherwise only the training checkpoints will store correct size (as for training the size is loaded from tokenizer)
+        if hasattr(args, 'total_multimodal_vocab_size'):
+            print_rank_0(f"Updating padded_vocab_size from {args.padded_vocab_size} to {args.total_multimodal_vocab_size} for extended model checkpoint")
+            args.padded_vocab_size = args.total_multimodal_vocab_size
+
         save_checkpoint(1, model , None, None, 0)
         sys.exit()
 

--- a/megatron/training/tokenizer/tokenizer.py
+++ b/megatron/training/tokenizer/tokenizer.py
@@ -180,10 +180,35 @@ class _HuggingFaceTokenizer(MegatronTokenizer):
     @property
     def eod(self):
         return self._tokenizer.eos_token_id
-    
+
     @property
     def bos(self):
         return self._tokenizer.bos_token_id
+
+    @property
+    def sft_user_begin_sequence(self):
+        """Get pre-tokenized user begin sequence from tokenizer config."""
+        return self._tokenizer.init_kwargs.get('sft_user_begin_sequence', None)
+
+    @property
+    def sft_assistant_begin_sequence(self):
+        """Get pre-tokenized assistant begin sequence from tokenizer config."""
+        return self._tokenizer.init_kwargs.get('sft_assistant_begin_sequence', None)
+
+    @property
+    def sft_eot_token(self):
+        """Get pre-tokenized end-of-turn token from tokenizer config."""
+        return self._tokenizer.init_kwargs.get('sft_eot_token', None)
+
+    @property
+    def img_begin_token(self):
+        """Get pre-tokenized image begin token from tokenizer config."""
+        return self._tokenizer.init_kwargs.get('img_begin_token', None)
+
+    @property
+    def img_end_token(self):
+        """Get pre-tokenized image end token from tokenizer config."""
+        return self._tokenizer.init_kwargs.get('img_end_token', None)
 
 
 class _BertWordPieceTokenizer(MegatronTokenizer):

--- a/megatron/training/tokenizer/tokenizer.py
+++ b/megatron/training/tokenizer/tokenizer.py
@@ -201,6 +201,18 @@ class _HuggingFaceTokenizer(MegatronTokenizer):
         return self._tokenizer.init_kwargs.get('sft_eot_token', None)
 
     @property
+    def sft_assistant_end_sequence(self):
+        """If tokenizer defines separate assistant-end sequence return it, otherwise return eot token"""
+        separate_token = self._tokenizer.init_kwargs.get('sft_assistant_end_sequence', None)
+        return separate_token if separate_token is not None else self.sft_eot_token
+
+    @property
+    def sft_user_end_sequence(self):
+        """If tokenizer defines separate user-end sequence return it, otherwise return eot token"""
+        separate_token = self._tokenizer.init_kwargs.get('sft_user_end_sequence', None)
+        return separate_token if separate_token is not None else self.sft_eot_token
+
+    @property
     def img_begin_token(self):
         """Get pre-tokenized image begin token from tokenizer config."""
         return self._tokenizer.init_kwargs.get('img_begin_token', None)

--- a/megatron/training/tokenizer/tokenizer.py
+++ b/megatron/training/tokenizer/tokenizer.py
@@ -180,6 +180,10 @@ class _HuggingFaceTokenizer(MegatronTokenizer):
     @property
     def eod(self):
         return self._tokenizer.eos_token_id
+    
+    @property
+    def bos(self):
+        return self._tokenizer.bos_token_id
 
 
 class _BertWordPieceTokenizer(MegatronTokenizer):

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -884,7 +884,8 @@ def train_step(forward_step_func, data_iterator,
                     # and so the denominator is 1.
                     numerator += val
                     denominator += 1
-            loss_reduced[key] = numerator / denominator
+            # Avoid division by zero (e.g., when all tokens of a type are masked)
+            loss_reduced[key] = numerator / denominator if denominator > 0 else numerator
         return loss_reduced, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad
     return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad
 
@@ -1844,7 +1845,8 @@ def evaluate(forward_step_func,
 
     for key in total_loss_dict:
         numerator, denominator = total_loss_dict[key]
-        total_loss_dict[key] = numerator / denominator
+        # Avoid division by zero (e.g., when all tokens of a type are masked)
+        total_loss_dict[key] = numerator / denominator if denominator > 0 else numerator
 
     timers('evaluate').stop()
     timers.log(['evaluate'])

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1704,6 +1704,23 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
         sys.exit(exit_code)
 
     torch.distributed.barrier()
+
+    # Save final checkpoint if requested and we haven't just saved at this iteration
+    if iteration >= args.train_iters and args.final_checkpoint and args.save:
+        # Check if we need to save (avoid duplicate if already saved at this iteration)
+        should_save_final = True
+        if args.save_interval and iteration % args.save_interval == 0:
+            should_save_final = False
+        if args.non_persistent_save_interval and iteration % args.non_persistent_save_interval == 0:
+            should_save_final = False
+
+        if should_save_final:
+            print_rank_0(f'Saving final checkpoint at iteration {iteration}')
+            save_checkpoint_and_time(iteration, model, optimizer,
+                                     opt_param_scheduler,
+                                     num_floating_point_operations_so_far,
+                                     checkpointing_context, train_data_iterator=train_data_iterator)
+
     if iteration >= args.train_iters and is_rank0():
         print(f"Training finished after {iteration} iterations; Canceling pending scheduled jobs.")
         Path(args.exit_trigger).touch()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1716,6 +1716,10 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
 
         if should_save_final:
             print_rank_0(f'Saving final checkpoint at iteration {iteration}')
+            # Re-enable hooks before saving if they were disabled, so save_checkpoint_and_time
+            # can properly manage them (it expects hooks to be enabled if overlap_param_gather is True)
+            if pre_hook_enabled and args.use_distributed_optimizer and args.overlap_param_gather:
+                enable_forward_pre_hook(model)
             save_checkpoint_and_time(iteration, model, optimizer,
                                      opt_param_scheduler,
                                      num_floating_point_operations_so_far,

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -441,7 +441,8 @@ def get_batch_on_this_tp_rank(data_iterator):
            'labels': data["labels"].cuda(non_blocking = True),
            'loss_mask': data["loss_mask"].cuda(non_blocking = True),
            'attention_mask': None if "attention_mask" not in data else data["attention_mask"].cuda(non_blocking = True),
-           'position_ids': data["position_ids"].cuda(non_blocking = True)
+           'position_ids': data["position_ids"].cuda(non_blocking = True),
+           'assistant_mask': None if "assistant_mask" not in data else data["assistant_mask"].cuda(non_blocking = True),
        }
 
        if args.pipeline_model_parallel_size == 1:
@@ -450,6 +451,7 @@ def get_batch_on_this_tp_rank(data_iterator):
            _broadcast(batch['loss_mask'])
            _broadcast(batch['attention_mask'])
            _broadcast(batch['position_ids'])
+           _broadcast(batch['assistant_mask'])
 
        elif mpu.is_pipeline_first_stage():
            _broadcast(batch['tokens'])
@@ -460,12 +462,14 @@ def get_batch_on_this_tp_rank(data_iterator):
            _broadcast(batch['labels'])
            _broadcast(batch['loss_mask'])
            _broadcast(batch['attention_mask'])
+           _broadcast(batch['assistant_mask'])
 
     else:
 
        tokens=torch.empty((args.micro_batch_size,args.seq_length), dtype = torch.int64 , device = torch.cuda.current_device())
        labels=torch.empty((args.micro_batch_size,args.seq_length), dtype = torch.int64 , device = torch.cuda.current_device())
        loss_mask=torch.empty((args.micro_batch_size,args.seq_length), dtype = torch.float32 , device = torch.cuda.current_device())
+       assistant_mask=None
        if args.create_attention_mask_in_dataloader:
            attention_mask=torch.empty(
                 (args.micro_batch_size,1,args.seq_length,args.seq_length), dtype = torch.bool , device = torch.cuda.current_device()
@@ -480,6 +484,7 @@ def get_batch_on_this_tp_rank(data_iterator):
            _broadcast(loss_mask)
            _broadcast(attention_mask)
            _broadcast(position_ids)
+           _broadcast(assistant_mask)
 
        elif mpu.is_pipeline_first_stage():
            labels=None
@@ -496,13 +501,15 @@ def get_batch_on_this_tp_rank(data_iterator):
            _broadcast(labels)
            _broadcast(loss_mask)
            _broadcast(attention_mask)
+           _broadcast(assistant_mask)
 
        batch = {
            'tokens': tokens,
            'labels': labels,
            'loss_mask': loss_mask,
            'attention_mask': attention_mask,
-           'position_ids': position_ids
+           'position_ids': position_ids,
+           'assistant_mask': assistant_mask,
        }
 
     return batch

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -157,7 +157,7 @@ def get_batch(data_iterator):
 
     # TODO: this is pretty hacky, find a better way
     if (not mpu.is_pipeline_first_stage()) and (not mpu.is_pipeline_last_stage()):
-        return None, None, None, None, None
+        return None, None, None, None, None, None
 
     # get batches based on the TP rank you are on
     batch = get_batch_on_this_tp_rank(data_iterator)
@@ -172,12 +172,14 @@ def get_batch(data_iterator):
 SPIKY_LOSS_PERC = 0.2
 
 
-def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor, labels: torch.Tensor = None):
+def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor, labels: torch.Tensor = None, assistant_mask: torch.Tensor = None):
     """Loss function.
 
     Args:
         loss_mask (torch.Tensor): Used to mask out some portions of the loss
         output_tensor (torch.Tensor): The tensor with the losses
+        labels (torch.Tensor): The labels for image/text loss separation (optional)
+        assistant_mask (torch.Tensor): Mask identifying assistant tokens for SFT (optional)
 
     Returns:
         the loss scalar for this micro-batch
@@ -257,13 +259,13 @@ def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor, labels: torc
         stats_dict['image_token_loss'] = (reporting_image_loss[0], reporting_image_loss[1])
         stats_dict['text_token_loss'] = (reporting_text_loss[0], reporting_text_loss[1])
 
-        # Log separate assistant loss for sft training when plw < 1 is used
-        if args.sft and args.sft_plw < 1:
-            # log separate assistant loss for sft training when plw < 1 is used
-            assistant_loss_mask = loss_mask == 1 # assistant responses are always fully included in the loss
+        # Log separate assistant loss for SFT training
+        if args.sft and assistant_mask is not None:
+            # Use assistant_mask to identify assistant response tokens
+            assistant_mask_flat = assistant_mask.view(-1).float()
             assistant_loss = torch.cat([
-                torch.sum(losses_flat * assistant_loss_mask.float()).view(1),
-                assistant_loss_mask.float().sum().view(1)
+                torch.sum(losses_flat * assistant_mask_flat).view(1),
+                assistant_mask_flat.sum().view(1)
             ])
             if args.context_parallel_size > 1:
                 torch.distributed.all_reduce(assistant_loss, group=mpu.get_context_parallel_group())
@@ -292,7 +294,7 @@ def forward_step(data_iterator, model: GPTModel):
     timers('batch-generator', log_level=2).start()
     global stimer
     with stimer(bdata=True):
-        tokens, labels, loss_mask, attention_mask, position_ids = get_batch(
+        tokens, labels, loss_mask, attention_mask, position_ids, assistant_mask = get_batch(
             data_iterator)
     timers('batch-generator').stop()
 
@@ -300,7 +302,7 @@ def forward_step(data_iterator, model: GPTModel):
         output_tensor = model(tokens, position_ids, attention_mask,
                               labels=labels)
 
-    return output_tensor, partial(loss_func, loss_mask, labels=labels)
+    return output_tensor, partial(loss_func, loss_mask, labels=labels, assistant_mask=assistant_mask)
 
 
 def is_dataset_built_on_rank():

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -322,7 +322,8 @@ def core_gpt_dataset_config_from_args(args):
         goldfish_k=args.goldfish_k,
         goldfish_h=args.goldfish_h,
         sft_mask_special_tokens=args.sft_mask_special_tokens,
-        sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens
+        sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
+        sft_plw=args.sft_plw
     )
 
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -9,7 +9,6 @@ import inspect
 
 from typing import List, Optional, Tuple, Union
 
-from megatron.core.datasets.sft_dataset import SFTIndexedDataset
 from megatron.training import get_args
 from megatron.training import print_rank_0
 from megatron.training import get_timers
@@ -337,6 +336,7 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
     # TODO: Add support for SFT dataset
     if args.sft:
+        from megatron.core.datasets.sft_dataset import SFTIndexedDataset
         dataset_type = SFTIndexedDataset
     elif args.mock_data:
         dataset_type = MockGPTDataset

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -220,7 +220,7 @@ def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor, labels: torc
 
     local_num_tokens = loss[1].clone().detach().to(torch.int)
 
-    # --- Optional: Separate image/text token losses ---
+    # --- Optional: Separate image/text token losses and separate assistant loss in SFT---
     stats_dict = {'lm loss': (reporting_loss[0], reporting_loss[1])}
     if labels is not None:
         losses_flat = losses.detach().clone().view(-1)
@@ -256,6 +256,20 @@ def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor, labels: torc
 
         stats_dict['image_token_loss'] = (reporting_image_loss[0], reporting_image_loss[1])
         stats_dict['text_token_loss'] = (reporting_text_loss[0], reporting_text_loss[1])
+
+        # Log separate assistant loss for sft training when plw < 1 is used
+        if args.sft and args.sft_plw < 1:
+            # log separate assistant loss for sft training when plw < 1 is used
+            assistant_loss_mask = loss_mask == 1 # assistant responses are always fully included in the loss
+            assistant_loss = torch.cat([
+                torch.sum(losses_flat * assistant_loss_mask.float()).view(1),
+                assistant_loss_mask.float().sum().view(1)
+            ])
+            if args.context_parallel_size > 1:
+                torch.distributed.all_reduce(assistant_loss, group=mpu.get_context_parallel_group())
+            reporting_assistant_loss = assistant_loss.clone().detach()
+            torch.distributed.all_reduce(reporting_assistant_loss, group=mpu.get_data_parallel_group())
+            stats_dict['assistant_loss'] = (reporting_assistant_loss[0], reporting_assistant_loss[1])
 
     return (
         loss[0] * args.context_parallel_size,

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -373,27 +373,6 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
     print_rank_0("> finished creating GPT datasets ...")
 
-    # If dummy data packing mode, print stats and exit
-    if args.dummy_data_packing:
-        if args.sft and args.sft_pack_samples:
-            print_rank_0("=" * 80)
-            print_rank_0("DUMMY DATA PACKING MODE - Dataset statistics calculated")
-            print_rank_0("=" * 80)
-            print_rank_0(f"Training dataset: {len(train_ds)} packed samples available")
-            if valid_ds:
-                print_rank_0(f"Validation dataset: {len(valid_ds)} packed samples available")
-            if test_ds:
-                print_rank_0(f"Test dataset: {len(test_ds)} packed samples available")
-            print_rank_0("=" * 80)
-            print_rank_0("Use these values to configure --train-samples for your training run.")
-            print_rank_0("Exiting now.")
-            import sys
-            sys.exit(0)
-        else:
-            print_rank_0("ERROR: --dummy-data-packing requires both --sft and --sft-pack-samples")
-            import sys
-            sys.exit(1)
-
     return train_ds, valid_ds, test_ds
 
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -338,9 +338,9 @@ def core_gpt_dataset_config_from_args(args):
         goldfish_k=args.goldfish_k,
         goldfish_h=args.goldfish_h,
         sft_mask_special_tokens=args.sft_mask_special_tokens,
-        sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
         sft_plw=args.sft_plw,
         sft_pack_samples=args.sft_pack_samples,
+        sft_equalize_sample_loss=args.sft_equalize_sample_loss,
         skip_margin_samples=args.data_skip_margin_samples
     )
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -8,6 +8,8 @@ from contextlib import nullcontext
 import inspect
 
 from typing import List, Optional, Tuple, Union
+
+from megatron.core.datasets.sft_dataset import SFTIndexedDataset
 from megatron.training import get_args
 from megatron.training import print_rank_0
 from megatron.training import get_timers
@@ -333,7 +335,10 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
     config = core_gpt_dataset_config_from_args(args)
 
-    if args.mock_data:
+    # TODO: Add support for SFT dataset
+    if args.sft:
+        dataset_type = SFTIndexedDataset
+    elif args.mock_data:
         dataset_type = MockGPTDataset
     else:
         dataset_type = GPTDataset

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -339,7 +339,8 @@ def core_gpt_dataset_config_from_args(args):
         goldfish_h=args.goldfish_h,
         sft_mask_special_tokens=args.sft_mask_special_tokens,
         sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
-        sft_plw=args.sft_plw
+        sft_plw=args.sft_plw,
+        sft_pack_samples=args.sft_pack_samples
     )
 
 
@@ -371,6 +372,27 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
     ).build()
 
     print_rank_0("> finished creating GPT datasets ...")
+
+    # If dummy data packing mode, print stats and exit
+    if args.dummy_data_packing:
+        if args.sft and args.sft_pack_samples:
+            print_rank_0("=" * 80)
+            print_rank_0("DUMMY DATA PACKING MODE - Dataset statistics calculated")
+            print_rank_0("=" * 80)
+            print_rank_0(f"Training dataset: {len(train_ds)} packed samples available")
+            if valid_ds:
+                print_rank_0(f"Validation dataset: {len(valid_ds)} packed samples available")
+            if test_ds:
+                print_rank_0(f"Test dataset: {len(test_ds)} packed samples available")
+            print_rank_0("=" * 80)
+            print_rank_0("Use these values to configure --train-samples for your training run.")
+            print_rank_0("Exiting now.")
+            import sys
+            sys.exit(0)
+        else:
+            print_rank_0("ERROR: --dummy-data-packing requires both --sft and --sft-pack-samples")
+            import sys
+            sys.exit(1)
 
     return train_ds, valid_ds, test_ds
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -340,7 +340,8 @@ def core_gpt_dataset_config_from_args(args):
         sft_mask_special_tokens=args.sft_mask_special_tokens,
         sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens,
         sft_plw=args.sft_plw,
-        sft_pack_samples=args.sft_pack_samples
+        sft_pack_samples=args.sft_pack_samples,
+        skip_margin_samples=args.data_skip_margin_samples
     )
 
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -319,9 +319,16 @@ def core_gpt_dataset_config_from_args(args):
     blend_per_split: Optional[List[Optional[Tuple[List[str], Optional[List[float]]]]]]
     blend, blend_per_split = get_blend_and_blend_per_split(args)
 
+    # Double sequence length if loading loss masks from disk (dataset stores tokens + loss_mask concatenated)
+    sequence_length = args.seq_length
+    if args.sft and args.sft_load_loss_mask:
+        sequence_length = args.seq_length * 2
+        print_rank_0(f"> SFT: Loading loss masks from disk, doubling dataset sequence_length to {sequence_length} "
+                     f"(model will see {args.seq_length} tokens)")
+
     return GPTDatasetConfig(
         random_seed=args.seed,
-        sequence_length=args.seq_length,
+        sequence_length=sequence_length,
         blend=blend,
         blend_per_split=blend_per_split,
         split=args.split,
@@ -341,6 +348,8 @@ def core_gpt_dataset_config_from_args(args):
         sft_plw=args.sft_plw,
         sft_pack_samples=args.sft_pack_samples,
         sft_equalize_sample_loss=args.sft_equalize_sample_loss,
+        sft_load_loss_mask=args.sft_load_loss_mask,
+        sft_disable_assistant_mask=args.sft_disable_assistant_mask,
         skip_margin_samples=args.data_skip_margin_samples
     )
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -321,6 +321,8 @@ def core_gpt_dataset_config_from_args(args):
         goldfish_loss=args.goldfish_loss,
         goldfish_k=args.goldfish_k,
         goldfish_h=args.goldfish_h,
+        sft_mask_special_tokens=args.sft_mask_special_tokens,
+        sft_do_not_mask_image_tokens=args.sft_do_not_mask_image_tokens
     )
 
 
@@ -334,7 +336,6 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
     config = core_gpt_dataset_config_from_args(args)
 
-    # TODO: Add support for SFT dataset
     if args.sft:
         from megatron.core.datasets.sft_dataset import SFTIndexedDataset
         dataset_type = SFTIndexedDataset

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -349,7 +349,6 @@ def core_gpt_dataset_config_from_args(args):
         sft_pack_samples=args.sft_pack_samples,
         sft_equalize_sample_loss=args.sft_equalize_sample_loss,
         sft_load_loss_mask=args.sft_load_loss_mask,
-        sft_disable_assistant_mask=args.sft_disable_assistant_mask,
         skip_margin_samples=args.data_skip_margin_samples
     )
 

--- a/scripts/tools/create_weighted_data_config.py
+++ b/scripts/tools/create_weighted_data_config.py
@@ -1,0 +1,159 @@
+"""
+This script is a modiefied version of create_data_config.py. It allows the same input as this script but to additionally define an overall weight in range 0-1.
+
+It will find all bin/idx pairs in the given paths and assign overall wights according to sizes of data samples. All weights normalized to sum to given weight.
+
+ex:
+
+python $MEGATRON_LM_DIR/scripts/tools/create_weighted_data_config.py \
+      --paths /iopsstor/scratch/cscs/jpcoles/a06/phase-5 \
+      --weight 0.1)
+"""
+
+import argparse
+import os
+import struct
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+
+def get_dataset_size(prefix: str) -> int:
+    """Get the number of documents from a .idx file.
+
+    Args:
+        prefix: Dataset prefix (without .bin or .idx extension)
+
+    Returns:
+        Number of documents in the dataset
+    """
+    idx_file = f"{prefix}.idx"
+    if not os.path.isfile(idx_file):
+        raise FileNotFoundError(f"Index file not found: {idx_file}")
+
+    # Read the number of documents from .idx file (at byte offset 9, uint64 little-endian)
+    with open(idx_file, 'rb') as f:
+        f.seek(9)
+        num_docs = struct.unpack('<Q', f.read(8))[0]
+
+    return num_docs
+
+
+def create_data_prefix(list_of_paths: List[str]) -> List[str]:
+    """Find all .bin files in the given paths and return their prefixes.
+
+    Args:
+        list_of_paths: List of directory paths to search
+
+    Returns:
+        List of dataset prefixes (without .bin extension)
+    """
+    list_of_bin_files = []
+    # Select all .bin files
+    for path in list_of_paths:
+        path_to_files = [
+            os.path.join(dp, f)
+            for dp, _, fn in os.walk(os.path.expanduser(path))
+            for f in fn
+        ]
+        list_of_bin_files.extend(
+            [
+                raw_file
+                for raw_file in path_to_files
+                if Path(raw_file).suffix.lower().endswith(".bin")
+            ]
+        )
+
+    list_of_bin_files = [
+        bin_file[:-4] for bin_file in list_of_bin_files
+    ]  # Delete .bin extension to have file prefixes
+
+    return list_of_bin_files
+
+
+def calculate_proportional_weights(prefixes: List[str], total_weight: float) -> List[Tuple[float, str]]:
+    """Calculate proportional weights for datasets based on their sizes.
+
+    Args:
+        prefixes: List of dataset prefixes
+        total_weight: Total weight to distribute (e.g., 0.1)
+
+    Returns:
+        List of (weight, prefix) tuples
+    """
+    # Get sizes for all datasets
+    sizes = []
+    for prefix in prefixes:
+        size = get_dataset_size(prefix)
+        sizes.append(size)
+
+    total_size = sum(sizes)
+
+    if total_size == 0:
+        raise ValueError("Total dataset size is zero")
+
+    # Calculate proportional weights
+    weighted_prefixes = []
+    for size, prefix in zip(sizes, prefixes):
+        weight = total_weight * size / total_size
+        weighted_prefixes.append((weight, prefix))
+
+    return weighted_prefixes
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Create weighted data config with proportional weights based on dataset sizes"
+    )
+    parser.add_argument(
+        "-p",
+        "--paths",
+        type=str,
+        required=True,
+        help="Comma separated list of paths to generate the config from. e.g. -p /path/to/dataset/A,/path/to/dataset/B,/path/to/dataset/C",
+    )
+    parser.add_argument(
+        "-w",
+        "--weight",
+        type=float,
+        required=True,
+        help="Total weight to distribute among datasets (e.g., 0.1). Weights will be proportional to dataset sizes.",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["megatron", "verbose"],
+        default="megatron",
+        help="Output format: 'megatron' outputs space-separated weights and prefixes, 'verbose' shows breakdown",
+    )
+    args = parser.parse_args()
+
+    paths = [x.strip() for x in args.paths.split(",")]
+    prefixes = create_data_prefix(paths)
+
+    if not prefixes:
+        print("Error: No .bin files found in the specified paths", file=sys.stderr)
+        sys.exit(1)
+
+    weighted_prefixes = calculate_proportional_weights(prefixes, args.weight)
+
+    if args.format == "verbose":
+        print(f"Found {len(prefixes)} datasets with total weight {args.weight}")
+        print(f"{'Weight':<12} {'Percentage':<12} {'Size':<15} {'Prefix'}")
+        print("-" * 80)
+        for weight, prefix in weighted_prefixes:
+            size = get_dataset_size(prefix)
+            percentage = (weight / args.weight) * 100
+            print(f"{weight:<12.6f} {percentage:<12.2f} {size:<15,} {prefix}")
+        print("-" * 80)
+        total = sum(w for w, _ in weighted_prefixes)
+        print(f"Total weight: {total:.6f}")
+        print()
+        print("Megatron format:")
+
+    # Output in Megatron format: weight1 prefix1 weight2 prefix2 ...
+    output_parts = []
+    for weight, prefix in weighted_prefixes:
+        output_parts.extend([f"{weight:.6f}", prefix])
+
+    print(*output_parts, sep=" ")


### PR DESCRIPTION
Implementation of a SFT Dataset for SFT Training in Megatron. Developed originally for Visual Instruction Tuning. 

-  As the gpt_dataset it uses an IndexedDataset as Low-Level Dataset.
-  From there it loads pre-tokenized sft data, then masks the user prompts (in our case including image tokens).
-  Per training sample: loads a single sample from indexed dataset, then pads to maximum sequence length

### Added
- `--sft` cli argument (when given, use the new SFTIndexedDataset)
- `SFTIndexedDataset` loading and preparing pre-tokenized sft data

### Questions / Todos

- [ ] Add dynamic loading of "begin of user prompt" and "end-of-turn" sequence (could be part of tokenizer, is currently hard-coded and thus only works for LLama3 Vision Model Chat templates)
- [ ] Implement option to mask loss on all special tokens (BOS, EOD, EOS, SFT-Related special tokens)??
