### PR TITLE
Update SeedNorm Weight-Decay Behavior for Softsign Activation

### DIFF
--- a/megatron/core/transformer/torch_norm.py
+++ b/megatron/core/transformer/torch_norm.py
@@ -164,7 +164,10 @@ class SeeDNorm(torch.nn.Module):
         setattr(self.alpha, "sequence_parallel", sequence_parallel)
         setattr(self.alpha, "apply_weight_decay", True)
         setattr(self.beta, "sequence_parallel", sequence_parallel)
-        setattr(self.beta, "apply_weight_decay", True)
+        if activation == "tanh":
+            setattr(self.beta, "apply_weight_decay", True)
+        else:
+            setattr(self.beta, "skip_weight_decay", True)
         setattr(self.gamma, "sequence_parallel", sequence_parallel)
 
     @jit_fuser

--- a/tests/unit_tests/transformer/test_seednorm.py
+++ b/tests/unit_tests/transformer/test_seednorm.py
@@ -64,6 +64,12 @@ def test_seednorm_weight_decay_flags():
     assert getattr(module.beta, "apply_weight_decay")
     assert not hasattr(module.gamma, "apply_weight_decay")
 
+    module = SeeDNorm(hidden_size=3, activation="softsign")
+    assert getattr(module.alpha, "apply_weight_decay")
+    assert hasattr(module.beta, "skip_weight_decay")
+    assert not hasattr(module.beta, "apply_weight_decay")
+    assert not hasattr(module.gamma, "apply_weight_decay")
+
 def test_seednorm_supports_zero_centered_gamma():
     torch.manual_seed(2)
     hidden_size = 6


### PR DESCRIPTION
## Summary

This PR updates the SeedNorm implementation so that:

* When `activation="softsign"`, the **`beta` parameter does *not* apply weight decay**.
* When `activation="tanh"` (default), `beta` still applies weight decay.

Related unit tests are updated accordingly.

## Changes

### Code

* In `megatron/core/transformer/torch_norm.py`:

  * Conditionally set `beta` to:

    * `apply_weight_decay=True` for `tanh`
    * `skip_weight_decay=True` for other activations (e.g., `softsign`)

### Tests

* In `tests/unit_tests/transformer/test_seednorm.py`:

  * Add test coverage to verify updated flags:

    * `alpha.apply_weight_decay == True`
    * For `softsign`:

      * `beta.skip_weight_decay` is set
      * `beta.apply_weight_decay` is **not** set
