### PR TITLE
feat: Update SFT dataset for best-fit pretraining

### DIFF
--- a/examples/sft/launcher_sft_apertus_8b.sh
+++ b/examples/sft/launcher_sft_apertus_8b.sh
@@ -1,0 +1,339 @@
+#!/bin/bash
+
+#SBATCH --account=infra01
+#SBATCH --time=0:29:00
+#SBATCH --job-name=32k_baseline
+#SBATCH --output=/capstor/scratch/cscs/dtamayomela/megatron/project/logs/slurm/training/%x-%j.out
+#SBATCH --error=/capstor/scratch/cscs/dtamayomela/megatron/project/logs/slurm/training/%x-%j.err
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=72
+#SBATCH --no-requeue
+#SBATCH --reservation=SD-69241-apertus-1-5
+
+echo "START TIME: $(date)"
+
+# Container environment (used by srun --environment)
+CONTAINER_ENV=/capstor/store/cscs/swissai/infra01/containers/ngc_25-12-alps2.toml
+
+DATAROOT=/iopsstor/scratch/cscs/jpcoles/a06
+
+SYNTHETIC_SFT_DATA="/capstor/scratch/cscs/dtamayomela/synthetic_data/ArtificialNeedles/simplified_repo/output_files_newint"
+PRETRAINING_DATA="${DATAROOT}/phase-5/finemath-3plus-merge,\
+${DATAROOT}/phase-5/roman/merged/stackv2/threshold_0"
+
+echo "------------------------ Debug info ------------------------"
+
+# Megatron source and dataset cache
+MEGATRON_LM_DIR=/iopsstor/scratch/cscs/$USER/megatron_folders/megatron_branch_sft
+DATASET_CACHE_DIR=/iopsstor/scratch/cscs/$USER/datasets/cache
+
+AUTO_JOB_REQUEUE=false # Set to `true` to continuously submit jobs to Slurm until training is complete. Enable it once you are sure of the cost involved in running this experiment.
+if [ "$AUTO_JOB_REQUEUE" = true ]; then
+    echo "[$(date)] Submitting follow-up job with singleton dependency and --resume"
+    # Export the script path and submit with --resume
+    sbatch --dependency=singleton --job-name=$SLURM_JOB_NAME $0 --resume
+fi
+
+RESUME_TRAINING=false
+MBS=1 # Micro batch size
+GBS=1024 # Global batch size
+SEQ_LEN=8192 # Sequence length
+TARGET_TOKENS=10000000000 # ~10B: 1 epoch of all data — 27.6B vision (46.3%), 8.4B audio (13.7%), 14.1 SC text + 9B LC text (39%)
+CHECKPOINT_STEPS=100
+TRAINING_STEPS=$((TARGET_TOKENS / (GBS * SEQ_LEN)))
+TRAINING_STEPS=$((((TRAINING_STEPS + CHECKPOINT_STEPS/2) / CHECKPOINT_STEPS) * CHECKPOINT_STEPS)) # Round to nearest multiple of CHECKPOINT_STEPS
+
+################ Parse Command Line Arguments ################
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --resume)
+                        echo "---> Resume Training <---"
+            RESUME_TRAINING=true
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            echo "Usage: $0 [--resume]"
+            exit 1
+            ;;
+    esac
+done
+
+
+#### Debugging ####
+LOG_NCCL=false # Log NCCL_DEBUG=info. Every process will dump the logging into separate files, check `NCCL_DEBUG_FILE`
+NSYS_PROFILER=false # Turn on the NSYS profiler. Check the `--profile-*` args available in megatron/training/arguments.py
+MOCK_DATA=false # Set to `true` to use mock data
+###################
+
+TORCH_INDUCTOR_CACHE_DIR=/tmp/.torch_inductor
+TRITON_HOME_DIR=/tmp/.triton
+PYTHON_CACHE_DIR=/tmp/.python_cache
+
+# Logging directories & artifacts
+PROJECT_NAME=main-runs-apertus-1p5_8k_sft
+EXP_NAME=apertus-1p5-8b_masking_$SLURM_JOB_NAME
+PROJECT_DIR=$MEGATRON_LM_DIR/logs/Meg-Runs/$PROJECT_NAME
+
+#########################################
+
+EXP_DIR=$PROJECT_DIR/$EXP_NAME
+CKPT_DIR=$EXP_DIR/checkpoints
+DEBUG_DIR=$EXP_DIR/debug/$SLURM_JOB_ID
+LOGGING_DIR=$EXP_DIR/logging
+TENSORBOARD_DIR=$LOGGING_DIR/tensorboard
+
+LOAD_DIR=/capstor/scratch/cscs/dtamayomela/8b_checkpoint/checkpoints
+SAVE_DIR=$CKPT_DIR
+
+# Set up ENV
+# export your WANDB_API_KEY here.
+# export WANDB_API_KEY=$(grep -A2 "api.wandb.ai" ~/.netrc 2>/dev/null | grep password | awk '{print $2}')
+export WANDB__FILE_STREAM_RETRY_MAX=10
+export HF_HUB_OFFLINE=1
+
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+export TRITON_HOME=$TRITON_HOME_DIR
+export TRITON_CACHE_DIR=$TRITON_HOME_DIR/cache
+
+# We are preparing for torch.distributed programs so it wants:
+# - MASTER_ADDR, MASTER_PORT, WORLD_SIZE - already known before `srun`
+# - RANK, LOCAL_RANK - will set at `srun` command
+export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
+export MASTER_PORT=8888
+export WORLD_SIZE=$SLURM_NPROCS
+
+
+TRANSFORMER_ENGINE_ARGS=(
+        --main-grads-dtype fp32
+        --log-params-norm
+)
+
+NETWORK_SIZE_ARGS=(
+        --num-layers 32
+        --hidden-size 4096
+        --ffn-hidden-size 21504  # xielu
+        --num-attention-heads 32
+        --group-query-attention
+        --num-query-groups 8
+        --max-position-embeddings $SEQ_LEN
+        --position-embedding-type rope
+        --rotary-base 2000000
+        --use-rope-scaling
+        --rope-scaling-factor 8
+        --make-vocab-size-divisible-by 128
+        --normalization RMSNorm
+        --xielu  # xielu
+        --qk-layernorm  # op-block
+        --qknorm-impl apex  # op-block
+        --untie-embeddings-and-output-weights
+)
+
+LOGGING_ARGS=(
+        --log-throughput
+        --tensorboard-dir $TENSORBOARD_DIR
+        --no-log-loss-scale-to-tensorboard
+        --log-memory-to-tensorboard
+)
+
+REGULARIZATION_ARGS=(
+        --attention-dropout 0.0
+        --hidden-dropout 0.0
+        --weight-decay 0.1
+        --weight-decay-on-xielu-alphas
+        --clip-grad 0.1  # ademamix
+        --adam-beta1 0.9
+        --adam-beta2 0.999  # ademamix
+        --ademamix-alpha 8 # ademamix
+        --ademamix-beta3 0.9999  # ademamix
+        --ademamix-beta3-warmup 100000  # ademamix
+        --ademamix-alpha-warmup 100000  # ademamix
+)
+
+TRAINING_ARGS=(
+        --micro-batch-size $MBS
+        --global-batch-size $GBS
+        --no-check-for-nan-in-loss-and-grad
+        --train-iters $TRAINING_STEPS # --train-samples 3662109375
+        --log-interval 1
+        --cross-entropy-loss-fusion
+        --disable-bias-linear
+        --optimizer ademamix  # ademamix
+        --dataloader-type single
+        --manual-gc
+        --manual-gc-interval 500
+        --exit-signal-handler
+        --eval-interval 100000000000
+        --eval-iters 0
+)
+
+INITIALIZATION_ARGS=(
+        --seed 41
+        --init-method-std 0.008944
+)
+
+LEARNING_RATE_ARGS=(
+        --lr 0.00011
+        --min-lr 0.000011 # x10 reduction
+        --lr-decay-style WSD  # WSD schedule
+        --lr-warmup-iters 500
+        --lr-wsd-decay-style minus_sqrt  # WSD schedule
+        --lr-wsd-decay-iters 0  # WSD decay will be a different run
+)
+
+# Check if --extend-model-vocab is in MULTIMODAL_ARGS
+# This determines whether we're extending the vocab (first step) or doing normal training (second step)
+
+CHECKPOINTING_ARGS=(
+        --load $LOAD_DIR
+        --save $SAVE_DIR
+        --save-interval $CHECKPOINT_STEPS
+        --ckpt-format torch_dist
+        --async-save
+        --ckpt-fully-parallel-load
+        --ckpt-fully-parallel-save
+        --dist-ckpt-strictness assume_ok_unexpected
+        --override-opt_param-scheduler
+        --no-load-optim
+        --no-load-rng
+        --finetune
+)
+
+MIXED_PRECISION_ARGS=(
+        --bf16
+)
+
+DISTRIBUTED_ARGS=(
+        --tensor-model-parallel-size 2
+        --pipeline-model-parallel-size 1
+        --context-parallel-size 1
+        --use-distributed-optimizer
+        --overlap-grad-reduce
+        --overlap-param-gather
+        --calculate-per-token-loss
+)
+
+TOKENIZER_ARGS=(
+        --tokenizer-type HuggingFaceTokenizer
+        --tokenizer-model /capstor/scratch/cscs/dtamayomela/tokenizer
+)
+
+TRUNCATE_RIGHT=false  # if true, truncate too-long samples on the right instead of left
+
+DATA_ARGS=(
+        --split 100,0,0
+        --seq-length $SEQ_LEN
+        --reset-position-ids  # crossDocAttn: need to reset position ids to properly separate samples! (not multiple pos ids in one sample)
+        #--reset-attention-mask  # crossDocAttn / ignore as attn mask from dataloader is ignore
+        --use-packed-seq-params # Use packed seq params to enable proper xdoc masking (ASSUMES THIS FIX IS AVAILABLE!)
+        --no-create-attention-mask-in-dataloader # Dont create attnmask in datalaoder as we use packed seq params
+        # --variable-seq-lengths
+        --eod-mask-loss  # crossDocAttn
+        --num-workers 16        # workers per rank
+        --num-dataset-builder-threads 4 # only needed for initialization
+        --goldfish-loss  # goldfish
+        --goldfish-k 50  # goldfish
+        --goldfish-h 50  # goldfish
+        # SFT masking: mask system/user templates, compute loss on assistant responses only
+        --ap-sft
+        --ap-sft-mask-special-tokens
+        --ap-sft-pack-samples
+        --ap-sft-packing-strategy bfd
+)
+
+if [ "$TRUNCATE_RIGHT" = true ]; then
+    DATA_ARGS+=(--ap-sft-truncate-right)
+fi
+
+# Set up directories
+mkdir -p $CKPT_DIR
+mkdir -p $PROJECT_DIR
+mkdir -p $DEBUG_DIR
+mkdir -p $LOGGING_DIR
+export PYTHONPATH=$MEGATRON_LM_DIR
+export PYTHONPATH=/capstor/scratch/cscs/$USER/pip-packages:$PYTHONPATH
+
+# Data Args
+if [ "$MOCK_DATA" = true ]; then
+  DATA_ARGS="${DATA_ARGS[@]} --mock-data"
+else
+  DATA_ARGS="${DATA_ARGS[@]} --data-path $(python3 $MEGATRON_LM_DIR/scripts/tools/create_weighted_data_config.py --paths "$SYNTHETIC_SFT_DATA" --weight 0.1) $(python3 $MEGATRON_LM_DIR/scripts/tools/create_weighted_data_config.py --paths "$PRETRAINING_DATA" --weight 0.9) --data-cache-path $DATASET_CACHE_DIR"
+
+fi
+
+#CMD_PREFIX="numactl --membind=0-3"
+
+TRAINING_CMD="python3 $MEGATRON_LM_DIR/pretrain_gpt.py \
+    ${TRANSFORMER_ENGINE_ARGS[@]} \
+    ${NETWORK_SIZE_ARGS[@]} \
+    ${LOGGING_ARGS[@]} \
+    ${REGULARIZATION_ARGS[@]} \
+    ${TRAINING_ARGS[@]} \
+    ${INITIALIZATION_ARGS[@]} \
+    ${LEARNING_RATE_ARGS[@]} \
+    ${CHECKPOINTING_ARGS[@]} \
+    ${MIXED_PRECISION_ARGS[@]} \
+    ${DISTRIBUTED_ARGS[@]} \
+    ${TOKENIZER_ARGS[@]} \
+    $DATA_ARGS"
+
+# WANDB Logging Setup - Only if API Key in Env
+if [ -n "$WANDB_API_KEY" ]; then
+  echo "[$(date)] WANDB API key detected. Enabling WANDB logging."
+
+  # Get and display WandB entity/workspace
+  WANDB_ENTITY=$(python3 -c "import wandb; api = wandb.Api(); print(api.default_entity)" 2>/dev/null || echo "unknown")
+  echo "[$(date)] WandB logs will be sent to:"
+  echo "           Organization/Workspace: $WANDB_ENTITY"
+  echo "           Project: $PROJECT_NAME"
+  echo "           Experiment: $EXP_NAME-$SLURM_JOB_ID"
+
+  # Sync any previous run data if present
+  if [ -d "$LOGGING_DIR/wandb/latest-run" ]; then
+    echo "[$(date)] Syncing WANDB from previous run"
+    wandb sync "$LOGGING_DIR/wandb/latest-run"
+  fi
+  # Add wandb-related args to TRAINING_CMD
+  TRAINING_CMD="$TRAINING_CMD \
+    --wandb-save-dir $LOGGING_DIR \
+    --wandb-project $PROJECT_NAME \
+    --wandb-exp-name $EXP_NAME-$SLURM_JOB_ID"
+else
+  export WANDB_MODE=disabled
+  echo "[$(date)] No WANDB API key found. WANDB logging disabled."
+fi
+
+# NCCL Debug
+if [ "$LOG_NCCL" = true ]; then
+  CMD_PREFIX="NCCL_DEBUG=INFO NCCL_DEBUG_FILE=$DEBUG_DIR/nccl-info-hostname-\$SLURMD_NODENAME-local-rank-\$SLURM_LOCALID-procid-\$SLURM_PROCID.txt $CMD_PREFIX"
+fi
+
+# NSYS profiler
+if [ "$NSYS_PROFILER" = true ]; then
+    NSYS_LAUNCHER="nsys profile -s none --trace='nvtx,cudnn,cublas,cuda' --output=$DEBUG_DIR/nsys-trace-hostname-\$SLURMD_NODENAME-procid-\$SLURM_PROCID.nsys-rep --force-overwrite true --capture-range=cudaProfilerApi --capture-range-end=stop"
+    TRAINING_CMD="$NSYS_LAUNCHER $TRAINING_CMD --profile"
+fi
+
+# export SFT_MAX_DOCS_PER_BIN=64
+
+srun \
+    --cpus-per-task $SLURM_CPUS_PER_TASK \
+    --mpi=pmix \
+    --environment=$CONTAINER_ENV \
+    --network=disable_rdzv_get \
+    -lu \
+    bash -c "
+    mkdir -p $TORCH_INDUCTOR_CACHE_DIR
+    mkdir -p $TRITON_HOME_DIR
+    mkdir -p $TRITON_CACHE_DIR
+    mkdir -p $PYTHON_CACHE_DIR
+    RANK=\$SLURM_PROCID LOCAL_RANK=\$SLURM_LOCALID $CMD_PREFIX $TRAINING_CMD
+    "
+
+echo "END TIME: $(date)"

--- a/examples/sft/launcher_sft_apertus_8b.sh
+++ b/examples/sft/launcher_sft_apertus_8b.sh
@@ -3,8 +3,8 @@
 #SBATCH --account=infra01
 #SBATCH --time=0:29:00
 #SBATCH --job-name=32k_baseline
-#SBATCH --output=/capstor/scratch/cscs/dtamayomela/megatron/project/logs/slurm/training/%x-%j.out
-#SBATCH --error=/capstor/scratch/cscs/dtamayomela/megatron/project/logs/slurm/training/%x-%j.err
+#SBATCH --output=./logs/slurm/training/%x-%j.out
+#SBATCH --error=./logs/slurm/training/%x-%j.err
 #SBATCH --nodes=2
 #SBATCH --ntasks-per-node=4
 #SBATCH --cpus-per-task=72
@@ -257,7 +257,6 @@ mkdir -p $PROJECT_DIR
 mkdir -p $DEBUG_DIR
 mkdir -p $LOGGING_DIR
 export PYTHONPATH=$MEGATRON_LM_DIR
-export PYTHONPATH=/capstor/scratch/cscs/$USER/pip-packages:$PYTHONPATH
 
 # Data Args
 if [ "$MOCK_DATA" = true ]; then

--- a/megatron/training/datasets/apertus_sft_dataset.py
+++ b/megatron/training/datasets/apertus_sft_dataset.py
@@ -30,6 +30,258 @@ def _pad_sequence_if_needed(document, target_length: int, padding_value):
     return np.concatenate([document, np.full(padding_length, padding_value, dtype=document.dtype)])
 
 
+from dataclasses import dataclass
+
+@dataclass
+class SpecialTokenIDs:
+    """Integer IDs for special tokens used in SFT loss masking."""
+    system_start: int     # <|system_start|>
+    assistant_start: int  # <|assistant_start|>
+    assistant_end: int    # <|assistant_end|>
+    eod: int              # </s>
+    bos: int              # <s>
+    developer_start: int  # <|developer_start|>
+    user_start: int       # <|user_start|>
+
+
+def _get_synthetic_special_ids(tokenizer) -> SpecialTokenIDs:
+    """Resolve special token strings to integer IDs via the HF tokenizer."""
+    hf_tok = tokenizer._tokenizer.tokenizer
+    def _tok_id(token: str) -> int:
+        idx = hf_tok.convert_tokens_to_ids(token)
+        if idx == hf_tok.unk_token_id:
+            raise KeyError(f"Token '{token}' not found in tokenizer vocabulary.")
+        return idx
+    return SpecialTokenIDs(
+        system_start=_tok_id("<|system_start|>"),
+        assistant_start=_tok_id("<|assistant_start|>"),
+        assistant_end=_tok_id("<|assistant_end|>"),
+        developer_start=_tok_id("<|developer_start|>"),
+        user_start=_tok_id("<|user_start|>"),
+        eod=tokenizer.eod,
+        bos=tokenizer.bos,
+    )
+
+
+def _get_subdoc_spans_from_eos(eos_indices: np.ndarray, seq_len: int) -> List[Tuple[int, int]]:
+    """Convert per-doc last-token positions into (start, end) inclusive spans.
+
+    Skips degenerate spans (start > end) from duplicate eos indices or eos at seq_len - 1.
+    """
+    spans: List[Tuple[int, int]] = []
+    start = 0
+    for eod_idx in eos_indices:
+        end = min(int(eod_idx), seq_len - 1)
+        if start <= end:
+            spans.append((start, end))
+        start = end + 1
+        if start >= seq_len:
+            break
+    if start < seq_len:
+        spans.append((start, seq_len - 1))
+    return spans
+
+
+def _process_subdoc_masking(
+    data: torch.Tensor,
+    tokens: torch.Tensor,
+    loss_mask: torch.Tensor,
+    assistant_mask: torch.Tensor,
+    start: int,
+    end: int,
+    special_ids: SpecialTokenIDs,
+) -> None:
+    """Apply masking rules in-place for one sub-document [start, end] (inclusive).
+
+    Span does not begin with BOS -> cut fragment; mask each SFT turn from its opening
+                              marker (<|system_start|> or <|developer_start|>) through
+                              the paired <|assistant_end|> (inclusive), so the model is
+                              not trained on answers that reference missing context (e.g.
+                              CWE counting tasks). Pre-training tokens before the first
+                              marker are left unmasked.
+    No SYS, no ASST -> pure pre-training; loss_mask unchanged (stays 1).
+    SYS, no ASST    -> broken tail;  zero [SYS .. end].
+    Both present    -> normal SFT:   zero [SYS .. ASST] and [AEND];
+                       assistant_mask = True for answer tokens (ASST+1 .. AEND-1).
+    """
+
+    # Case 1: Document cut
+    if tokens[start] != special_ids.bos:
+        _sub = data[start : end + 1]
+        _SYS = special_ids.system_start
+        _DEV = special_ids.developer_start
+        _AEND = special_ids.assistant_end
+        _USST = special_ids.user_start
+        _turn_starts = sorted(
+            [int(p) for p in (_sub == _SYS).nonzero(as_tuple=True)[0]] +
+            [int(p) for p in (_sub == _DEV).nonzero(as_tuple=True)[0]] +
+            [int(p) for p in (_sub == _USST).nonzero(as_tuple=True)[0]]
+        )
+        _aend_positions = (_sub == _AEND).nonzero(as_tuple=True)[0].tolist()
+        for ts_pos in _turn_starts:
+            next_aend = next((a for a in _aend_positions if a > ts_pos), None)
+            mask_end = next_aend if next_aend is not None else (end - start)
+            loss_mask[start + ts_pos : start + mask_end + 1] = 0.0
+        return
+
+    sub = data[start : end + 1]
+
+    SYS  = special_ids.system_start
+    ASST = special_ids.assistant_start
+    AEND = special_ids.assistant_end
+    USST  = special_ids.user_start
+    DEV  = special_ids.developer_start
+
+    sys_positions = (sub == SYS).nonzero(as_tuple=True)[0].tolist()
+    asst_positions = (sub == ASST).nonzero(as_tuple=True)[0].tolist()
+    aend_positions = (sub == AEND).nonzero(as_tuple=True)[0].tolist()
+    usst_positions = (sub == USST).nonzero(as_tuple=True)[0].tolist()
+    dev_positions = (sub == DEV).nonzero(as_tuple=True)[0].tolist()
+
+    has_sys  = bool(sys_positions)
+    has_asst = bool(asst_positions)
+    has_user = bool(usst_positions)
+
+    # Case 2: pure pre-training
+    if not has_user and not has_asst:       
+        return
+    
+    first_turn = min(
+        sys_positions + usst_positions + dev_positions
+    )
+    loss_mask[start + first_turn : end + 1] = 0.0
+
+    # Case 3: broken tail, we mask all the chat
+    if has_user and not has_asst:
+        return
+
+    # Case 4: both SYS and ASST (possibly multi-turn)
+    for asst_pos in asst_positions:
+        # Find corresponding AEND
+        aend_pos = next((a for a in aend_positions if a > asst_pos), None)
+
+        if aend_pos is not None:
+            ans_start = start + asst_pos + 1
+            ans_end = start + aend_pos + 1
+
+            if ans_start < ans_end:
+                loss_mask[ans_start:ans_end] = 1.0
+                assistant_mask[ans_start:ans_end] = True
+        else:
+            # Broken tail: unmask until end
+            ans_start = start + asst_pos + 1
+            ans_end = end + 1
+
+            if ans_start < ans_end:
+                loss_mask[ans_start:ans_end] = 1.0
+                assistant_mask[ans_start:ans_end] = True
+
+def _build_virtual_docs(
+    document_index: np.ndarray,
+    sequence_lengths: np.ndarray,
+    capacity: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Split any document longer than *capacity* into capacity-sized chunks.
+
+    Documents that fit within *capacity* are kept as a single virtual entry.
+    Oversized documents produce multiple virtual entries, each loadable via
+    ``IndexedDataset.get(doc_id, offset=start, length=length)``.
+
+    Returns:
+        chunk_map: Shape (num_virtual, 3), int64. Columns:
+            [real_doc_id, chunk_start_token, chunk_length_tokens].
+        virtual_sizes: Shape (num_virtual,), int32. Length of each virtual chunk.
+    """
+    real_doc_ids = document_index.astype(np.int64)
+    doc_lens = sequence_lengths[real_doc_ids].astype(np.int64)
+
+    # Number of chunks each document produces (ceil division for oversized docs)
+    num_chunks = np.where(doc_lens <= capacity, 1, (doc_lens + capacity - 1) // capacity)
+    total_virtual = int(num_chunks.sum())
+
+    chunk_map = np.empty((total_virtual, 3), dtype=np.int64)
+    virtual_sizes = np.empty(total_virtual, dtype=np.int32)
+
+    # Cumulative output positions: chunk_offsets[i] = first output row for doc i
+    chunk_offsets = np.empty(len(num_chunks) + 1, dtype=np.int64)
+    chunk_offsets[0] = 0
+    np.cumsum(num_chunks, out=chunk_offsets[1:])
+
+    # Fast vectorised path for single-chunk docs (the common case)
+    single = num_chunks == 1
+    single_out = chunk_offsets[:-1][single]
+    chunk_map[single_out, 0] = real_doc_ids[single]
+    chunk_map[single_out, 1] = 0
+    chunk_map[single_out, 2] = doc_lens[single]
+    virtual_sizes[single_out] = doc_lens[single].astype(np.int32)
+
+    # Scalar loop only for oversized docs (rare)
+    for pos in np.where(~single)[0]:
+        rid = int(real_doc_ids[pos])
+        dlen = int(doc_lens[pos])
+        base = int(chunk_offsets[pos])
+        offset = 0
+        ci = 0
+        while offset < dlen:
+            clen = min(capacity, dlen - offset)
+            chunk_map[base + ci] = [rid, offset, clen]
+            virtual_sizes[base + ci] = clen
+            offset += capacity
+            ci += 1
+
+    return chunk_map, virtual_sizes
+
+
+def _load_bfd_c_library():
+    """Load (or compile then load) the C/C++ BFD packing library.
+
+    Uses a segment-tree + min-heap structure for O(n log C) best-fit lookup,
+    ~10-15x faster than pure-Python bisect at million-doc scale. Thread-safe.
+    Returns the loaded ctypes library, or None if unavailable.
+    """
+    import ctypes
+    import subprocess
+
+    _dir = os.path.dirname(os.path.abspath(__file__))
+    so_path  = os.path.join(_dir, "libbfd_pack.so")
+    cpp_path = os.path.join(_dir, "bfd_pack.cpp")
+
+    if os.path.isfile(so_path):
+        try:
+            lib = ctypes.CDLL(so_path)
+            lib.bfd_pack.argtypes = [
+                ctypes.POINTER(ctypes.c_int), # sorted_positions
+                ctypes.POINTER(ctypes.c_long), # doc_lengths
+                ctypes.c_int, # num_docs
+                ctypes.c_int, # capacity
+                ctypes.POINTER(ctypes.c_int), # document_index
+                ctypes.POINTER(ctypes.c_int), # doc_idx_out
+                ctypes.POINTER(ctypes.c_int), # boundaries_out
+                ctypes.POINTER(ctypes.c_int), # num_bins_out
+            ]
+            lib.bfd_pack.restype = None
+            return lib
+        except OSError:
+            pass
+
+    # Compile from source (prefer C++, fall back to C)
+    for src_path, compiler in [(cpp_path, "g++")]:
+        if os.path.isfile(src_path):
+            try:
+                subprocess.check_call(
+                    [compiler, "-O3", "-shared", "-fPIC", "-o", so_path, src_path],
+                    stderr=subprocess.DEVNULL,
+                )
+                return _load_bfd_c_library()
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                continue
+
+    return None
+
+
+_bfd_c_lib = _load_bfd_c_library()
+
+
 def _build_sample_idx_bfd(
     sequence_lengths: np.ndarray,
     document_index: np.ndarray,
@@ -41,6 +293,9 @@ def _build_sample_idx_bfd(
     Sorts documents by decreasing length and assigns each to the bin with the
     least remaining capacity that still fits. Produces fewer bins (less padding)
     than greedy sequential packing when document lengths vary.
+
+    Uses the C-accelerated implementation when available, otherwise a pure-Python
+    bisect-based fallback.
 
     Args:
         sequence_lengths: Array of document lengths indexed by document ID.
@@ -54,6 +309,52 @@ def _build_sample_idx_bfd(
         sample_index: Shape (num_bins + 1, 2) boundary array. Column 0 holds
             offsets into reordered_document_index; column 1 is always 0.
     """
+    if _bfd_c_lib is not None:
+        return _build_sample_idx_bfd_c(sequence_lengths, document_index, seq_length, add_extra_token)
+    return _build_sample_idx_bfd_python(sequence_lengths, document_index, seq_length, add_extra_token)
+
+
+def _build_sample_idx_bfd_c(sequence_lengths, document_index, seq_length, add_extra_token):
+    """C-accelerated BFD bin packing via ctypes. See _build_sample_idx_bfd."""
+    import ctypes
+
+    capacity = seq_length + add_extra_token
+    num_docs = len(document_index)
+
+    doc_lengths = sequence_lengths[document_index].astype(np.int64)
+    sorted_positions = np.argsort(-doc_lengths, kind='stable').astype(np.int32)
+    doc_index_i32 = document_index.astype(np.int32)
+
+    doc_idx_out = np.empty(num_docs, dtype=np.int32)
+    boundaries_out = np.empty(num_docs + 1, dtype=np.int32)
+    num_bins_out = ctypes.c_int(0)
+
+    _bfd_c_lib.bfd_pack(
+        sorted_positions.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        doc_lengths.ctypes.data_as(ctypes.POINTER(ctypes.c_long)),
+        num_docs, capacity,
+        doc_index_i32.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        doc_idx_out.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        boundaries_out.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        ctypes.byref(num_bins_out),
+    )
+
+    nb = num_bins_out.value
+    reordered = doc_idx_out[:num_docs].astype(document_index.dtype)
+    sample_index = np.zeros((nb + 1, 2), dtype=document_index.dtype)
+    sample_index[:, 0] = boundaries_out[:nb + 1].astype(document_index.dtype)
+
+    assert boundaries_out[nb] == num_docs, f"BFD placed {boundaries_out[nb]} docs but expected {num_docs}"
+    return reordered, sample_index
+
+
+def _build_sample_idx_bfd_python(
+    sequence_lengths: np.ndarray,
+    document_index: np.ndarray,
+    seq_length: int,
+    add_extra_token: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Pure-Python BFD fallback using bisect. See _build_sample_idx_bfd."""
     capacity = seq_length + add_extra_token
     num_docs = len(document_index)
 
@@ -132,20 +433,22 @@ class ApertusSFTDataset(GPTDataset):
 
     Loads already-tokenized conversation data from Megatron indexed datasets (.bin/.idx).
     Supports single-document and multi-document packing modes (--ap-sft-pack-samples).
+    Supports mixed pre-training + SFT binaries: pre-training sub-documents (no
+    <|system_start|>) receive full loss; SFT sub-documents have their prompt scaffold
+    masked and only assistant answer tokens contribute to the loss.
+
+    Oversized documents (longer than seq_length) are split into capacity-sized virtual
+    chunks at index-build time via _build_virtual_docs, eliminating truncation.
 
     Loss masking operates in two modes:
       1. **From disk** (--ap-sft-load-loss-mask): Each document stores tokens and a pre-computed
          loss mask concatenated together ([tokens, loss_mask]). The dataset splits them at load
          time and uses the mask as-is.
-      2. **On the fly** (default): The loss mask is built at runtime by detecting assistant
-         response regions. This requires the tokenizer to expose ``sft_assistant_begin_sequence``
-         and ``sft_assistant_end_sequence`` attributes (see HuggingFaceTokenizer in
-         megatron/training/tokenizer/tokenizer.py). Everything outside assistant regions is
-         masked (or weighted by --ap-sft-plw). Special tokens (BOS, EOD, assistant begin) can
-         optionally be masked via --ap-sft-mask-special-tokens.
+      2. **On the fly** (default): loss_mask starts at 1 for all tokens. Per sub-document,
+         _process_subdoc_masking zeros scaffold regions for SFT docs and leaves pre-training
+         sub-documents (no <|system_start|>) fully unmasked.
 
     Note: Goldfish loss (--goldfish-loss) is not supported and will be ignored if enabled.
-    Note: Omnimodal weighting during loss mask creation is not supported. We simply have all assistant tokens unmasked.
     """
     def __init__(
         self,
@@ -182,33 +485,22 @@ class ApertusSFTDataset(GPTDataset):
         self._eod_token_id = self.tokenizer.eod
         self._bos_token_id = self.tokenizer.bos
 
-        # Load pre-computed SFT sequences from tokenizer config (tokenizer_config.json).
-        # These must be set as pre-tokenized token ID lists, e.g. by
-        # add_emu3_tokens_llama3_vision_instruct.py. Some models use separate assistant/user
-        # end sequences, others share a common eot token.
-        missing = [attr for attr in ('sft_assistant_begin_sequence', 'sft_assistant_end_sequence')
-                   if not hasattr(self.tokenizer, attr)]
-        if missing:
+        # Special token IDs for subdoc-based masking. Replaces the old
+        # sft_assistant_begin/end_sequence + tokens_to_mask machinery.
+        try:
+            self._special_ids = _get_synthetic_special_ids(self.tokenizer)
+            log_single_rank(logger, logging.INFO,
+                f"Synthetic masking IDs — SYS={self._special_ids.system_start}, "
+                f"ASST={self._special_ids.assistant_start}, "
+                f"AEND={self._special_ids.assistant_end}, "
+                f"BOS={self._special_ids.bos}, "
+                f"DEV={self._special_ids.developer_start}")
+        except KeyError as e:
             raise ValueError(
-                f"Tokenizer is missing required SFT attributes: {missing}. "
-                f"ApertusSFTDataset requires 'sft_assistant_begin_sequence' and "
-                f"'sft_assistant_end_sequence' (list of token IDs) to be defined in "
-                f"tokenizer_config.json."
-            )
-        self._sft_assistant_begin_sequence = torch.tensor(self.tokenizer.sft_assistant_begin_sequence, dtype=torch.long)
-        self._sft_assistant_end_sequence = torch.tensor(self.tokenizer.sft_assistant_end_sequence, dtype=torch.long)
-
-        # Configure token (sequences) to remove from loss calculation
-        self.tokens_to_mask = []
-        if self.config.sft_mask_special_tokens and not self.config.sft_load_loss_mask:
-            # add tokenizer special tokens like EOS, BOS and assistant begin to be masked. Never mask End of turn.
-            # TODO: in current apertus tokenizer eod is eot by default!!
-            self.tokens_to_mask.append(torch.tensor([self._eod_token_id], dtype=torch.long))
-            self.tokens_to_mask.append(torch.tensor([self._bos_token_id], dtype=torch.long))
-            self.tokens_to_mask.append(self._sft_assistant_begin_sequence)  # already a tensor
-            # user begin and end are masked by default as only assistant unmasked
-        if self.tokens_to_mask:
-            log_single_rank(logger, logging.INFO, f"On the fly masking the following tokens/token-sequences: {[t.tolist() for t in self.tokens_to_mask]}")
+                f"Tokenizer vocab is missing required special token: {e}. "
+                f"ApertusSFTDataset requires <|system_start|>, <|assistant_start|>, "
+                f"and <|assistant_end|> in the tokenizer vocabulary."
+            ) from e
 
         # Set actual model sequence length (config.sequence_length is doubled if loading loss masks from disk)
         if self.config.sft_load_loss_mask:
@@ -231,8 +523,8 @@ class ApertusSFTDataset(GPTDataset):
 
         # Build indices based on packing mode
         if self.config.sft_pack_samples:
-            # Use multi-document packing with sample_index
-            (self.document_index, self.sample_index, self.shuffle_index) = (
+            # Use multi-document packing with sample_index and virtual chunk map
+            (self.document_index, self.sample_index, self.shuffle_index, self.chunk_map) = (
                 self._build_packing_document_to_sample_indices()
             )
             self._using_packed_samples = True
@@ -240,6 +532,7 @@ class ApertusSFTDataset(GPTDataset):
 
             # Use simple single-document indexing
             self.document_index = self._build_single_document_indices()
+            self.chunk_map = None
             self._using_packed_samples = False
 
     @staticmethod
@@ -264,7 +557,7 @@ class ApertusSFTDataset(GPTDataset):
         Log statistics about packed samples.
 
         Args:
-            document_index: Array of document IDs
+            document_index: Array of document IDs (virtual chunk IDs in packing mode)
             sample_index: Array of sample boundaries
             from_cache: Whether the indices were loaded from cache
         """
@@ -291,23 +584,21 @@ class ApertusSFTDataset(GPTDataset):
     def _build_packing_document_to_sample_indices(self):
         """
         Build indices for packed document sampling. Always packs exactly one epoch so that
-        every document is used. If more samples are requested than one epoch provides, the
-        shuffle index is tiled with independent permutations (no re-packing).
+        every document is used. Oversized documents are pre-split into capacity-sized virtual
+        chunks via _build_virtual_docs so no tokens are lost to truncation. If more samples
+        are requested than one epoch provides, the shuffle index is tiled with independent
+        permutations (no re-packing).
 
-        Returns a tuple of three indices:
-        - document_index: Shuffled document IDs for one epoch
+        Returns a tuple of four indices:
+        - document_index: Permutation of virtual chunk IDs (0..num_virtual-1) in packing order
         - sample_index: Maps sample boundaries to (document_index position, offset) pairs
         - shuffle_index: Permutation indices, possibly tiled to meet num_samples
-
-        Returns:
-            Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]:
-                - document_index: Shape (num_documents,) - shuffled document IDs for one epoch
-                - sample_index: Shape (num_epoch_samples + 1, 2) - sample boundaries as [doc_idx_index, offset=0]
-                - shuffle_index: Shape (num_total_samples,) - permutation indices, tiled if needed
+        - chunk_map: Shape (num_virtual, 3) mapping virtual chunk ID to
+          [real_doc_id, chunk_start_token, chunk_length_tokens]
         """
         from megatron.core.datasets import helpers
 
-        index_names = ["document_index", "sample_index", "shuffle_index"]
+        index_names = ["document_index", "sample_index", "shuffle_index", "chunk_map"]
         cache_hit = self.cache_manager.cache_exists(index_names)
 
         if self.cache_manager.get_cache_path():
@@ -340,22 +631,38 @@ class ApertusSFTDataset(GPTDataset):
             else:
                 sequence_lengths_for_cpp = self.dataset.sequence_lengths
 
-            # Build the sample index using the configured packing strategy
+            # Build virtual document list: oversized docs are split into capacity-sized
+            # chunks so they never waste space. Each virtual entry maps to a slice of a
+            # real document loadable via dataset.get(doc_id, offset=start, length=length).
+            capacity = sequence_length + self.config.add_extra_token_to_sequence
+            chunk_map, virtual_sizes = _build_virtual_docs(
+                document_index, sequence_lengths_for_cpp, capacity
+            )
+            num_virtual = len(virtual_sizes)
+            virtual_idx = np.arange(num_virtual, dtype=np.int32)
+
+            n_extra = num_virtual - len(document_index)
+            log_single_rank(logger, logging.INFO,
+                f"  Document chunking: {len(document_index)} docs → {num_virtual} virtual chunks"
+                + (f" ({n_extra} extra chunks from oversized docs)" if n_extra > 0 else " (no oversized docs)"))
+
+            # Build the sample index using the configured packing strategy.
+            # We pass virtual_sizes as the sequence_lengths lookup table and virtual_idx
+            # as the document_index (identity: virtual_idx[i] == i).
             if self.config.sft_packing_strategy == "bfd":
-                log_single_rank(logger, logging.INFO, "Using Best-Fit Decreasing packing strategy")
+                _accel = "C-accelerated" if _bfd_c_lib is not None else "Python fallback"
+                log_single_rank(logger, logging.INFO,
+                    f"Using Best-Fit Decreasing packing strategy ({_accel})")
                 document_index, sample_index = _build_sample_idx_bfd(
-                    sequence_lengths_for_cpp,
-                    document_index,
-                    sequence_length,
+                    virtual_sizes, virtual_idx, sequence_length,
                     add_extra_token=self.config.add_extra_token_to_sequence,
                 )
             else:
                 sample_index = helpers.build_sample_idx_packed_whole_docs(
-                    sequence_lengths_for_cpp,
-                    document_index,
-                    sequence_length,
+                    virtual_sizes, virtual_idx, sequence_length,
                     add_extra_token_to_sequence=self.config.add_extra_token_to_sequence,
                 )
+                document_index = virtual_idx
 
             # Log packing statistics for the single epoch
             self._log_packing_statistics(document_index, sample_index, from_cache=False)
@@ -370,13 +677,14 @@ class ApertusSFTDataset(GPTDataset):
                 "description": self.unique_description,
                 "document_index": document_index,
                 "sample_index": sample_index,
-                "shuffle_index": shuffle_index
+                "shuffle_index": shuffle_index,
+                "chunk_map": chunk_map,
             })
 
             t_end = time.time()
             log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {t_end - t_beg:4f} seconds")
 
-            return document_index, sample_index, shuffle_index
+            return document_index, sample_index, shuffle_index, chunk_map
 
         # Load from cache
         log_single_rank(
@@ -386,9 +694,10 @@ class ApertusSFTDataset(GPTDataset):
         document_index = indices["document_index"]
         sample_index = indices["sample_index"]
         shuffle_index = indices["shuffle_index"]
+        chunk_map = indices["chunk_map"]
         self._log_packing_statistics(document_index, sample_index, from_cache=True)
 
-        return document_index, sample_index, shuffle_index
+        return document_index, sample_index, shuffle_index, chunk_map
 
     def _build_shuffle_index_with_tiling(
         self, num_epoch_samples: int, numpy_random_state: np.random.RandomState
@@ -521,7 +830,8 @@ class ApertusSFTDataset(GPTDataset):
         Packs documents as defined in pre-computed index.
             - sample-index: defines ranges of documents to be packed together ex. sample i has interval ( doc-idx[sample-idx[i]], doc-idx[sample-idx[i+1]] (
             - shuffle-index: randomizes packed samples (positions in sample index)
-            - document-index: maps documents to low-level-dset documents (randomize raw doc order)
+            - document-index: permutation of virtual chunk IDs; each is looked up via chunk_map
+              to obtain [real_doc_id, chunk_start, chunk_len]
 
         Args:
             idx (int): Index of sample to retrieve
@@ -546,9 +856,13 @@ class ApertusSFTDataset(GPTDataset):
         doc_end_indices = [] # store positions of sample ends (use to reset pos id and attn mask)
 
         for i in range(doc_index_beg, doc_index_end):
-            # Get the actual document ID from document_index & load whole document
-            doc_id = self.document_index[i]
-            document = self.dataset.get(doc_id)
+            # chunk_map[virtual_id] = [real_doc_id, chunk_start, chunk_len]. Load exactly the
+            # chunk slice; no full-document load or truncation needed (chunks <= capacity).
+            virtual_id = int(self.document_index[i])
+            real_doc_id = int(self.chunk_map[virtual_id, 0])
+            chunk_start = int(self.chunk_map[virtual_id, 1])
+            chunk_len   = int(self.chunk_map[virtual_id, 2])
+            document = self.dataset.get(real_doc_id, offset=chunk_start, length=chunk_len)
 
             # If loading loss masks from disk, split the document into tokens and loss_mask
             if self.config.sft_load_loss_mask:
@@ -557,16 +871,11 @@ class ApertusSFTDataset(GPTDataset):
                 doc_tokens = document[:doc_len]
                 doc_loss_mask = document[doc_len:]
 
-                # Truncate document and end with EOD if too long
-                doc_tokens = self._truncate_sequence_if_needed(doc_tokens, target_length, self._eod_token_id)
-                doc_loss_mask = self._truncate_sequence_if_needed(doc_loss_mask, target_length, 0.0)
-
                 document_tokens.append(doc_tokens)
                 document_loss_masks.append(doc_loss_mask)
                 doc_end_indices.append(doc_tokens.size)
             else:
                 # Original behavior: no loss mask splitting
-                document = self._truncate_sequence_if_needed(document, target_length, self._eod_token_id)
                 document_tokens.append(document)
                 doc_end_indices.append(document.size)
 
@@ -589,7 +898,7 @@ class ApertusSFTDataset(GPTDataset):
             # This should never happen with correct packing - raise error
             raise RuntimeError(
                 f"Packed sample {idx} exceeded target length ({len(text)} > {target_length}). "
-                f"This indicates a bug in build_sample_idx_packed_whole_docs. "
+                f"This indicates a bug in _build_virtual_docs or the packing index. "
                 f"Sample contains {len(document_tokens)} documents."
             )
 
@@ -686,10 +995,12 @@ class ApertusSFTDataset(GPTDataset):
             labels = torch.roll(text, shifts=-1, dims=0)
             labels[-1] = self._pad_token_id
 
-        # Generate loss-mask, position-ids, assistant mask and optionally attention mask. If PLW activated, loss mask will have partial weight for user input tokens
+        # Generate loss-mask, position-ids, assistant mask and optionally attention mask.
+        # tokens are passed for BOS detection in subdoc masking; labels drive matching.
         attention_mask, loss_mask, position_ids, assistant_mask = self._get_ltor_masks_and_position_ids(
-            labels, # labels are used to create the loss and assistant mask
-            eos_idx, # eos_idx is based on tokens(NOT labels) and controls position-ids and attn mask reset
+            tokens,
+            labels,
+            eos_idx,
             torch.from_numpy(preloaded_loss_mask).float() if preloaded_loss_mask is not None else None
         )
 
@@ -716,11 +1027,16 @@ class ApertusSFTDataset(GPTDataset):
                 "assistant_mask": assistant_mask,
             }
 
-    def _get_ltor_masks_and_position_ids(self, data: torch.Tensor, eos_indices: np.ndarray, preloaded_loss_mask: Optional[torch.Tensor] = None) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    def _get_ltor_masks_and_position_ids(self, tokens: torch.Tensor, data: torch.Tensor, eos_indices: np.ndarray, preloaded_loss_mask: Optional[torch.Tensor] = None) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """
-        Build masks and position id for SFT data. Possibility to mask arbitrary (also special) token(sequences).
-            1. Can mask full user prompts or with prompt-loss-weight (plw)
-            2. Can mask arbitrary token sequences (e.g. assistant begin, assistant end, BOS, EOS)
+        Build masks and position ids for mixed pre-training + SFT data.
+        loss_mask starts at 1 for all tokens (pre-training default). Per-subdoc scaffold
+        masking via _process_subdoc_masking then zeros prompt regions for SFT sub-documents,
+        leaving pre-training sub-documents (no <|system_start|>) fully unmasked.
+        Also creates an assistant_mask to identify assistant response tokens (always built
+        on-the-fly, even when preloaded_loss_mask is used).
+            1. Can mask full user prompts (per-subdoc, always)
+            2. Special tokens are handled implicitly via _process_subdoc_masking
             3. Creates attention mask if configured. The attention mask will exclude padding tokens from attention.
             4. Can equalize sample loss for packed and non-packed sequences (loss = 1 for each sample in seq)
 
@@ -729,18 +1045,18 @@ class ApertusSFTDataset(GPTDataset):
             - Attention mask blocks cross-document attention at EOD boundaries
             - ASSUMES NO WRONG PLACED EOD (=ONLY PROPERLY BOUNDARY OF SAMPLES)
 
-        Also creates an assistant_mask to identify assistant response tokens for separate loss tracking.
-
         Args:
-            data:                   labels
+            tokens:                 tokens (text[:-1]), used only for BOS detection in subdoc masking.
+            data:                   labels (text[1:]).
             eos_indices:            indices of document boundaries (calculated based on sample loading from low level dataset as
                                     sft data can be contaminated with eod or eod missing).
-            preloaded_loss_mask:    Optional pre-computed loss mask loaded from disk. If provided, user prompt masking
-                                    and special token masking are skipped for loss_mask.
+            preloaded_loss_mask:    Optional pre-computed loss mask loaded from disk. If provided, scaffold
+                                    masking is skipped for loss_mask (but assistant_mask is still populated).
         """
 
         position_ids = torch.arange(self.model_seq_length, dtype=torch.long)
-        loss_mask = preloaded_loss_mask.to(device=data.device) if preloaded_loss_mask is not None else torch.zeros(self.model_seq_length, dtype=torch.float, device=data.device)
+        # Start at ones (pre-training default). Scaffold regions are zeroed by _process_subdoc_masking.
+        loss_mask = preloaded_loss_mask.to(device=data.device) if preloaded_loss_mask is not None else torch.ones(self.model_seq_length, dtype=torch.float, device=data.device)
 
         # 0) For packed samples: reset position IDs at document boundaries
         if self._using_packed_samples:
@@ -752,36 +1068,17 @@ class ApertusSFTDataset(GPTDataset):
                         to_subtract = position_ids[eod_idx].clone() + 1
                         position_ids[(eod_idx + 1):] -= to_subtract
 
-        # 1) unmask assistant parts and set rest to plw value (if not loaded from disk) otherwise assistant loss needed
-        #    to keep track of assistant loss
-        # NOTE: Left truncation can cut into an assistant response, leaving an orphaned end_seq
-        # with no preceding begin_seq. In that case tokens before the first end_seq are incorrectly
-        # treated as non-assistant. A fix would detect orphaned end markers and mask 0..first_end
-        # as assistant. Same applies to right truncation of pre-packed data cutting through a begin_seq.
-        begin_seq = self._sft_assistant_begin_sequence.to(dtype=data.dtype, device=data.device)
-        end_seq = self._sft_assistant_end_sequence.to(dtype=data.dtype, device=data.device)
-        assistant_mask = get_matching_mask_by_start_end(data, begin_seq, end_seq)
+        # 1) Per-subdoc scaffold masking + assistant_mask.
+        # Pre-training sub-documents pass through Case 1 of _process_subdoc_masking
+        # unchanged (loss_mask stays 1). SFT sub-documents have scaffold zeroed.
+        # When preloaded_loss_mask is given, scaffold writes go to a scratch tensor so the
+        # disk-loaded mask is preserved; assistant_mask is still populated.
+        assistant_mask = torch.zeros(self.model_seq_length, dtype=torch.bool, device=data.device)
+        scaffold_target = loss_mask if preloaded_loss_mask is None else torch.zeros_like(loss_mask)
+        for span_start, span_end in _get_subdoc_spans_from_eos(eos_indices, self.model_seq_length):
+            _process_subdoc_masking(data, tokens, scaffold_target, assistant_mask, span_start, span_end, self._special_ids)
 
-        # Only apply to loss_mask if NOT loading from disk
-        if preloaded_loss_mask is None:
-            loss_mask[assistant_mask] = 1
-            if self.sft_plw_value > 0:
-                loss_mask[~assistant_mask] = self.sft_plw_value # value is 0 by default for full masking
-
-
-        # 2) Mask loss for special tokens (if activated) - only if not load loss from disk
-        if preloaded_loss_mask is None:
-            for t in self.tokens_to_mask:
-                t_tensor = t.to(dtype=data.dtype, device=data.device)
-                if len(t_tensor) == 1:
-                    mask = (data == t_tensor[0])
-                elif len(t_tensor) > 1:
-                    mask = get_matching_mask(data, t_tensor, only_begin=False)
-                else:
-                    raise ValueError(f"Invalid token to mask: {t}")
-                loss_mask[mask] = 0.0
-
-        # 3) Create attention mask: mask attention from/to padding tokens
+        # 2) Create attention mask: mask attention from/to padding tokens
         if self.config.create_attention_mask:
             attention_mask = torch.tril(
                 torch.ones((self.model_seq_length, self.model_seq_length), device=data.device)
@@ -807,12 +1104,12 @@ class ApertusSFTDataset(GPTDataset):
         else:
             attention_mask = None
 
-        # 4) Make sure padding tokens are masked even if they are part of an assistant answer somehow TODO: check!
+        # 3) Make sure padding tokens are masked even if they are part of an assistant answer somehow TODO: check!
         loss_mask[data == self._pad_token_id] = 0.0
         if assistant_mask is not None:
             assistant_mask[data == self._pad_token_id] = False
 
-        # 5) Equalize sample loss
+        # 4) Equalize sample loss
         if self.config.sft_equalize_sample_loss:
             # Add small epsilon to prevent division by very small numbers
             eps = 1e-10
@@ -839,89 +1136,6 @@ class ApertusSFTDataset(GPTDataset):
                         loss_mask[start_idx:] = segment_mask / segment_loss_sum
 
         return attention_mask, loss_mask, position_ids, assistant_mask
-
-
-def get_matching_mask(sequence, query: torch.Tensor, only_begin:bool=True):
-    """
-    Given a sequence and a query, return a mask indicating which positions in the sequence match the query.
-    If the query has len > 1, only_begin arg will determine whether the mask is true only where
-    the query begins in the sequence. Otherwise, full query is masked.
-    """
-    query_len = len(query)
-    # Vectorized pattern matching using unfold
-    if query_len == 1:
-        matches = (sequence == query[0])
-    else:
-        # Create sliding windows
-        windows = sequence.unfold(0, query_len, 1)
-        # Compare all windows at once
-        matches = (windows == query).all(dim=1)
-        # Pad to original length
-        matches = F.pad(matches, (0, query_len - 1), value=False)
-        if not only_begin:
-            matches_float = matches.float().unsqueeze(0).unsqueeze(0)  # (1, 1, N)
-            kernel = torch.ones(1, 1, query_len, device=sequence.device)
-            expanded = F.conv1d(matches_float, kernel, padding=query_len - 1)
-            matches = (expanded.squeeze(0).squeeze(0)[:len(sequence)] > 0)
-    return matches
-
-
-def get_matching_mask_by_start_end(sequence, begin_seq: torch.Tensor, end_seq: torch.Tensor):
-    """
-    Given a sequence and a start and end query, return a mask indicating which positions in the sequence
-    are between the start and end queries (inclusive).
-
-    Limitation: If the sequence starts mid-region (e.g. due to left truncation), an orphaned end_seq
-    without a preceding begin_seq will be ignored, leaving those leading tokens unmasked.
-    """
-    mask = torch.zeros(len(sequence), dtype=torch.bool, device=sequence.device)
-    begin_len = len(begin_seq)
-    end_len = len(end_seq)
-
-    if 0 < begin_len <= len(sequence):
-        matches_begin = get_matching_mask(sequence, begin_seq, only_begin=True)
-
-        if 0 < end_len <= len(sequence):
-            matches_end = get_matching_mask(sequence, end_seq, only_begin=True)
-            end_indices = torch.where(matches_end)[0]
-        else:
-            end_indices = torch.empty(0, dtype=torch.long, device=sequence.device)
-
-        begin_indices = torch.where(matches_begin)[0]
-
-        # Vectorized masking
-        if len(begin_indices) > 0 and len(end_indices) > 0:
-            # For each begin, find the next ends (vectorized)
-            end_matrix = end_indices.unsqueeze(0) > begin_indices.unsqueeze(1)
-            has_valid_end = end_matrix.any(dim=1)
-            first_end_idx = end_matrix.int().argmax(dim=1)
-
-            # Compute end positions for each begin
-            end_positions = torch.where(
-                has_valid_end,
-                end_indices[first_end_idx] + end_len,
-                len(mask)
-            )
-
-            # Create ranges and mask in one go, Shape: (num_begins, max_range_len)
-            max_len = (end_positions - begin_indices).max().item()
-            ranges = torch.arange(max_len, device=sequence.device).unsqueeze(0)
-            lengths = (end_positions - begin_indices).unsqueeze(1)
-
-            # Get all indices to mask
-            mask_positions = begin_indices.unsqueeze(1) + ranges
-            valid_mask = ranges < lengths
-            indices_to_mask = mask_positions[valid_mask]
-
-            mask[indices_to_mask] = True
-        elif len(begin_indices) > 0:
-            # No end sequences, mask from each begin to the end
-            max_len = len(mask) - begin_indices.min().item()
-            ranges = torch.arange(max_len, device=sequence.device).unsqueeze(0)
-            mask_positions = begin_indices.unsqueeze(1) + ranges
-            valid = mask_positions < len(mask)
-            mask[mask_positions[valid]] = True
-    return mask
 
 
 class IndexCacheManager:

--- a/megatron/training/datasets/bfd_pack.cpp
+++ b/megatron/training/datasets/bfd_pack.cpp
@@ -1,0 +1,144 @@
+// bfd_pack.cpp — Thread-safe Best-Fit Decreasing bin packing.
+//
+// Compile: g++ -O3 -shared -fPIC -o libbfd_pack.so bfd_pack.cpp
+//
+// Algorithm: segment tree over remaining-capacity values [0..capacity],
+// with a min-heap of bin IDs at each capacity level.  Finding the best
+// bin for a document of size s costs O(log C) where C = capacity (~32k),
+// regardless of how many bins are open.
+//
+// Thread-safe: all state is local to each bfd_pack() call.
+
+#include <vector>
+#include <queue>
+#include <cstring>
+
+// Tracks which remaining-capacity values have at least one open bin.
+// Each leaf corresponds to one capacity value; internal nodes store the
+// OR of their children (1 = at least one non-empty bucket below).
+
+class SegmentTree {
+    int n_;                                             // number of leaves (power of 2)
+    std::vector<int> tree_;                             // 1-indexed, size 4*n_
+    std::vector<std::priority_queue<int,              // min-heap per capacity value
+                std::vector<int>, std::greater<int>>> buckets_;
+
+public:
+    explicit SegmentTree(int capacity) {
+        // Round up to next power of 2
+        n_ = 1;
+        while (n_ <= capacity) n_ <<= 1;
+        tree_.assign(4 * n_, 0);
+        buckets_.resize(n_);
+    }
+
+    // Find the smallest remaining capacity >= target that has an open bin.
+    // Returns -1 if none exists.
+    int find_best_fit(int target) const {
+        return query(target, 1, 0, n_ - 1);
+    }
+
+    // Add a bin to the bucket for the given remaining capacity.
+    void add_bin(int remaining, int bin_id) {
+        buckets_[remaining].push(bin_id);
+        update(remaining, 1, 0, n_ - 1);
+    }
+
+    // Remove and return the smallest bin_id from the given capacity bucket.
+    int pop_bin(int remaining) {
+        int bin_id = buckets_[remaining].top();
+        buckets_[remaining].pop();
+        update(remaining, 1, 0, n_ - 1);
+        return bin_id;
+    }
+
+private:
+    void update(int pos, int node, int lo, int hi) {
+        if (lo == hi) {
+            tree_[node] = buckets_[pos].empty() ? 0 : 1;
+            return;
+        }
+        int mid = (lo + hi) / 2;
+        if (pos <= mid) update(pos, 2 * node,     lo, mid);
+        else            update(pos, 2 * node + 1, mid + 1, hi);
+        tree_[node] = tree_[2 * node] | tree_[2 * node + 1];
+    }
+
+    int query(int target, int node, int lo, int hi) const {
+        if (!tree_[node] || hi < target) return -1;
+        if (lo == hi) return lo;
+        int mid = (lo + hi) / 2;
+        int left = query(target, 2 * node, lo, mid);
+        if (left != -1) return left;
+        return query(target, 2 * node + 1, mid + 1, hi);
+    }
+};
+
+
+// extern "C" so Python ctypes can call it by name.
+
+extern "C" void bfd_pack(
+    const int  *sorted_positions,   // indices into doc_lengths, sorted by decreasing length
+    const long *doc_lengths,        // length of each document (indexed by position)
+    int         num_docs,           // total number of documents
+    int         capacity,           // bin capacity (seq_length + extra_token)
+    const int  *document_index,     // maps position -> actual document ID
+    // outputs:
+    int        *doc_idx_out,        // reordered document IDs  (size: num_docs)
+    int        *boundaries_out,     // bin boundary offsets     (size: num_docs + 1, worst case)
+    int        *num_bins_out        // number of bins created
+) {
+    SegmentTree tree(capacity);
+    std::vector<std::vector<int>> bins;     // bins[bin_id] = list of positions
+
+    for (int i = 0; i < num_docs; i++) {
+        int  pos    = sorted_positions[i];
+        long length = doc_lengths[pos];
+
+        // Oversized document: gets its own bin
+        if (length > capacity) {
+            bins.push_back({pos});
+            continue;
+        }
+
+        // Zero-length document: tuck into any existing bin, or open a new one
+        if (length == 0) {
+            int r = tree.find_best_fit(0);
+            if (r >= 0) {
+                int bid = tree.pop_bin(r);
+                bins[bid].push_back(pos);
+                tree.add_bin(r, bid);               // remaining unchanged
+            } else {
+                int bid = static_cast<int>(bins.size());
+                bins.push_back({pos});
+                tree.add_bin(capacity, bid);
+            }
+            continue;
+        }
+
+        // Normal case: find tightest-fitting bin, or open a new one
+        int r = tree.find_best_fit(static_cast<int>(length));
+        if (r >= 0) {
+            int bid   = tree.pop_bin(r);
+            int new_r = r - static_cast<int>(length);
+            bins[bid].push_back(pos);
+            if (new_r > 0) tree.add_bin(new_r, bid);
+        } else {
+            int bid   = static_cast<int>(bins.size());
+            int new_r = capacity - static_cast<int>(length);
+            bins.push_back({pos});
+            if (new_r > 0) tree.add_bin(new_r, bid);
+        }
+    }
+
+    // Flatten bins into contiguous output arrays
+    int offset = 0;
+    for (int b = 0; b < static_cast<int>(bins.size()); b++) {
+        boundaries_out[b] = offset;
+        for (int pos : bins[b]) {
+            doc_idx_out[offset++] = document_index[pos];
+        }
+    }
+    boundaries_out[bins.size()] = offset;
+    *num_bins_out = static_cast<int>(bins.size());
+}


### PR DESCRIPTION
**Motivation**

Previous implementation worked correctly for SFT, but did not scale to pre-training workloads and eventually led to NCCL timeouts under tests with 4000 files and billions of tokens.

**Features Introduced**

The main bottleneck was the packing stage:

- bisect.insort() incurs O(N) insertion cost, making the overall complexity O(N log N + NxB), which degrades to ~O(N^2) for large corpora (N = number of documents, B = number of bins). Replacing it with SortedList reduced insertion to O(log N) and improved the complexity to O(N log N), but Python overhead remained a bottleneck at scale.
To fully address this, the default implementation was changed to C++ (python implementation is still available).

To correctly adapt the pipeline for pre-training, the following changes were also introduced:

- Chunking instead of truncation: documents longer than seq_len are split into fixed-length chunks prior to packing. For SFT-derived fragments missing a valid BOS/context, all turns (<|system_start|> ... <|assistant_end|>) are masked to avoid learning from incomplete contexts.
- Support for mixed data regimes: the pipeline now handles both SFT and raw pre-training data. Sub-documents without `<|system_start|>`,`<|developer_start|>` or `<|user_start|>` are treated as pure pre-training samples and incur full loss without masking.

**Tests done**:
- Large run with pre-training + SFT synthetic long context samples: Gives best performance on RULER while keeping the same short context performance. Speed is similar.
- Tests with SFT samples with sample_length > seq_length: The loss is correctly masked.

**Observation on Packing Efficiency**

When most documents are already close to seq_len, best-fit packing becomes inefficient. In the current long-context setting, I regenerated the dataset with a wider length distribution, which significantly improved bin-packing efficiency. This is an important consideration for future dataset construction.