### PR TITLE
Fix stale runtime vocab extension path

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3345,10 +3345,6 @@ def _add_vision_args(parser):
                        dest='data_sharding')
     group.add_argument('--head-lr-mult', type=float, default=1.0,
                        help='learning rate multiplier for head during finetuning')
-    group.add_argument('--extend-model-vocab', action='store_true',
-                       help='Extend model vocabulary with vision tokens. '
-                       'This is useful for multimodal models.')
-
     # pretraining type and backbone selection`
     group.add_argument('--vision-pretraining', action='store_true',
                        help='flag to indicate vision pretraining')

--- a/model_provider.py
+++ b/model_provider.py
@@ -77,13 +77,6 @@ def model_provider(
 
         torch._C._cuda_attach_out_of_memory_observer(oom_observer)
 
-    # Logic to handle additional vocab size for multimodal models
-    if getattr(args, "base_vocab_size", None) is not None and args.base_vocab_size != args.padded_vocab_size:
-        args.total_multimodal_vocab_size = args.padded_vocab_size
-        if args.extend_model_vocab:
-            # Build model with base vocab size first; checkpointing.py will extend embeddings
-            args.padded_vocab_size = args.base_padded_vocab_size
-
     if has_nvidia_modelopt and getattr(args, 'modelopt_enabled', False):
         # [ModelOpt]: Use custom builder + spec when modelopt is enabled
         model_builder = modelopt_gpt_mamba_builder


### PR DESCRIPTION
This is a stacked cleanup PR on top of #112.\n\nIt removes the stale runtime --extend-model-vocab path after vocab extension moved to the Apertus loader:\n- removes the obsolete CLI flag\n- removes model_provider.py logic that shrank padded_vocab_size for the deleted checkpointing expansion flow\n\nValidation:\n- git diff --check\n- python -m py_compile model_provider.py megatron/training/arguments.py\n- grep confirmed no remaining tracked references to extend_model_vocab / extend-model-vocab / total_multimodal_vocab_size / load_expanded_weights / extend_vocab_and_load_weights in the relevant paths