### PR TITLE
Add SeeDNorm

### DIFF
--- a/gpt_builders.py
+++ b/gpt_builders.py
@@ -107,6 +107,11 @@ def _get_transformer_layer_spec(use_te, config):
     """
     args = get_args()
     if use_te:
+        if args.normalization == "SeeDNorm":
+            raise ValueError(
+                "SeeDNorm is not supported with Transformer Engine backend. "
+                "Set --transformer-impl local to use SeeDNorm."
+            )
         return get_gpt_layer_with_transformer_engine_spec(
             args.num_experts,
             args.moe_grouped_gemm,

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -228,6 +228,11 @@ class TENorm:
                 zero_centered_gamma=config.layernorm_zero_centered_gamma,
                 **_get_extra_te_kwargs(config),
             )
+        elif config.normalization == "SeeDNorm":
+            raise NotImplementedError(
+                "Transformer-Engine backend does not support SeeDNorm. "
+                "Use --transformer-impl local to enable SeeDNorm."
+            )
         else:
             raise Exception("Only LayerNorm and RMSNorm are curently supported")
 

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -229,8 +229,8 @@ def get_gpt_layer_local_spec(
         backend = KitchenSpecProvider(fallback=LocalSpecProvider())
     else:
         backend = LocalSpecProvider()
-    # Adjust for RMS norm style normalizations (RMSNorm, SeeDNorm).
-    if normalization in ("RMSNorm", "SeeDNorm"):
+    # Adjust for RMS norm.
+    if normalization == "RMSNorm":
         layer_norm = backend.layer_norm(rms_norm=True, for_qk=False)
         qk_norm = backend.layer_norm(rms_norm=True, for_qk=True)
     else:

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -229,8 +229,8 @@ def get_gpt_layer_local_spec(
         backend = KitchenSpecProvider(fallback=LocalSpecProvider())
     else:
         backend = LocalSpecProvider()
-    # Adjust for RMS norm.
-    if normalization == "RMSNorm":
+    # Adjust for RMS norm style normalizations (RMSNorm, SeeDNorm).
+    if normalization in ("RMSNorm", "SeeDNorm"):
         layer_norm = backend.layer_norm(rms_norm=True, for_qk=False)
         qk_norm = backend.layer_norm(rms_norm=True, for_qk=True)
     else:

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -108,7 +108,16 @@ def _get_param_groups(
                     or (default_skip_embedding_weight_decay and "embedding" in name)
                 )
 
-            if any(keyword in name for keyword in ["alpha"]):
+            if hasattr(param, "apply_weight_decay"):
+                no_wd = not bool(getattr(param, "apply_weight_decay"))
+            elif hasattr(param, "skip_weight_decay"):
+                no_wd = bool(getattr(param, "skip_weight_decay"))
+
+            if (
+                any(keyword in name for keyword in ["alpha"])
+                and not hasattr(param, "apply_weight_decay")
+                and not hasattr(param, "skip_weight_decay")
+            ):
                 no_wd = True
 
             if scale_lr_cond is not None:

--- a/megatron/core/post_training/modelopt/layers.py
+++ b/megatron/core/post_training/modelopt/layers.py
@@ -73,6 +73,11 @@ class Norm:
                 zero_centered_gamma=config.layernorm_zero_centered_gamma,
                 **_get_extra_te_kwargs(config),
             )
+        elif config.normalization == "SeeDNorm":
+            raise NotImplementedError(
+                "Transformer-Engine backend does not support SeeDNorm. "
+                "Use --transformer-impl local to enable SeeDNorm."
+            )
         else:
             raise Exception("Only LayerNorm and RMSNorm are curently supported")
 

--- a/megatron/core/ssm/mamba_block.py
+++ b/megatron/core/ssm/mamba_block.py
@@ -28,6 +28,7 @@ from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from megatron.core.transformer.torch_layer_norm import WrappedTorchLayerNorm
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.transformer.utils import sharded_state_dict_default
 from megatron.core.utils import WrappedTensor, deprecate_inference_params, make_viewless_tensor
@@ -197,11 +198,18 @@ class MambaStack(MegatronModule):
 
         if self.post_process and self.post_layer_norm:
             # Final layer norm before output.
-            self.final_norm = TENorm(
-                config=self.config,
-                hidden_size=self.config.hidden_size,
-                eps=self.config.layernorm_epsilon,
-            )
+            if self.config.normalization == "SeeDNorm":
+                self.final_norm = WrappedTorchLayerNorm(
+                    config=self.config,
+                    hidden_size=self.config.hidden_size,
+                    eps=self.config.layernorm_epsilon,
+                )
+            else:
+                self.final_norm = TENorm(
+                    config=self.config,
+                    hidden_size=self.config.hidden_size,
+                    eps=self.config.layernorm_epsilon,
+                )
 
         self.apply(
             partial(

--- a/megatron/core/transformer/torch_norm.py
+++ b/megatron/core/transformer/torch_norm.py
@@ -1,9 +1,17 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+from typing import Callable, Union
+
 import torch
+import torch.nn.functional as F
 
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer import TransformerConfig
 from megatron.core.utils import is_torch_min_version
+
+_SEEDNORM_ACTIVATIONS = {
+    "tanh": torch.tanh,
+    "softsign": F.softsign,
+}
 
 
 class WrappedTorchNorm:
@@ -34,6 +42,15 @@ class WrappedTorchNorm:
         assert (
             not config.memory_efficient_layer_norm
         ), f"memory_efficient_layer_norm not supported by torch LayerNorm"
+
+        if config.normalization == "SeeDNorm":
+            return SeeDNorm(
+                hidden_size=hidden_size,
+                eps=eps,
+                init=getattr(config, "seednorm_init", 1.0),
+                sequence_parallel=config.sequence_parallel,
+                activation=getattr(config, "seednorm_activation", "tanh"),
+            )
 
         if config.normalization == "LayerNorm":
             norm_cls = torch.nn.LayerNorm
@@ -94,3 +111,65 @@ class L2Norm(torch.nn.Module):
             torch.Tensor: L2-normalized tensor with the same dtype as input.
         """
         return self._norm(x)
+
+class SeeDNorm(torch.nn.Module):
+    """SeeDNorm implementation following the SeeDNorm pseudocode."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        init: float = 1.0,
+        sequence_parallel: bool = False,
+        activation: Union[str, Callable[[torch.Tensor], torch.Tensor]] = "tanh",
+        **kwargs,
+    ):
+        super().__init__()
+        if isinstance(hidden_size, torch.Size):
+            normalized_shape = hidden_size
+        elif isinstance(hidden_size, (tuple, list)):
+            normalized_shape = torch.Size(hidden_size)
+        else:
+            normalized_shape = torch.Size((hidden_size,))
+
+        # Determine activation function
+        if isinstance(activation, str):
+            if activation not in _SEEDNORM_ACTIVATIONS:
+                raise ValueError(
+                    f"Unsupported SeeDNorm activation '{activation}'. "
+                    f"Supported values: {list(_SEEDNORM_ACTIVATIONS.keys())}"
+                )
+            self._activation = _SEEDNORM_ACTIVATIONS[activation]
+            self.activation_name = activation
+        elif callable(activation):
+            self._activation = activation
+            self.activation_name = getattr(activation, "__name__", "custom_activation")
+        else:
+            raise TypeError("activation must be a string identifier or a callable.")
+
+        self.eps = eps
+        self.alpha = torch.nn.Parameter(torch.ones(normalized_shape) * init)
+        self.beta = torch.nn.Parameter(torch.zeros(normalized_shape))
+        self.gamma = torch.nn.Parameter(torch.ones(normalized_shape))
+
+        setattr(self.alpha, "sequence_parallel", sequence_parallel)
+        setattr(self.alpha, "apply_weight_decay", True)
+        setattr(self.beta, "sequence_parallel", sequence_parallel)
+        setattr(self.beta, "apply_weight_decay", True)
+        setattr(self.gamma, "sequence_parallel", sequence_parallel)
+
+    @jit_fuser
+    def _seed_norm(self, x: torch.Tensor) -> torch.Tensor:
+        x_float = x.float()
+        beta = self.beta.float()
+        alpha = self.alpha.float()
+        gamma = self.gamma.float()
+
+        rescale = self._activation(torch.matmul(x_float, beta))
+        inv_rms = torch.rsqrt(x_float.pow(2).mean(dim=-1, keepdim=True) + self.eps)
+        x_norm = x_float * inv_rms
+        dynamic_scale = rescale.unsqueeze(-1) * alpha
+        return ((dynamic_scale + gamma) * x_norm).type_as(x)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self._seed_norm(x)

--- a/megatron/core/transformer/torch_norm.py
+++ b/megatron/core/transformer/torch_norm.py
@@ -31,9 +31,10 @@ class WrappedTorchNorm:
         zero_centered_gamma: bool = False,
         normalization: str = "LayerNorm",
     ):
-        assert (
-            not config.layernorm_zero_centered_gamma
-        ), f"zero_centered_gamma not supported by torch LayerNorm"
+        if config.normalization != "SeeDNorm":
+            assert (
+                not config.layernorm_zero_centered_gamma
+            ), "layernorm_zero_centered_gamma requires SeeDNorm with the torch backend"
 
         assert not config.persist_layer_norm, f"persist_layer_norm not supported by torch LayerNorm"
 
@@ -50,6 +51,7 @@ class WrappedTorchNorm:
                 init=getattr(config, "seednorm_init", 1.0),
                 sequence_parallel=config.sequence_parallel,
                 activation=getattr(config, "seednorm_activation", "tanh"),
+                zero_centered_gamma=config.layernorm_zero_centered_gamma,
             )
 
         if config.normalization == "LayerNorm":
@@ -122,6 +124,7 @@ class SeeDNorm(torch.nn.Module):
         init: float = 1.0,
         sequence_parallel: bool = False,
         activation: Union[str, Callable[[torch.Tensor], torch.Tensor]] = "tanh",
+        zero_centered_gamma: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -148,9 +151,15 @@ class SeeDNorm(torch.nn.Module):
             raise TypeError("activation must be a string identifier or a callable.")
 
         self.eps = eps
+        self.zero_centered_gamma = zero_centered_gamma
         self.alpha = torch.nn.Parameter(torch.ones(normalized_shape) * init)
         self.beta = torch.nn.Parameter(torch.zeros(normalized_shape))
-        self.gamma = torch.nn.Parameter(torch.ones(normalized_shape))
+        gamma_init = (
+            torch.zeros(normalized_shape)
+            if zero_centered_gamma
+            else torch.ones(normalized_shape)
+        )
+        self.gamma = torch.nn.Parameter(gamma_init)
 
         setattr(self.alpha, "sequence_parallel", sequence_parallel)
         setattr(self.alpha, "apply_weight_decay", True)
@@ -164,6 +173,8 @@ class SeeDNorm(torch.nn.Module):
         beta = self.beta.float()
         alpha = self.alpha.float()
         gamma = self.gamma.float()
+        if self.zero_centered_gamma:
+            gamma = gamma + 1.0
 
         rescale = self._activation(torch.matmul(x_float, beta))
         inv_rms = torch.rsqrt(x_float.pow(2).mean(dim=-1, keepdim=True) + self.eps)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -168,7 +168,13 @@ class TransformerConfig(ModelParallelConfig):
     the numbers inside the tuple; -1 is special value meaning "infinite window size"."""
 
     normalization: str = "LayerNorm"
-    """Which norm to use for normalization layers, valid options are `LayerNorm` and `RMSNorm`."""
+    """Which norm to use for normalization layers, valid options are `LayerNorm`, `RMSNorm`, and `SeeDNorm`."""
+
+    seednorm_init: Optional[float] = 1.0
+    """Initialization value for SeeDNorm normalization layers."""
+
+    seednorm_activation: Optional[str] = "tanh"
+    """Activation function for SeeDNorm normalization layers."""
 
     qk_layernorm: bool = False
     """Whether to apply `normalization` type of normalization to the query and key embeddings."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1562,8 +1562,13 @@ def _add_network_size_args(parser):
                        help='Pad the vocab size to be divisible by this value.'
                        'This is added for computational efficieny reasons.')
     group.add_argument('--normalization', default='LayerNorm',
-                       choices=['LayerNorm', 'RMSNorm'],
+                       choices=['LayerNorm', 'RMSNorm', 'SeeDNorm'],
                        help='Which normalization technique to use.')
+    group.add_argument('--seednorm-init', type=float, default=1.0,
+                          help='Initial value for the seednorm scaling parameter.')
+    group.add_argument('--seednorm-activation', type=str, default='tanh',
+                          choices=['tanh', 'softsign'],
+                          help='Activation function for seednorm layers.')
     group.add_argument('--norm-epsilon', type=float, default=1e-5,
                        help='Epsilon for layer norm and RMS norm.')
     group.add_argument('--apply-layernorm-1p', action='store_true',

--- a/tests/unit_tests/transformer/test_seednorm.py
+++ b/tests/unit_tests/transformer/test_seednorm.py
@@ -1,0 +1,63 @@
+import torch
+import torch.nn.functional as F
+
+from megatron.core.transformer.torch_norm import SeeDNorm
+
+
+def _manual_seednorm(x: torch.Tensor, module: SeeDNorm, activation: str) -> torch.Tensor:
+    if activation == "tanh":
+        act_fn = torch.tanh
+    elif activation == "softsign":
+        act_fn = F.softsign
+    else:
+        raise ValueError(f"Unsupported activation in test: {activation}")
+
+    beta = module.beta
+    alpha = module.alpha
+    gamma = module.gamma
+    eps = module.eps
+
+    rescale = act_fn(torch.matmul(x, beta))
+    rms = torch.sqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+    x_norm = x / rms
+    dynamic_scale = rescale.unsqueeze(-1) * alpha
+    return (dynamic_scale + gamma) * x_norm
+
+
+def test_seednorm_matches_reference_tanh():
+    torch.manual_seed(0)
+    hidden_size = 7
+    module = SeeDNorm(hidden_size=hidden_size, activation="tanh").double()
+    x = torch.randn(4, hidden_size, dtype=torch.float64, requires_grad=True)
+
+    out = module(x)
+    ref = _manual_seednorm(x, module, activation="tanh")
+
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+
+    out.sum().backward()
+    assert x.grad is not None
+    assert not torch.isnan(x.grad).any()
+
+
+def test_seednorm_supports_softsign_activation():
+    torch.manual_seed(1)
+    hidden_size = 5
+    module = SeeDNorm(hidden_size=hidden_size, activation="softsign").double()
+    x = torch.randn(3, hidden_size, dtype=torch.float64, requires_grad=True)
+
+    out = module(x)
+    ref = _manual_seednorm(x, module, activation="softsign")
+
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+
+    out.sum().backward()
+    assert x.grad is not None
+    assert not torch.isnan(x.grad).any()
+
+
+def test_seednorm_weight_decay_flags():
+    module = SeeDNorm(hidden_size=3, activation="tanh")
+    assert getattr(module.alpha, "apply_weight_decay")
+    assert getattr(module.beta, "apply_weight_decay")
+    assert not hasattr(module.gamma, "apply_weight_decay")

--- a/tests/unit_tests/transformer/test_seednorm.py
+++ b/tests/unit_tests/transformer/test_seednorm.py
@@ -15,6 +15,8 @@ def _manual_seednorm(x: torch.Tensor, module: SeeDNorm, activation: str) -> torc
     beta = module.beta
     alpha = module.alpha
     gamma = module.gamma
+    if getattr(module, "zero_centered_gamma", False):
+        gamma = gamma + torch.ones_like(gamma)
     eps = module.eps
 
     rescale = act_fn(torch.matmul(x, beta))
@@ -61,3 +63,19 @@ def test_seednorm_weight_decay_flags():
     assert getattr(module.alpha, "apply_weight_decay")
     assert getattr(module.beta, "apply_weight_decay")
     assert not hasattr(module.gamma, "apply_weight_decay")
+
+def test_seednorm_supports_zero_centered_gamma():
+    torch.manual_seed(2)
+    hidden_size = 6
+    module = SeeDNorm(hidden_size=hidden_size, activation="tanh", zero_centered_gamma=True).double()
+    x = torch.randn(2, hidden_size, dtype=torch.float64, requires_grad=True)
+
+    out = module(x)
+    ref = _manual_seednorm(x, module, activation="tanh")
+
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+
+    out.sum().backward()
+    assert x.grad is not None
+    assert not torch.isnan(x.grad).any()
+    assert torch.allclose(module.gamma.detach(), torch.zeros_like(module.gamma.detach()))


### PR DESCRIPTION
## Summary

This PR introduces support for [SeeDNorm](https://arxiv.org/abs/2510.22777) into Megatron-LM, including configuration, implementation, and tests. It also adds optional **zero-centered gamma** and custom activation support (tanh / softsign). The change brings SeeDNorm to Megatron-LM while keeping TE backend paths safe via explicit guards.

---

## Key Changes

### 1. Core Implementation

* Added `SeeDNorm` module under `megatron/core/transformer/torch_norm.py`

  * Learnable parameters: `alpha`, `beta`, `gamma`
  * Optional `zero_centered_gamma`
  * Dynamic scaling using activation(beta·x)
  * Supported activations: `tanh`, `softsign`

* Integrated activation registry `_SEEDNORM_ACTIVATIONS`

---

### 2. Configuration / Arguments

* Added new CLI args:

  * `--normalization {LayerNorm,RMSNorm,SeeDNorm}`
  * `--seednorm-init`
  * `--seednorm-activation {tanh,softsign}`

* Added `TransformerConfig` fields:

  * `seednorm_init`
  * `seednorm_activation`

---

### 3. Mamba block + Backend Guardrails

* Updated Mamba block to support using SeeDNorm as final norm layer.
* Added guards to TE backend:

  * Raises error when SeeDNorm is requested under Transformer-Engine backend
  * Directs users to `--transformer-impl local`

---

### 4. Optimizer Handling

* Added regularization according to the paper:

  * `alpha` / `beta` are weight-decay eligible
  * `gamma` is not

---

### 5. Unit Tests

Added `tests/unit_tests/transformer/test_seednorm.py` to validate:

* Forward equivalence to reference implementation
* Tanh and softsign support
* Backprop stability
* Parameter weight-decay flag correctness
* zero_centered_gamma behavior

---

## Notes

* Not supported under Transformer-Engine backend; enforced via runtime error.
* Default activation is `tanh`.
* Default init value is `1.0`
