### PR TITLE
Fix log parameter and loading of optimizer state when using distributed and precision aware optimizer

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1786,6 +1786,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     for src_tensors, (model_param, param_range_map) in zip(
                         bucket_state, gbuf_range_map["param_map"].items()
                     ):
+                        # Remove non-tensor metadata before restoring optimizer states.
+                        src_tensors.pop('padding', None)
                         # Main param & optimizer states.
                         self._set_main_param_and_optimizer_states(model_param, src_tensors)
 

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -87,6 +87,11 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
                         if getattr(param, 'main_param_sharded', False):
                             if param.main_param is not None:
                                 sharded_params_data.append(param.main_param)
+                            else:
+                                # Precision-aware optimizer: main_param is None
+                                # because master weights are held by FusedAdam.
+                                # Fall back to using the model param directly.
+                                moe_params_data.append(param.data.float())
                         else:
                             moe_params_data.append(param.main_param)
                     else:
@@ -103,6 +108,11 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
                             if getattr(param, 'main_param_sharded', False):
                                 if param.main_param is not None:
                                     sharded_params_data.append(param.main_param)
+                                else:
+                                    # Precision-aware optimizer: main_param is None
+                                    # because master weights are held by FusedAdam.
+                                    # Fall back to using the model param directly.
+                                    params_data.append(param.data.float())
                             else:
                                 params_data.append(param.main_param)
                         else:


### PR DESCRIPTION
### Issue
1) During my experiments with llama3B model extended with emu3.5 discrete vision tokens I encountered, that given `--log-params-norm` the logged value is always 0.

2) When resume from a checkpoint with precision aware and distributed optimizer, loading of optimizer state fails.

### Root Cause

1) In `megatron/training/utils.py` method `calc_params_l2_norm` has an issue: If parameters: `--use-precision-aware-optimizer + --bf16 + --use-distributed-optimizer` are all given method looks in `param.main_param` for the master weights, but becuase of combination of `--use-precision-aware-optimizer +  --use-distributed-optimizer` those are held by FusedAdam. This silently led to value to be None.

2) In `megatron/core/optimizer/distrib_optimizer.py` when laoding from checkpoint stored with `--use-precision-aware-optimizer +  --use-distributed-optimizer`, the "padding" info in the tensor-dict metadata is assumed to not exist. But it existed, leading to key/value being "padding bool" value instead of correct tensor name / tensor

### Fix

1) add else clause to fallback to normal weight value stored in `param.data`
2) In respective path pop padding info from dict.