### PR TITLE
fix: Containers point to infra01, and rehydrater is added

### DIFF
--- a/container/datatrove.toml
+++ b/container/datatrove.toml
@@ -1,6 +1,6 @@
-image = "/capstor/store/cscs/swissai/a06/containers/data-pipeline-pretrain/data-pipeline-pretrain.sqsh"
+image = "/capstor/store/cscs/swissai/infra01/containers/data-pipeline-pretrain/data-pipeline-pretrain-0.2.0.sqsh"
 
-mounts = ["/capstor", "/iopsstor", "/users", "/users/asolergi/data-pipeline-pretrain:/data-pipeline-pretrain"]
+mounts = ["/capstor", "/iopsstor", "/users", "/users/$USER/data-pipeline-pretrain:/data-pipeline-pretrain"]
 
 writable = true
 

--- a/scripts/merge_datasets/merge.sh
+++ b/scripts/merge_datasets/merge.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --account=a-a06
+#SBATCH --account=infra01
 #SBATCH --time=00:59:59
 #SBATCH --nodes=1
 #SBATCH --gres=gpu:4
 #SBATCH --cpus-per-task=288
-#SBATCH --environment=/capstor/store/cscs/swissai/a06/containers/NGC-PyTorch/ngc_pt_jan.toml	# Vanilla 25.01 PyTorch NGC Image 
+#SBATCH --environment=/capstor/store/cscs/swissai/infra01/containers/data-pipeline-pretrain/data-pipeline.toml	# Vanilla 25.01 PyTorch NGC Image 
 #SBATCH --no-requeue
 
 input_folder=$1

--- a/scripts/merge_datasets/submit_merge_dataset_dump.sh
+++ b/scripts/merge_datasets/submit_merge_dataset_dump.sh
@@ -1,11 +1,12 @@
-TOKENIZER_NAME=Llama-3.1-70B
-DATASET_NAME=fineweb-2
+TOKENIZER_NAME=Apertus-70B-2509
+# DATASET_NAME=fineweb2-hq/fra_latn
+DATASET_NAME=fineweb2-hq-baseline_fra/fra_retention_01
 
 MEGATRON_LM_DIR=/iopsstor/scratch/cscs/$USER/Megatron-LM
 PATH_TO_SLURM_LOGGING_DIR=$MEGATRON_LM_DIR/logs/slurm/merge-$TOKENIZER_NAME-$DATASET_NAME
 
-PATH_TO_INPUT_FOLDER=/iopsstor/scratch/cscs/asolergi/Megatron-LM/datasets/$DATASET_NAME/tokenized-dir-link
-PATH_TO_OUTPUT_FOLDER=/capstor/store/cscs/swissai/a06/datasets_tokenized/nemo # /iopsstor/scratch/cscs/$USER/datasets
+PATH_TO_INPUT_FOLDER=/iopsstor/scratch/cscs/$USER/datasets_Megatron_tokenized/$TOKENIZER_NAME/$DATASET_NAME
+PATH_TO_OUTPUT_FOLDER=/iopsstor/scratch/cscs/$USER/datasets_Megatron_merged # /iopsstor/scratch/cscs/$USER/datasets
 DATASET_OUTPUT_FOLDER_NAME=$PATH_TO_OUTPUT_FOLDER/$TOKENIZER_NAME/$DATASET_NAME-merge
 
 mkdir -p $PATH_TO_SLURM_LOGGING_DIR

--- a/scripts/tokenization/preprocess_megatron.py
+++ b/scripts/tokenization/preprocess_megatron.py
@@ -7,6 +7,7 @@ import argparse
 from data_pipeline_pretrain.pipeline.tokens import MegatronDocumentTokenizer
 from datatrove.executor.local import LocalPipelineExecutor
 from datatrove.pipeline.readers import ParquetReader
+from data_pipeline_pretrain.pipeline.tokens.rehydrater import Rehydrater
 
 
 def get_args():
@@ -71,6 +72,11 @@ def get_args():
         default="text",
         help="Column to preprocess from the Dataset. Default: text",
     )
+    group.add_argument(
+        "--rehydrate",
+        action="store_true",
+        help="Whether to rehydrate the dataset. Default: False",
+    )
 
     args = parser.parse_args()
 
@@ -92,6 +98,7 @@ def main(args):
                 paths_file=args.paths_file,
                 text_key=args.column,
             ),
+            *([Rehydrater()] if args.rehydrate else []),
             MegatronDocumentTokenizer(
                 output_folder=args.output_folder,
                 tokenizer_name_or_path=args.tokenizer_name_or_path,

--- a/scripts/tokenization/submit_tokenization.sh
+++ b/scripts/tokenization/submit_tokenization.sh
@@ -6,19 +6,30 @@
 # ⚠️ WARNING ⚠️
 
 NUMBER_OF_DATATROVE_TASKS=20
-TOKENIZER=meta-llama/Llama-3.1-70B
-TOKENIZER_NAME=Llama-3.1-70B
-DATASET_NAME=fineweb-2
+TOKENIZER=swiss-ai/Apertus-70B-2509
+TOKENIZER_NAME=Apertus-70B-2509
+# DATASET_NAME=fineweb2-hq/fra_latn
+DATASET_NAME=fineweb2-hq-baseline_fra/fra_retention_01
 COLUMN_KEY=text
 
+REHYDRATE=True  # Set to True or False
+if [ "$REHYDRATE" = "True" ]; then
+  REHYDRATE_FLAG="--rehydrate"
+else
+  REHYDRATE_FLAG=""
+fi
+
 MEGATRON_LM_DIR=/iopsstor/scratch/cscs/$USER/Megatron-LM
-PATH_TO_PREPROCESSING_METADATA=$MEGATRON_LM_DIR/datasets/$DATASET_NAME
-PATH_TO_DATATROVE_LOGGING_DIR=$MEGATRON_LM_DIR/logs/datatrove
+# PATH_TO_PREPROCESSING_METADATA=$MEGATRON_LM_DIR/datasets/$DATASET_NAME # Where dumps are stored
+PATH_TO_PREPROCESSING_METADATA=$SCRATCH/datasets_Megatron/$DATASET_NAME
+PATH_TO_DATATROVE_LOGGING_DIR=$MEGATRON_LM_DIR/logs/datatrove # Where datatrove logs are stored
 PATH_TO_SLURM_LOGGING_DIR=$MEGATRON_LM_DIR/logs/slurm/tokenization-$TOKENIZER_NAME-$DATASET_NAME
-PATH_TO_OUTPUT_FOLDER=/iopsstor/scratch/cscs/$USER/datasets
+PATH_TO_OUTPUT_FOLDER=/iopsstor/scratch/cscs/$USER/datasets_Megatron_tokenized # Where tokenized datasets are stored
 
 DATASET_OUTPUT_FOLDER_NAME=$PATH_TO_OUTPUT_FOLDER/$TOKENIZER_NAME/$DATASET_NAME
-CSV_RESULTS_FILE=$PATH_TO_PREPROCESSING_METADATA/tokenize-$TOKENIZER_NAME-$DATASET_NAME.csv
+# CSV_RESULTS_FILE=$PATH_TO_PREPROCESSING_METADATA/tokenize-$TOKENIZER_NAME-$DATASET_NAME.csv
+SANITIZED_DATASET_NAME=$(echo "$DATASET_NAME" | tr '/' '_')
+CSV_RESULTS_FILE=$PATH_TO_PREPROCESSING_METADATA/tokenize-$TOKENIZER_NAME-$SANITIZED_DATASET_NAME.csv
 
 mkdir -p $DATASET_OUTPUT_FOLDER_NAME
 mkdir -p $PATH_TO_SLURM_LOGGING_DIR
@@ -31,5 +42,5 @@ for paths_file in "$PATH_TO_PREPROCESSING_METADATA/dumps"/*; do
   dump=$(grep -oP '(?<=paths_file_)\d+(?=\.txt)' <<< $paths_file)
   output_folder=$DATASET_OUTPUT_FOLDER_NAME/dump-$dump
   logging_dir=$PATH_TO_DATATROVE_LOGGING_DIR/$TOKENIZER_NAME/$DATASET_NAME/dump-$dump
-  sbatch --job-name=tokenize-$DATASET_NAME-dump-$dump --output=$PATH_TO_SLURM_LOGGING_DIR/R-%x-%j.out --error=$PATH_TO_SLURM_LOGGING_DIR/R-%x-%j.err $MEGATRON_LM_DIR/scripts/tokenization/tokenize.sh $PATH_TO_PREPROCESSING_METADATA/raw-dataset-link $output_folder $TOKENIZER $logging_dir $CSV_RESULTS_FILE $paths_file $NUMBER_OF_DATATROVE_TASKS $MEGATRON_LM_DIR $COLUMN_KEY
-done
+  sbatch --job-name=tokenize-$DATASET_NAME-dump-$dump --output=$PATH_TO_SLURM_LOGGING_DIR/R-%x-%j.out --error=$PATH_TO_SLURM_LOGGING_DIR/R-%x-%j.err $MEGATRON_LM_DIR/scripts/tokenization/tokenize.sh $PATH_TO_PREPROCESSING_METADATA/raw-dataset-link $output_folder $TOKENIZER $logging_dir $CSV_RESULTS_FILE $paths_file $NUMBER_OF_DATATROVE_TASKS $MEGATRON_LM_DIR $COLUMN_KEY $REHYDRATE_FLAG
+done  

--- a/scripts/tokenization/tokenize.sh
+++ b/scripts/tokenization/tokenize.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-#SBATCH --account=a-a06
+#SBATCH --account=infra01
 #SBATCH --time=07:59:59
 #SBATCH --nodes=1
 #SBATCH --gres=gpu:4
 #SBATCH --cpus-per-task=288
-#SBATCH --environment=/iopsstor/scratch/cscs/asolergi/Megatron-LM/container/datatrove.toml # WARN(tj.solergibert) Modify path to your own file
+#SBATCH --environment=/iopsstor/scratch/cscs/yassine_turki/Megatron-LM/container/datatrove.toml # WARN(tj.solergibert) Modify path to your own file
 #SBATCH --no-requeue
-
 input_folder=$1
 output_folder=$2
 tokenizer=$3
@@ -17,9 +16,11 @@ paths_file=$6
 number_of_tasks=$7
 MEGATRON_LM_DIR=$8
 COLUMN_KEY=$9
-
+REHYDRATE_FLAG=${10}
 set -eo pipefail
 
+# # Make the local pretrain-data package importable inside the container
+# export PYTHONPATH=/iopsstor/scratch/cscs/$USER/pretrain-data/src:$PYTHONPATH
 # Setup ENV
 export HF_HUB_ENABLE_HF_TRANSFER=0
 # Setup directories
@@ -30,7 +31,7 @@ mkdir -p $output_folder
 echo "START TIME: $(date) | Preprocessing $paths_file with $number_of_tasks tasks per node with the $tokenizer tokenizer. Storing tokenized dataset in $output_folder"
 start_s=`date`
 start=`date +%s`
-numactl --membind=0-3 python3 $MEGATRON_LM_DIR/scripts/tokenization/preprocess_megatron.py --tokenizer-name-or-path $tokenizer --output-folder $output_folder --logging-dir $logging_dir --n-tasks $number_of_tasks --dataset $input_folder --paths-file $paths_file --column $COLUMN_KEY
+numactl --membind=0-3 python3 $MEGATRON_LM_DIR/scripts/tokenization/preprocess_megatron.py --tokenizer-name-or-path $tokenizer --output-folder $output_folder --logging-dir $logging_dir --n-tasks $number_of_tasks --dataset $input_folder --paths-file $paths_file --column $COLUMN_KEY $REHYDRATE_FLAG
 end=`date +%s`
 end_s=`date`
 echo "FINISH TIME: $(date) | Preprocessed $paths_file ! Stored in $output_folder"


### PR DESCRIPTION
- Changed accounts and containers to point to `infra01` instead of `a06` so that new students can access the toml file and smoothly run experiments
- Added the `Rehydrater` class as an optional argument in tokenization. 