### PR TITLE
Fix: Add max_docs_per_bin and best-fit for optimal pre-training

### DIFF
--- a/megatron/core/datasets/bfd_pack.cpp
+++ b/megatron/core/datasets/bfd_pack.cpp
@@ -1,0 +1,157 @@
+// bfd_pack.cpp — Thread-safe Best-Fit Decreasing bin packing.
+//
+// Compile: g++ -O3 -shared -fPIC -o libbfd_pack.so bfd_pack.cpp
+//
+// Algorithm: segment tree over remaining-capacity values [0..capacity],
+// with a min-heap of bin IDs at each capacity level.  Finding the best
+// bin for a document of size s costs O(log C) where C = capacity,
+// regardless of how many bins are open.
+//
+// Thread-safe: all state is local to each bfd_pack() call.
+//
+// max_docs_per_bin: when >0, bins are withheld from the segment tree once
+// they reach the cap, clamping the upper tail of docs-per-sample. Pass 0
+// to disable.
+
+#include <vector>
+#include <queue>
+#include <cstring>
+
+// Tracks which remaining-capacity values have at least one open bin.
+// Each leaf corresponds to one capacity value; internal nodes store the
+// OR of their children (1 = at least one non-empty bucket below).
+
+class SegmentTree {
+    int n_;                                             // number of leaves (power of 2)
+    std::vector<int> tree_;                             // 1-indexed, size 4*n_
+    std::vector<std::priority_queue<int,              // min-heap per capacity value
+                std::vector<int>, std::greater<int>>> buckets_;
+
+public:
+    explicit SegmentTree(int capacity) {
+        // Round up to next power of 2
+        n_ = 1;
+        while (n_ <= capacity) n_ <<= 1;
+        tree_.assign(4 * n_, 0);
+        buckets_.resize(n_);
+    }
+
+    // Find the smallest remaining capacity >= target that has an open bin.
+    // Returns -1 if none exists.
+    int find_best_fit(int target) const {
+        return query(target, 1, 0, n_ - 1);
+    }
+
+    // Add a bin to the bucket for the given remaining capacity.
+    void add_bin(int remaining, int bin_id) {
+        buckets_[remaining].push(bin_id);
+        update(remaining, 1, 0, n_ - 1);
+    }
+
+    // Remove and return the smallest bin_id from the given capacity bucket.
+    int pop_bin(int remaining) {
+        int bin_id = buckets_[remaining].top();
+        buckets_[remaining].pop();
+        update(remaining, 1, 0, n_ - 1);
+        return bin_id;
+    }
+
+private:
+    void update(int pos, int node, int lo, int hi) {
+        if (lo == hi) {
+            tree_[node] = buckets_[pos].empty() ? 0 : 1;
+            return;
+        }
+        int mid = (lo + hi) / 2;
+        if (pos <= mid) update(pos, 2 * node,     lo, mid);
+        else            update(pos, 2 * node + 1, mid + 1, hi);
+        tree_[node] = tree_[2 * node] | tree_[2 * node + 1];
+    }
+
+    int query(int target, int node, int lo, int hi) const {
+        if (!tree_[node] || hi < target) return -1;
+        if (lo == hi) return lo;
+        int mid = (lo + hi) / 2;
+        int left = query(target, 2 * node, lo, mid);
+        if (left != -1) return left;
+        return query(target, 2 * node + 1, mid + 1, hi);
+    }
+};
+
+
+// extern "C" so Python ctypes can call it by name.
+
+extern "C" void bfd_pack(
+    const int  *sorted_positions,   // indices into doc_lengths, sorted by decreasing length
+    const long *doc_lengths,        // length of each document (indexed by position)
+    int         num_docs,           // total number of documents
+    int         capacity,           // bin capacity (seq_length + extra_token)
+    int         max_docs_per_bin,   // <=0 means no cap
+    const int  *document_index,     // maps position -> actual document ID
+    // outputs:
+    int        *doc_idx_out,        // reordered document IDs  (size: num_docs)
+    int        *boundaries_out,     // bin boundary offsets     (size: num_docs + 1, worst case)
+    int        *num_bins_out        // number of bins created
+) {
+    SegmentTree tree(capacity);
+    std::vector<std::vector<int>> bins;     // bins[bin_id] = list of positions
+
+    // A bin is eligible for more docs iff it has room AND is below the cap.
+    auto try_insert_bin = [&](int bin_id, int new_remaining) {
+        if (new_remaining <= 0) return;
+        if (max_docs_per_bin > 0 &&
+            static_cast<int>(bins[bin_id].size()) >= max_docs_per_bin) return;
+        tree.add_bin(new_remaining, bin_id);
+    };
+
+    for (int i = 0; i < num_docs; i++) {
+        int  pos    = sorted_positions[i];
+        long length = doc_lengths[pos];
+
+        // Oversized document: gets its own bin
+        if (length > capacity) {
+            bins.push_back({pos});
+            continue;
+        }
+
+        // Zero-length document: tuck into any existing bin, or open a new one
+        if (length == 0) {
+            int r = tree.find_best_fit(0);
+            if (r >= 0) {
+                int bid = tree.pop_bin(r);
+                bins[bid].push_back(pos);
+                try_insert_bin(bid, r);             // remaining unchanged
+            } else {
+                int bid = static_cast<int>(bins.size());
+                bins.push_back({pos});
+                try_insert_bin(bid, capacity);
+            }
+            continue;
+        }
+
+        // Normal case: find tightest-fitting bin, or open a new one
+        int r = tree.find_best_fit(static_cast<int>(length));
+        if (r >= 0) {
+            int bid   = tree.pop_bin(r);
+            int new_r = r - static_cast<int>(length);
+            bins[bid].push_back(pos);
+            try_insert_bin(bid, new_r);
+        } else {
+            int bid   = static_cast<int>(bins.size());
+            int new_r = capacity - static_cast<int>(length);
+            bins.push_back({pos});
+            try_insert_bin(bid, new_r);
+        }
+    }
+
+    // Flatten bins into contiguous output arrays
+    int offset = 0;
+    for (int b = 0; b < static_cast<int>(bins.size()); b++) {
+        boundaries_out[b] = offset;
+        for (int pos : bins[b]) {
+            doc_idx_out[offset++] = document_index[pos];
+        }
+    }
+    boundaries_out[bins.size()] = offset;
+    *num_bins_out = static_cast<int>(bins.size());
+}

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -18,11 +18,230 @@ from megatron.core.datasets.utils import Split
 from megatron.core.tokenizers import MegatronTokenizerBase
 from megatron.core.utils import log_single_rank
 
+import bisect
+
 logger = logging.getLogger(__name__)
 
 
 _GOLDFISH_TOKEN_ID = -2
 _HASH_TABLE_SIZE = 1_000_003
+
+
+def _load_bfd_c_library():
+    """Load (or compile then load) the C/C++ BFD packing library.
+
+    Uses a segment-tree + min-heap structure for O(n log C) best-fit lookup,
+    ~10-15x faster than pure-Python bisect at million-doc scale. Thread-safe.
+    Returns the loaded ctypes library, or None if unavailable.
+    """
+    import ctypes
+    import subprocess
+
+    _dir = os.path.dirname(os.path.abspath(__file__))
+    so_path  = os.path.join(_dir, "libbfd_pack.so")
+    cpp_path = os.path.join(_dir, "bfd_pack.cpp")
+
+    # Rebuild if source is newer (e.g. after the max_docs_per_bin signature change).
+    so_is_fresh = (
+        os.path.isfile(so_path)
+        and (not os.path.isfile(cpp_path) or os.path.getmtime(so_path) >= os.path.getmtime(cpp_path))
+    )
+    if so_is_fresh:
+        try:
+            lib = ctypes.CDLL(so_path)
+            lib.bfd_pack.argtypes = [
+                ctypes.POINTER(ctypes.c_int),  # sorted_positions
+                ctypes.POINTER(ctypes.c_long), # doc_lengths
+                ctypes.c_int,                  # num_docs
+                ctypes.c_int,                  # capacity
+                ctypes.c_int,                  # max_docs_per_bin (0 = no cap)
+                ctypes.POINTER(ctypes.c_int),  # document_index
+                ctypes.POINTER(ctypes.c_int),  # doc_idx_out
+                ctypes.POINTER(ctypes.c_int),  # boundaries_out
+                ctypes.POINTER(ctypes.c_int),  # num_bins_out
+            ]
+            lib.bfd_pack.restype = None
+            return lib
+        except OSError:
+            pass
+
+    for src_path, compiler in [(cpp_path, "g++")]:
+        if os.path.isfile(src_path):
+            try:
+                subprocess.check_call(
+                    [compiler, "-O3", "-shared", "-fPIC", "-o", so_path, src_path],
+                    stderr=subprocess.DEVNULL,
+                )
+                return _load_bfd_c_library()
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                continue
+
+    return None
+
+
+_bfd_c_lib = _load_bfd_c_library()
+
+def _build_virtual_docs(document_index, sequence_lengths, capacity, eod_token_id):
+    """Split any document longer than *capacity* into chunks with proper EOD boundaries.
+
+    For oversized docs (L > capacity), chunks are taken at step `capacity - 1` real tokens
+    and the loader appends a synthetic EOD to every non-last chunk so each chunk ends on an
+    EOD. The last chunk of an oversized doc carries the document's natural EOD. Docs that
+    fit within `capacity` are kept whole (single chunk, no synthetic token).
+
+    Returns:
+        chunk_map: Shape (num_virtual, 4), int64. Columns:
+            [real_doc_id, chunk_start_token, chunk_length_tokens, append_synthetic_eod].
+        virtual_sizes: Shape (num_virtual,), int32. Virtual chunk length *including* any
+            synthetic EOD that the loader will append.
+    """
+    real_doc_ids = document_index.astype(numpy.int64)
+    doc_lens = sequence_lengths[real_doc_ids].astype(numpy.int64)
+
+    step = capacity - 1
+    oversized = doc_lens > capacity
+    num_chunks = numpy.where(oversized, (doc_lens + step - 1) // step, 1)
+    total_virtual = int(num_chunks.sum())
+
+    chunk_map = numpy.empty((total_virtual, 4), dtype=numpy.int64)
+    virtual_sizes = numpy.empty(total_virtual, dtype=numpy.int32)
+
+    chunk_offsets = numpy.empty(len(num_chunks) + 1, dtype=numpy.int64)
+    chunk_offsets[0] = 0
+    numpy.cumsum(num_chunks, out=chunk_offsets[1:])
+
+    # Single-chunk fast path (L <= capacity): use doc whole, no synthetic EOD
+    single_mask = ~oversized
+    single_out = chunk_offsets[:-1][single_mask]
+    chunk_map[single_out, 0] = real_doc_ids[single_mask]
+    chunk_map[single_out, 1] = 0
+    chunk_map[single_out, 2] = doc_lens[single_mask]
+    chunk_map[single_out, 3] = 0
+    virtual_sizes[single_out] = doc_lens[single_mask].astype(numpy.int32)
+
+    # Oversized: step-sized chunks with synth EOD, last chunk uses natural EOD
+    for pos in numpy.where(oversized)[0]:
+        rid = int(real_doc_ids[pos])
+        dlen = int(doc_lens[pos])
+        base = int(chunk_offsets[pos])
+        nc = int(num_chunks[pos])
+        for ci in range(nc):
+            off = ci * step
+            is_last = (ci == nc - 1)
+            if is_last:
+                clen = dlen - off
+                append_eod = 0
+            else:
+                clen = step
+                append_eod = 1
+            chunk_map[base + ci] = [rid, off, clen, append_eod]
+            virtual_sizes[base + ci] = clen + append_eod
+
+    return chunk_map, virtual_sizes
+
+
+def _build_sample_idx_bfd(sequence_lengths, document_index, seq_length, add_extra_token, max_docs_per_bin):
+    """Best-Fit Decreasing bin packing for whole documents. C-accelerated when available."""
+    if _bfd_c_lib is not None:
+        return _build_sample_idx_bfd_c(sequence_lengths, document_index, seq_length, add_extra_token, max_docs_per_bin)
+    return _build_sample_idx_bfd_python(sequence_lengths, document_index, seq_length, add_extra_token, max_docs_per_bin)
+
+
+def _build_sample_idx_bfd_c(sequence_lengths, document_index, seq_length, add_extra_token, max_docs_per_bin=0):
+    """C-accelerated BFD bin packing via ctypes. See _build_sample_idx_bfd."""
+    import ctypes
+
+    capacity = seq_length + add_extra_token
+    num_docs = len(document_index)
+
+    doc_lengths = sequence_lengths[document_index].astype(numpy.int64)
+    sorted_positions = numpy.argsort(-doc_lengths, kind='stable').astype(numpy.int32)
+    doc_index_i32 = document_index.astype(numpy.int32)
+
+    doc_idx_out = numpy.empty(num_docs, dtype=numpy.int32)
+    boundaries_out = numpy.empty(num_docs + 1, dtype=numpy.int32)
+    num_bins_out = ctypes.c_int(0)
+
+    _bfd_c_lib.bfd_pack(
+        sorted_positions.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        doc_lengths.ctypes.data_as(ctypes.POINTER(ctypes.c_long)),
+        num_docs, capacity, int(max_docs_per_bin),
+        doc_index_i32.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        doc_idx_out.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        boundaries_out.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
+        ctypes.byref(num_bins_out),
+    )
+
+    nb = num_bins_out.value
+    reordered = doc_idx_out[:num_docs].astype(document_index.dtype)
+    sample_index = numpy.zeros((nb + 1, 2), dtype=document_index.dtype)
+    sample_index[:, 0] = boundaries_out[:nb + 1].astype(document_index.dtype)
+
+    assert boundaries_out[nb] == num_docs, f"BFD placed {boundaries_out[nb]} docs but expected {num_docs}"
+    return reordered, sample_index
+
+
+def _build_sample_idx_bfd_python(sequence_lengths, document_index, seq_length, add_extra_token, max_docs_per_bin=0):
+    """Pure-Python BFD fallback using bisect. See _build_sample_idx_bfd."""
+    capacity = seq_length + add_extra_token
+    num_docs = len(document_index)
+
+    doc_lengths = sequence_lengths[document_index].astype(numpy.int64)
+    sorted_positions = numpy.argsort(-doc_lengths, kind='stable')
+
+    bins_sorted = []
+    bin_contents = []
+
+    # A bin is at the cap iff max_docs_per_bin > 0 and it already holds that many docs.
+    def _capped(bid):
+        return max_docs_per_bin > 0 and len(bin_contents[bid]) >= max_docs_per_bin
+
+    for pos in sorted_positions:
+        length = int(doc_lengths[pos])
+        if length > capacity:
+            bin_contents.append([int(pos)])
+            continue
+        if length == 0:
+            if bins_sorted:
+                _, bin_id = bins_sorted[0]
+                bin_contents[bin_id].append(int(pos))
+                if _capped(bin_id):
+                    bins_sorted.pop(0)
+            else:
+                bin_id = len(bin_contents)
+                bin_contents.append([int(pos)])
+                if not _capped(bin_id):
+                    bisect.insort(bins_sorted, (capacity, bin_id))
+            continue
+        idx = bisect.bisect_left(bins_sorted, (length,))
+        if idx < len(bins_sorted):
+            remaining, bin_id = bins_sorted.pop(idx)
+            new_remaining = remaining - length
+            bin_contents[bin_id].append(int(pos))
+            if new_remaining > 0 and not _capped(bin_id):
+                bisect.insort(bins_sorted, (new_remaining, bin_id))
+        else:
+            bin_id = len(bin_contents)
+            bin_contents.append([int(pos)])
+            new_remaining = capacity - length
+            if new_remaining > 0 and not _capped(bin_id):
+                bisect.insort(bins_sorted, (new_remaining, bin_id))
+
+    reordered = numpy.empty(num_docs, dtype=document_index.dtype)
+    boundaries = []
+    offset = 0
+    for contents in bin_contents:
+        boundaries.append(offset)
+        for pos in contents:
+            reordered[offset] = document_index[pos]
+            offset += 1
+    boundaries.append(offset)
+
+    sample_index = numpy.zeros((len(boundaries), 2), dtype=document_index.dtype)
+    sample_index[:, 0] = numpy.array(boundaries, dtype=document_index.dtype)
+    assert offset == num_docs
+    return reordered, sample_index
+
 
 @dataclass
 class GPTDatasetConfig(BlendedMegatronDatasetConfig):
@@ -80,6 +299,12 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     """Token IDs whose predictions should be masked from the loss (loss_mask=0).
     Useful for task-control tokens (e.g. <|stt_transcribe|>, <|tts_continue|>) that
     should condition the model but never be predicted."""
+
+    pretraining_packing_strategy: str = "greedy"
+    """Packing strategy for SFT: 'greedy' (sequential) or 'bfd' (Best-Fit Decreasing)."""
+
+    max_docs_per_bin: int = 0
+    """Maximum number of documents allowed per sample in bfd, 0 means no limit"""
 
 
     def __post_init__(self) -> None:
@@ -442,6 +667,9 @@ class GPTDataset(MegatronDataset):
         Returns:
             Tuple[numpy.ndarray, numpy.ndarray]: The text ids and document ids
         """
+        if self.config.pretraining_packing_strategy == "bfd":
+            return self._query_bfd_packed_sample(idx) 
+
         if self.shuffle_index is None:
             # NOTE(asolergi-nv): Lazy memmap the indexes
             self.shuffle_index = numpy.load(
@@ -513,6 +741,197 @@ class GPTDataset(MegatronDataset):
             numpy.concatenate(sample_parts, dtype=numpy.int64),
             numpy.array(document_ids, dtype=numpy.int64),
         )
+    def _build_bfd_packing_indices(self):
+        """BFD pack virtual chunks; oversized docs are split so no tokens are truncated.
+
+        document_index holds virtual chunk IDs; self.chunk_map maps each virtual chunk
+        to [real_doc_id, chunk_start, chunk_length]. Samples are loaded via
+        _query_bfd_packed_sample, which uses chunk_map to fetch exact slices.
+        """
+        path_to_cache = self.config.path_to_cache
+        if path_to_cache is None and not self.config.mock:
+            path_to_cache = os.path.join(
+                self.dataset.path_prefix, "cache", f"{type(self).__name__}_indices"
+            )
+
+        if path_to_cache:
+            base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}"
+            get_path_to = lambda affix: os.path.join(path_to_cache, f"{base}-{affix}")
+            path_to_description = get_path_to("description.txt")
+            path_to_document_index = get_path_to("document_index.npy")
+            path_to_sample_index = get_path_to("sample_index.npy")
+            path_to_shuffle_index = get_path_to("shuffle_index.npy")
+            path_to_chunk_map = get_path_to("chunk_map.npy")
+            cache_hit = all(
+                map(os.path.isfile, [
+                    path_to_description, path_to_document_index,
+                    path_to_sample_index, path_to_shuffle_index, path_to_chunk_map,
+                ])
+            )
+        else:
+            cache_hit = False
+
+        if not path_to_cache or (
+            not cache_hit
+            and (not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0)
+        ):
+            log_single_rank(logger, logging.INFO,
+                f"Build and save the {type(self).__name__} {self.index_split.name} BFD indices")
+            t_beg = time.time()
+
+            sequence_length = self.config.sequence_length
+            numpy_random_state = numpy.random.RandomState(self.config.random_seed)
+
+            # One shuffled epoch of real doc IDs — BFD always packs one epoch; shuffle tiles after.
+            real_doc_index = _build_document_index(self.indices, 1, numpy_random_state, False)
+            assert real_doc_index.dtype == numpy.int32
+            assert self.dataset.sequence_lengths.dtype == numpy.int32
+
+            if len(real_doc_index) * 2 > len(self.dataset.sequence_lengths):
+                seq_lens = self.dataset.sequence_lengths.copy()
+            else:
+                seq_lens = self.dataset.sequence_lengths
+
+            # Virtual chunking: split oversized docs into capacity-sized pieces.
+            capacity = sequence_length + self.config.add_extra_token_to_sequence
+            chunk_map, virtual_sizes = _build_virtual_docs(
+                real_doc_index, seq_lens, capacity, self.config.tokenizer.eod
+            )
+            num_virtual = len(virtual_sizes)
+            virtual_idx = numpy.arange(num_virtual, dtype=numpy.int32)
+
+            n_extra = num_virtual - len(real_doc_index)
+            log_single_rank(logger, logging.INFO,
+                f"  Document chunking: {len(real_doc_index)} docs → {num_virtual} virtual chunks"
+                + (f" ({n_extra} extra from oversized docs)" if n_extra > 0 else ""))
+
+            _accel = "C-accelerated" if _bfd_c_lib is not None else "Python fallback"
+            log_single_rank(logger, logging.INFO,
+                f"Using Best-Fit Decreasing packing strategy ({_accel})")
+
+            document_index, sample_index = _build_sample_idx_bfd(
+                virtual_sizes, virtual_idx, sequence_length,
+                add_extra_token=self.config.add_extra_token_to_sequence,
+                max_docs_per_bin=self.config.max_docs_per_bin
+            )
+            self._log_bfd_packing_statistics(
+                num_docs=len(real_doc_index),
+                num_virtual=num_virtual,
+                sample_index=sample_index,
+                from_cache=False,
+            )
+
+            # Shuffle packed samples; tile with fresh permutations if num_samples > one epoch.
+            num_epoch_samples = sample_index.shape[0] - 1
+            if self.num_samples is None or self.num_samples <= num_epoch_samples:
+                n = self.num_samples if self.num_samples is not None else num_epoch_samples
+                shuffle_index = _build_shuffle_index(num_epoch_samples, n, numpy_random_state)
+            else:
+                num_repeats = int(numpy.ceil(self.num_samples / num_epoch_samples))
+                log_single_rank(logger, logging.WARNING,
+                    f"> Requested {self.num_samples} samples but one epoch provides only "
+                    f"{num_epoch_samples}. Tiling shuffle index {num_repeats}x.")
+                tiles = [_build_shuffle_index(num_epoch_samples, num_epoch_samples, numpy_random_state)
+                         for _ in range(num_repeats)]
+                shuffle_index = numpy.concatenate(tiles)[:self.num_samples]
+
+            if path_to_cache:
+                os.makedirs(path_to_cache, exist_ok=True)
+                with open(path_to_description, "wt") as writer:
+                    writer.write(self.unique_description)
+                numpy.save(path_to_document_index, document_index, allow_pickle=True)
+                numpy.save(path_to_sample_index, sample_index, allow_pickle=True)
+                numpy.save(path_to_shuffle_index, shuffle_index, allow_pickle=True)
+                numpy.save(path_to_chunk_map, chunk_map, allow_pickle=True)
+
+            self.chunk_map = chunk_map
+            log_single_rank(logger, logging.DEBUG, f"\t> time elapsed: {time.time() - t_beg:4f} s")
+            log_single_rank(logger, logging.INFO, f"> total number of samples: {sample_index.shape[0] - 1}")
+
+            self._log_bfd_packing_statistics(
+                num_docs=len(self.indices),
+                num_virtual=len(self.chunk_map),
+                sample_index=sample_index,
+                from_cache=True,
+            )
+            
+            return document_index, sample_index, shuffle_index
+
+        # Cache hit
+        log_single_rank(logger, logging.INFO,
+            f"Load the {type(self).__name__} {self.index_split.name} BFD indices")
+        document_index = numpy.load(path_to_document_index, allow_pickle=True, mmap_mode='r')
+        sample_index = numpy.load(path_to_sample_index, allow_pickle=True, mmap_mode='r')
+        shuffle_index = numpy.load(path_to_shuffle_index, allow_pickle=True, mmap_mode='r')
+        self.chunk_map = numpy.load(path_to_chunk_map, allow_pickle=True, mmap_mode='r')
+        log_single_rank(logger, logging.INFO, f"> total number of samples: {sample_index.shape[0] - 1}")
+
+        self._log_bfd_packing_statistics(
+            num_docs=len(self.indices),
+            num_virtual=len(self.chunk_map),
+            sample_index=sample_index,
+            from_cache=True,
+        )
+        
+        return document_index, sample_index, shuffle_index
+
+    def _log_bfd_packing_statistics(self, num_docs, num_virtual, sample_index, from_cache=False):
+        num_samples = sample_index.shape[0] - 1
+        sequence_length = self.config.sequence_length
+        num_tokens_per_epoch = int(numpy.sum(self.dataset.sequence_lengths[self.indices]))
+        total_tokens_in_samples = num_samples * sequence_length
+        avg_docs_per_sample = num_virtual / num_samples if num_samples > 0 else 0
+        packing_efficiency = (
+            100 * num_tokens_per_epoch / total_tokens_in_samples
+            if total_tokens_in_samples > 0 else 0
+        )
+        suffix = " (loaded from cache)" if from_cache else ""
+        log_single_rank(logger, logging.INFO, f"> ===== BFD Packing Statistics (ONE EPOCH){suffix} =====")
+        log_single_rank(logger, logging.INFO, f" > #real docs in epoch:               {num_docs:>12,}")
+        log_single_rank(logger, logging.INFO, f" > #virtual chunks (after split):     {num_virtual:>12,}")
+        log_single_rank(logger, logging.INFO, f" > #tokens in epoch:                  {num_tokens_per_epoch:>12,}")
+        log_single_rank(logger, logging.INFO, f" > Sequence length:                   {sequence_length:>12,}")
+        log_single_rank(logger, logging.INFO, f" > #packed samples (per epoch):       {num_samples:>12,}")
+        log_single_rank(logger, logging.INFO, f" > #tokens(incl. padding) in samples: {total_tokens_in_samples:>12,}")
+        log_single_rank(logger, logging.INFO, f" > Average #chunks/sample:            {avg_docs_per_sample:>12.2f}")
+        log_single_rank(logger, logging.INFO, f" > Packing efficiency:                {packing_efficiency:>11.2f}%")
+
+    def _query_bfd_packed_sample(self, idx):
+        """Load one BFD-packed sample: concatenate virtual chunks, synthesize EOD on
+        non-last oversized-doc chunks, pad to target length.
+        """
+        shuffled = int(self.shuffle_index[idx])
+        doc_index_beg = int(self.sample_index[shuffled][0])
+        doc_index_end = int(self.sample_index[shuffled + 1][0])
+
+        target_length = self.config.sequence_length + self.config.add_extra_token_to_sequence
+        eod_token_id = self.config.tokenizer.eod
+
+        sample_parts = []
+        document_ids = []
+        for i in range(doc_index_beg, doc_index_end):
+            virtual_id = int(self.document_index[i])
+            real_doc_id = int(self.chunk_map[virtual_id, 0])
+            chunk_start = int(self.chunk_map[virtual_id, 1])
+            chunk_len   = int(self.chunk_map[virtual_id, 2])
+            append_eod  = int(self.chunk_map[virtual_id, 3])
+
+            data = self.dataset.get(real_doc_id, offset=chunk_start, length=chunk_len)
+            if append_eod:
+                data = numpy.concatenate([data, numpy.array([eod_token_id], dtype=data.dtype)])
+            sample_parts.append(data)
+            document_ids.append(real_doc_id)
+
+        length = sum(map(len, sample_parts))
+        if length < target_length:
+            sample_parts.append(
+                [self._pad_token_id] * (target_length - length)
+            )
+
+        return (
+            numpy.concatenate(sample_parts, dtype=numpy.int64),
+            numpy.array(document_ids, dtype=numpy.int64),
+        )
 
     def _build_document_sample_shuffle_indices(
         self,
@@ -535,6 +954,10 @@ class GPTDataset(MegatronDataset):
             Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]: The document index, the sample
             index, and the shuffle index
         """
+
+        if self.config.pretraining_packing_strategy == "bfd":
+            return self._build_bfd_packing_indices()
+            
         if self.config.defer_npy_index_mmap:
             # NOTE(asolergi-nv): Direct path to lazy memmap the indexes
             base = f"{self.unique_description_hash}-{type(self).__name__}-{self.index_split.name}"

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3145,6 +3145,14 @@ def _add_data_args(parser):
                        'end-of-document token.')
     group.add_argument('--variable-seq-lengths', action='store_true',
                        help='Compute the length of the tensor you send in PP groups, not fixed. Relevant with CP.')
+    group.add_argument('--pretraining-packing-strategy', type=str, default='greedy',
+                       choices=['greedy', 'bfd'],
+                       help='Packing strategy for pre-training. '
+                            '"greedy" packs documents in shuffled order (current default). '
+                            '"bfd" (Best-Fit Decreasing) sorts by length for higher packing '
+                            'efficiency and don\'t cut the samples if < sequence_length.')
+    group.add_argument('--max-docs-per-bin', type=int, default=0,
+                       help='Maximum number of documents allowed per sample in bfd, 0 means no limit. ')
     group.add_argument('--eod-mask-loss', action='store_true',
                        help='Mask loss for the end of document tokens.')
     group.add_argument('--use-packed-seq-params', action='store_true',

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -661,6 +661,8 @@ def core_gpt_dataset_config_from_args(args):
         "vision_weight": args.vision_weight,
         "audio_weight": args.audio_weight,
         "loss_mask_token_ids": getattr(args, "loss_mask_token_ids", None),
+        "pretraining_packing_strategy": args.pretraining_packing_strategy,
+        "max_docs_per_bin": args.max_docs_per_bin,
     }
 
     # add FIM args to the config


### PR DESCRIPTION
## Motivation

xdoc attention masking becomes inefficient when samples contain many very small documents. Without xdoc attention masking, samples are uniformly sized, each parallel group processes sequences equivalent lengths, leading to well-balanced workloads and straightforward synchronization.

However, with xdoc masking, pathological cases can arise. For example, a sequence of 8192 tokens may contain hundreds of tiny documents (e.g., ~410 documents of ~20 tokens each). This forces the model to repeatedly process very small attention contexts, significantly increasing overhead.

Even if such cases are rare, the training step must remain synchronized across all parallel workers. As a result, these outliers determine the step time and degrade overall throughput.

## Problem Visualization

Throughput becomes highly unstable over time when these pathological samples are encountered, as shown below:
<img width="1569" height="839" alt="image" src="https://github.com/user-attachments/assets/808804c1-71f6-49ad-a758-2ba848e43f73" />

## Solution

Introduce a cap on the number of documents per sample. When a sample contains many very small documents, we truncate the number of documents to a predefined limit and pad the remaining sequence length.

In practice, these edge cases are rare (observed in only 4 datasets for the 70B setting), so the additional padding overhead is minimal while significantly improving stability and throughput.

## Changes

Add a [best-fit decreasing (BFD)](https://arxiv.org/pdf/2404.10830) packing strategy with support for limiting the number of documents per sample.

This change is fully backward compatible with the main branch if these arguments are not given. The new behavior is enabled via:

```
--pretraining-packing-strategy bfd
--max-docs-per-bin 16
```

which activates document-capped packing.