### PR TITLE
Multimodality/vocab extension

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -20,7 +20,6 @@ import torch
 from typing import Optional, Union, List, Dict, Any
 from torch.distributed.checkpoint import FileSystemReader, default_planner
 
-from megatron.core.models.common.embeddings.language_model_embedding import LanguageModelEmbedding
 from megatron.core import dist_checkpointing, mpu, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedObject
 from megatron.core.dist_checkpointing.serialization import get_default_load_sharded_strategy
@@ -1737,26 +1736,10 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                     continue
                 load_model_state_dict(ddp_model[i], state_dict['model%d' % i], strict)
 
-    # Expand the embedding size to make the model multimodal
-    if args.extend_model_vocab:
-        assert args.pipeline_model_parallel_size == 1, \
-            "--extend-model-vocab requires PP=1. Run conversion separately, then train with any PP (requires save as torch_dist cp which is topology agnostic)"
-    if getattr(args, 'total_multimodal_vocab_size', None) is not None and model[0].vocab_size != args.total_multimodal_vocab_size:
-        print_rank_0(f"Expanding model vocab size from {model[0].vocab_size} to {args.total_multimodal_vocab_size}")
-        model[0].vocab_size = args.total_multimodal_vocab_size
-        extend_vocab_and_load_weights(model, state_dict, args.base_vocab_size, mpu)
-
     # Fix up query/key/value matrix ordering if needed.
     checkpoint_version = get_checkpoint_version()
     print_rank_0(f' checkpoint version {checkpoint_version}')
     fix_query_key_value_ordering(model, checkpoint_version)
-    if args.extend_model_vocab:
-        # Save the extended model and stop training since the optimizer state is not compatible
-        # After this you can start a new training with the extended model, just remove the --extend-model-vocab flag
-        # And specify the correct load path
-        # TODO (nirmiger): would it be possible to continue training directly?
-        save_checkpoint(1, model , None, None, 0)
-        sys.exit()
 
     # Optimizer.
     if not release and not args.finetune and not args.no_load_optim:
@@ -1898,96 +1881,6 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 log_printed = True
 
     return iteration, num_floating_point_operations_so_far, tokens_so_far
-
-def extend_vocab_and_load_weights(
-    model: list,
-    state_dict: dict,
-    old_vocab_size: int,
-    mpu,
-):
-    model[0].embedding = LanguageModelEmbedding(
-                config=model[0].config,
-                vocab_size=model[0].vocab_size,
-                max_sequence_length=model[0].max_sequence_length,
-                position_embedding_type=model[0].position_embedding_type,
-                scatter_to_sequence_parallel=model[0].embedding.scatter_to_sequence_parallel,
-            )
-    # Extend the output layer to match the new vocab size
-    model[0].output_layer = tensor_parallel.ColumnParallelLinear(
-                model[0].config.hidden_size,
-                model[0].vocab_size,
-                config=model[0].config,
-                init_method=model[0].config.init_method,
-                bias=False,
-                skip_bias_add=False,
-                gather_output=not model[0].parallel_output,
-                skip_weight_param_allocation=model[0].pre_process
-                and model[0].share_embeddings_and_output_weights,
-                embedding_activation_buffer=model[0].embedding_activation_buffer,
-                grad_output_buffer=model[0].grad_output_buffer,
-            )
-    # Load the pretrained weights into the new embeddings
-    load_expanded_weights(
-        model_weight=model[0].embedding.word_embeddings.weight,
-        ckpt_state_dict=state_dict,
-        global_old_vocab_size=old_vocab_size,
-        global_new_vocab_size=model[0].vocab_size, # EXPAND
-        mpu=mpu,
-        weight_key='embedding.word_embeddings.weight',
-        weight_type='embedding',
-    )
-    # Load the pretrained weights into the new output layer
-    if 'output_layer.weight' in state_dict['model']:
-        load_expanded_weights(
-            model_weight=model[0].output_layer.weight,
-            ckpt_state_dict=state_dict,
-            global_old_vocab_size=old_vocab_size,
-            global_new_vocab_size=model[0].vocab_size,
-            mpu=mpu,
-            weight_key='output_layer.weight',
-            weight_type='output',
-        )
-
-def load_expanded_weights(
-    model_weight: torch.Tensor,
-    ckpt_state_dict: dict,
-    global_old_vocab_size: int,
-    global_new_vocab_size: int,
-    mpu,
-    weight_key: str,
-    weight_type: str = "embedding"  # for logging
-):
-    tp_rank = mpu.get_tensor_model_parallel_rank()
-    tp_size = mpu.get_tensor_model_parallel_world_size()
-    tp_group = mpu.get_tensor_model_parallel_group()
-
-    # Get local shard from checkpoint
-    local_old_weight = ckpt_state_dict['model'][weight_key].contiguous().to(model_weight.device)
-
-    # All-gather old shards
-    gathered_weights = [torch.empty_like(local_old_weight) for _ in range(tp_size)]
-    torch.distributed.all_gather(gathered_weights, local_old_weight, group=tp_group)
-    full_old_weight = torch.cat(gathered_weights, dim=0)  # [global_old_vocab, hidden_dim]
-
-    # Compute new shard slice for this rank
-    base_new_shard = global_new_vocab_size // tp_size
-    remainder = global_new_vocab_size % tp_size
-    new_local_start = tp_rank * base_new_shard
-    new_local_end = new_local_start + base_new_shard
-    if tp_rank == tp_size - 1:
-        new_local_end += remainder
-
-    new_local_vocab_size = new_local_end - new_local_start
-
-    # Determine how many rows we can copy from old weights
-    num_rows_to_copy = max(0, min(global_old_vocab_size - new_local_start, new_local_vocab_size))
-    print(f"Loading {num_rows_to_copy} rows into model {weight_type} from old weight on tp rank {tp_rank}")
-
-    if num_rows_to_copy > 0:
-        with torch.no_grad():
-            model_weight[:num_rows_to_copy].copy_(
-                full_old_weight[new_local_start:new_local_start + num_rows_to_copy]
-            )
 
 
 def _to_dtensor(wrapped_model, model_state_dict):

--- a/tools/checkpoint/loader_apertus.py
+++ b/tools/checkpoint/loader_apertus.py
@@ -49,6 +49,11 @@ def add_arguments(parser):
                        help='Base directory of Megatron repository')
     group.add_argument('--make-vocab-size-divisible-by', type=int, default=128,
                        help='Make vocab size divisible by this value')
+    group.add_argument('--extend-vocab-to', type=int, default=None,
+                       help='If set, pad the input/output embedding tables to this vocab size '
+                            '(used for adding multimodal / image tokens before training). '
+                            'New rows are initialized from the mean of the existing embeddings '
+                            'plus small Gaussian jitter.')
 
 
 def load_args_from_checkpoint(args, load_dir):
@@ -86,6 +91,35 @@ def load_args_from_checkpoint(args, load_dir):
     args.iteration = 1  # '0' doesn't work with some savers
 
     return args
+
+
+def extend_embedding_table(weight: torch.Tensor, new_vocab_size: int) -> torch.Tensor:
+    """Append rows to an embedding / lm_head weight table up to ``new_vocab_size``.
+
+    The new rows are sampled from a Gaussian whose per-dimension mean and std
+    match the empirical distribution of the existing rows. This matches the
+    statistics of the pretrained tokens and converges faster than fixed-std
+    or zero init.
+
+    The first ``weight.shape[0]`` rows of the returned tensor are exactly the
+    input rows (in the same dtype), so any forward pass that only indexes
+    token IDs ``< weight.shape[0]`` is bit-identical to the original.
+    """
+    old_vocab_size = weight.shape[0]
+    if new_vocab_size < old_vocab_size:
+        raise ValueError(
+            f"new_vocab_size={new_vocab_size} is smaller than current vocab size "
+            f"({old_vocab_size}); shrinking is not supported."
+        )
+    if new_vocab_size == old_vocab_size:
+        return weight
+
+    n_new = new_vocab_size - old_vocab_size
+    w_f32 = weight.to(torch.float32)
+    mean = w_f32.mean(dim=0, keepdim=True)
+    std = w_f32.std(dim=0, keepdim=True)
+    new_rows = mean + std * torch.randn(n_new, w_f32.shape[1], dtype=torch.float32)
+    return torch.cat([weight, new_rows.to(weight.dtype)], dim=0)
 
 
 def _load_checkpoint(queue, args):
@@ -169,6 +203,36 @@ def _load_checkpoint(queue, args):
     tokenizer = transformers.AutoTokenizer.from_pretrained(args.tokenizer_model, trust_remote_code=True)
     true_vocab_size = len(tokenizer)
 
+    # Optionally extend the embedding / lm_head tables (e.g. for adding image tokens).
+    # We do the padding here, on the source HF tensors, so that the saver only sees a
+    # checkpoint that already has the new vocab size. This avoids any runtime module
+    # surgery, plays nicely with TP/PP/FSDP, and correctly handles tied embeddings.
+    # It was previously done in megatron/training/checkpointing.py but that
+    # caused various complications and edge cases especially for TP/PP/FSDP.
+    word_embed = hf_model.model.embed_tokens.weight.data
+    lm_head_weight = hf_model.lm_head.weight.data if margs.untie_embeddings_and_output_weights else None
+
+    if args.extend_vocab_to is not None:
+        old_vocab_size = word_embed.shape[0]
+        new_vocab_size = args.extend_vocab_to
+        if new_vocab_size > old_vocab_size:
+            print(f"Extending vocab from {old_vocab_size} to {new_vocab_size} "
+                  f"(+{new_vocab_size - old_vocab_size} rows)")
+            word_embed = extend_embedding_table(word_embed, new_vocab_size)
+            if lm_head_weight is not None:
+                lm_head_weight = extend_embedding_table(lm_head_weight, new_vocab_size)
+
+            # Reflect the new vocab size in args/metadata so the saver builds a model
+            # of the right size and chunks the embedding correctly across TP.
+            true_vocab_size = new_vocab_size
+            margs.vocab_size = new_vocab_size
+            margs.padded_vocab_size = new_vocab_size
+        elif new_vocab_size < old_vocab_size:
+            raise ValueError(
+                f"--extend-vocab-to={new_vocab_size} is smaller than the current vocab size "
+                f"({old_vocab_size}); shrinking is not supported."
+            )
+
     # Build metadata
     md = types.SimpleNamespace()
     md.model_type = args.model_type
@@ -207,7 +271,7 @@ def _load_checkpoint(queue, args):
 
     # Send embeddings
     message = {
-        "word embeddings": hf_model.model.embed_tokens.weight.data,
+        "word embeddings": word_embed,
     }
     queue_put("embeddings", message)
 
@@ -283,7 +347,7 @@ def _load_checkpoint(queue, args):
     # Send output layer (lm_head)
     if md.output_layer:
         message = {
-            "weight": hf_model.lm_head.weight.data,
+            "weight": lm_head_weight,
         }
         queue_put("output layer", message)
 

--- a/tools/checkpoint/loader_apertus.py
+++ b/tools/checkpoint/loader_apertus.py
@@ -52,8 +52,7 @@ def add_arguments(parser):
     group.add_argument('--extend-vocab-to', type=int, default=None,
                        help='If set, pad the input/output embedding tables to this vocab size '
                             '(used for adding multimodal / image tokens before training). '
-                            'New rows are initialized from the mean of the existing embeddings '
-                            'plus small Gaussian jitter.')
+                            'New rows are initialized from the mean and std of the existing embeddings ')
 
 
 def load_args_from_checkpoint(args, load_dir):
@@ -97,9 +96,7 @@ def extend_embedding_table(weight: torch.Tensor, new_vocab_size: int) -> torch.T
     """Append rows to an embedding / lm_head weight table up to ``new_vocab_size``.
 
     The new rows are sampled from a Gaussian whose per-dimension mean and std
-    match the empirical distribution of the existing rows. This matches the
-    statistics of the pretrained tokens and converges faster than fixed-std
-    or zero init.
+    match the empirical distribution of the existing rows.
 
     The first ``weight.shape[0]`` rows of the returned tensor are exactly the
     input rows (in the same dtype), so any forward pass that only indexes


### PR DESCRIPTION
Vocab Extension for Mulitmodality

The previous vocabulary extension approach caused issues when working with larger models, particularly in setups using TP, PP, and FSDP.

This PR addresses those problems by moving the vocabulary extension logic from `checkpointing.py` to `loader_apertus.py`. As a result, the vocabulary is now extended in the Hugging Face (HF) format rather than the Megatron-LM format, which avoids the parallelism-related issues encountered previously.

This is a draft PR, as the feature has not yet been fully validated during training. So far, we have only confirmed that, at inference time in Hugging Face (HF) format, the model continues to produce the same logits for language tokens.