### PR TITLE
Add better handling of sft vs pretrain dataset selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [Set the Datasets in Megatron](#set-the-datasets-in-megatron)
     - [Data mixtures](#data-mixtures)
 - [Supervised Fine-Tuning (SFT)](#supervised-fine-tuning-sft)
+    - [Selecting SFT vs Pretrain Datasets](#selecting-sft-vs-pretrain-datasets)
     - [Apertus SFT with Sample Packing](#apertus-sft-with-sample-packing)
 - [Checkpointing](#checkpointing)
     - [Resuming from a checkpoint](#resuming-from-a-checkpoint)
@@ -120,6 +121,27 @@ To enable best-fit decreasing packing, add the following arguments to your launc
 # Supervised Fine-Tuning (SFT)
 
 This repository provides the **ApertusSFT** dataset (`--ap-sft`) for supervised fine-tuning on pre-tokenized Megatron indexed datasets (`.bin/.idx`). It supports sample packing, configurable loss masking, and works with the standard `pretrain_gpt.py` entry point.
+
+## Selecting SFT vs Pretrain Datasets
+
+Each entry in `--data-path` (and `--train-data-path` / `--valid-data-path` / `--test-data-path`, `--data-args-path`, `--per-split-data-args-path`) can carry an explicit dataset-type marker that decides whether the entry is built as `ApertusSFTDataset` or `GPTDataset`. This lets you mix SFT and pretrain data in the same weighted blend.
+
+Marker syntax: prefix the path with `sft:` or `pretrain:` (case-insensitive — `SFT:` works too). Only the **leading** marker is stripped, so a literal `sft:` in the underlying path is preserved (e.g. `sft:sft:/data/x` resolves to type `sft` with clean path `sft:/data/x`). Example mixed blend:
+```bash
+--data-path 0.3 sft:/data/dolly_prefix 0.7 pretrain:/data/fineweb_prefix
+```
+
+For entries **without** a marker, dispatch is decided in this order:
+
+1. **`--ap-sft` is set** → unmarked entries are treated as SFT (`ApertusSFTDataset`). No warning. This preserves backward compatibility for existing all-SFT launchers (e.g. `--ap-sft --data-path 1.0 /data/dolly`).
+2. **`--ap-sft` is not set, but the path string contains the substring `"apertus_sft"`** → `ApertusSFTDataset` with a one-time `DeprecationWarning`. Legacy fallback for datasets whose directory names encode their type. Migrate to explicit `sft:` markers.
+3. **Otherwise** → `GPTDataset` (pretrain). Default for any bare path.
+
+Explicit `sft:` / `pretrain:` markers always override these three rules. Use them whenever you mix types in one blend.
+
+`--ap-sft` is still required for any SFT run (including mixed blends), because it also gates the `--calculate-per-token-loss` assertion needed for correct SFT loss normalization. The marker controls **per-entry dispatch**; the flag controls **run-level SFT mode**.
+
+The helper `scripts/tools/create_weighted_data_config.py` accepts `--dataset-type {sft,pretrain,none}` to emit marker-prefixed entries automatically.
 
 ## Apertus SFT with Sample Packing
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Marker syntax: prefix the path with `sft:` or `pretrain:` (case-insensitive — 
 For entries **without** a marker, dispatch is decided in this order:
 
 1. **`--ap-sft` is set** → unmarked entries are treated as SFT (`ApertusSFTDataset`). No warning. This preserves backward compatibility for existing all-SFT launchers (e.g. `--ap-sft --data-path 1.0 /data/dolly`).
-2. **`--ap-sft` is not set, but the path string contains the substring `"apertus_sft"`** → `ApertusSFTDataset` with a one-time `DeprecationWarning`. Legacy fallback for datasets whose directory names encode their type. Migrate to explicit `sft:` markers.
+2. **`--ap-sft` is not set, but the path contains a legacy SFT substring (`"apertus_sft"` or `"apertus1p5_sft"`, matched case-insensitively)** → `ApertusSFTDataset` with a one-time `DeprecationWarning`. Legacy fallback for datasets whose directory names encode their type. Migrate to explicit `sft:` markers.
 3. **Otherwise** → `GPTDataset` (pretrain). Default for any bare path.
 
 Explicit `sft:` / `pretrain:` markers always override these three rules. Use them whenever you mix types in one blend.

--- a/initialize_sft_dataset.py
+++ b/initialize_sft_dataset.py
@@ -53,7 +53,6 @@ from megatron.training import get_tokenizer
 from megatron.core import mpu
 from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
 from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
-from megatron.core.datasets.gpt_dataset import MockGPTDataset, GPTDataset
 from megatron.core.tokenizers.text.utils.build_tokenizer import build_tokenizer
 from megatron.training.initialize import initialize_megatron
 from megatron.training.tokenizer.tokenizer_omni_metadata import populate_omni_metadata_from_tokenizer
@@ -145,6 +144,7 @@ def core_gpt_dataset_config_from_args(args):
         sft_equalize_sample_loss=args.ap_sft_equalize_sample_loss,
         sft_load_loss_mask=args.ap_sft_load_loss_mask,
         sft_truncate_right=args.ap_sft_truncate_right,
+        ap_sft_auto_tag=args.ap_sft,
     )
 
 
@@ -158,21 +158,9 @@ def build_train_valid_test_datasets(train_val_test_num_samples):
 
     config = core_gpt_dataset_config_from_args(args)
 
-    if args.ap_sft:
-        from megatron.training.datasets.apertus_sft_dataset import ApertusSFTDataset
-        dataset_type = ApertusSFTDataset
-    elif args.sft:
-        from megatron.training.datasets.sft_dataset import SFTDataset
-        dataset_type = SFTDataset
-    elif args.mock_data:
-        dataset_type = MockGPTDataset
-    else:
-        dataset_type = GPTDataset
-
     print_rank_0("> building train, validation, and test datasets for GPT ...")
 
     train_ds, valid_ds, test_ds = BlendedMegatronDatasetBuilder(
-        dataset_type,
         train_val_test_num_samples,
         is_dataset_built_on_rank,
         config

--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -27,6 +27,11 @@ DistributedDataset = Union[
     TopLevelDataset, MidLevelDataset, LowLevelDataset, torch.utils.data.Dataset
 ]
 
+# Legacy: paths whose name contains one of these substrings (matched
+# case-insensitively) are inferred to be SFT datasets. Deprecated in favor of
+# explicit "sft:" markers.
+LEGACY_SFT_PATH_SUBSTRINGS = ("apertus_sft", "apertus1p5_sft")
+
 
 class BlendedMegatronDatasetBuilder(object):
     """Builder class for the BlendedDataset and MegatronDataset classes
@@ -424,7 +429,9 @@ class BlendedMegatronDatasetBuilder(object):
           1. Explicit ``sft:`` / ``pretrain:`` marker on the path.
           2. ``GPTDatasetConfig.ap_sft_auto_tag`` (set by ``--ap-sft``) → SFT for
              any unmarked path.
-          3. Legacy ``"apertus_sft"`` substring → SFT with a DeprecationWarning.
+          3. Legacy substring (one of ``LEGACY_SFT_PATH_SUBSTRINGS``, e.g.
+             ``"apertus_sft"`` / ``"apertus1p5_sft"``, matched case-insensitively)
+             → SFT with a DeprecationWarning.
           4. Default → ``GPTDataset``.
 
         Returns the chosen class and the marker-stripped path. Mock configs and
@@ -439,14 +446,19 @@ class BlendedMegatronDatasetBuilder(object):
             return GPTDataset, clean
         if getattr(self.config, "ap_sft_auto_tag", False):
             return ApertusSFTDataset, clean
-        if clean and "apertus_sft" in clean:
-            warnings.warn(
-                "Inferring SFT dataset from 'apertus_sft' substring in "
-                f"'{clean}' is deprecated; prefix the path with 'sft:' instead.",
-                DeprecationWarning,
-                stacklevel=2,
+        if clean:
+            clean_lower = clean.lower()
+            matched = next(
+                (s for s in LEGACY_SFT_PATH_SUBSTRINGS if s in clean_lower), None
             )
-            return ApertusSFTDataset, clean
+            if matched is not None:
+                warnings.warn(
+                    f"Inferring SFT dataset from '{matched}' substring in "
+                    f"'{clean}' is deprecated; prefix the path with 'sft:' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return ApertusSFTDataset, clean
         return GPTDataset, clean
 
     def _build_megatron_dataset_splits(

--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -2,17 +2,18 @@
 
 import logging
 import math
+import warnings
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Iterable, List, Optional, Type, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Type, Union
 
 import numpy
 import torch
 
 from megatron.core.datasets.blended_dataset import BlendedDataset
 from megatron.core.datasets.blended_megatron_dataset_config import BlendedMegatronDatasetConfig
-from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, GPTDataset
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, GPTDataset, MockGPTDataset
 from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
-from megatron.core.datasets.utils import Split, normalize
+from megatron.core.datasets.utils import Split, normalize, split_dataset_type_marker
 from megatron.core.utils import log_single_rank
 from megatron.training.datasets.apertus_sft_dataset import ApertusSFTDataset
 
@@ -414,6 +415,40 @@ class BlendedMegatronDatasetBuilder(object):
 
         return megatron_datasets
 
+    def _resolve_dataset_class(
+        self, dataset_path: Optional[str]
+    ) -> Tuple[Type[MegatronDataset], Optional[str]]:
+        """Decide which dataset class builds ``dataset_path``.
+
+        Precedence:
+          1. Explicit ``sft:`` / ``pretrain:`` marker on the path.
+          2. ``GPTDatasetConfig.ap_sft_auto_tag`` (set by ``--ap-sft``) → SFT for
+             any unmarked path.
+          3. Legacy ``"apertus_sft"`` substring → SFT with a DeprecationWarning.
+          4. Default → ``GPTDataset``.
+
+        Returns the chosen class and the marker-stripped path. Mock configs and
+        ``None`` paths short-circuit to ``MockGPTDataset``.
+        """
+        if self.config.mock or dataset_path is None:
+            return MockGPTDataset, None
+        dtype, clean = split_dataset_type_marker(dataset_path)
+        if dtype == "sft":
+            return ApertusSFTDataset, clean
+        if dtype == "pretrain":
+            return GPTDataset, clean
+        if getattr(self.config, "ap_sft_auto_tag", False):
+            return ApertusSFTDataset, clean
+        if clean and "apertus_sft" in clean:
+            warnings.warn(
+                "Inferring SFT dataset from 'apertus_sft' substring in "
+                f"'{clean}' is deprecated; prefix the path with 'sft:' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return ApertusSFTDataset, clean
+        return GPTDataset, clean
+
     def _build_megatron_dataset_splits(
         self,
         dataset_path: Optional[str],
@@ -438,10 +473,7 @@ class BlendedMegatronDatasetBuilder(object):
             List[Optional[MidLevelDataset]]: The MidLevelDataset (or None) per split
         """
 
-        if "apertus_sft" in dataset_path:
-            dataset_cls = ApertusSFTDataset
-        else:
-            dataset_cls = GPTDataset
+        dataset_cls, dataset_path = self._resolve_dataset_class(dataset_path)
 
         synchronize_ranks = (
             False

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -326,6 +326,11 @@ class GPTDatasetConfig(BlendedMegatronDatasetConfig):
     max_docs_per_bin: int = 0
     """Maximum number of documents allowed per sample in bfd, 0 means no limit"""
 
+    ap_sft_auto_tag: bool = False
+    """When True, blend entries without an explicit 'sft:' / 'pretrain:' marker
+    are dispatched as ApertusSFTDataset. Set by --ap-sft for backward compatibility
+    with launchers that pass a single all-SFT blend."""
+
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""
         super().__post_init__()

--- a/megatron/core/datasets/utils.py
+++ b/megatron/core/datasets/utils.py
@@ -90,3 +90,31 @@ def get_blend_from_list(
     prefix_per_dataset = [rppd.strip() for rppd in raw_prefix_per_dataset]
 
     return prefix_per_dataset, weight_per_dataset
+
+
+DATASET_TYPE_MARKERS = ("sft:", "pretrain:")
+
+
+def split_dataset_type_marker(prefix: Optional[str]) -> Tuple[str, Optional[str]]:
+    """Split a blend prefix into (dataset_type, clean_path).
+
+    Recognises the reserved markers ``sft:`` and ``pretrain:`` (matched
+    case-insensitively, so ``SFT:/x`` and ``sft:/x`` behave identically).
+    Returns ``("default", original_path)`` when no marker is present.
+    A ``None`` prefix (mock datasets) round-trips as ``("default", None)``.
+    Only the leading marker is stripped, so ``"sft:sft:/x"`` resolves to
+    ``("sft", "sft:/x")``. An empty path after a marker raises an
+    AssertionError so typos like ``"sft:"`` fail fast.
+    """
+    if prefix is None:
+        return ("default", None)
+    lowered = prefix.lower()
+    for marker in DATASET_TYPE_MARKERS:
+        if lowered.startswith(marker):
+            clean = prefix[len(marker):]
+            assert clean, (
+                f"Dataset path is empty after dataset-type marker "
+                f"'{prefix[:len(marker)]}'"
+            )
+            return (marker[:-1], clean)
+    return ("default", prefix)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3079,6 +3079,9 @@ def _add_data_args(parser):
                        '(2) a list of weight prefix pairs e.g. weight1 prefix1 weight2 prefix2, '
                        '(3) a list of prefixes e.g. prefix1 prefix2. '
                        'For (3), weights are inferred from the lengths of the contributing datasets. '
+                       'Each prefix may be tagged with a reserved dataset-type marker (case-insensitive): '
+                       '"sft:<prefix>" builds ApertusSFTDataset, "pretrain:<prefix>" builds GPTDataset. '
+                       'See the README "Selecting SFT vs Pretrain Datasets" section for precedence rules. '
                        'This argument is exclusive to the other independent --*-data-path arguments.')
     group.add_argument('--phase-transition-iterations', type=str, default=None,
                        help='Comma-separated list of iterations where phase '
@@ -3745,7 +3748,9 @@ def _add_sft_args(parser):
     group.add_argument('--sft-tokenizer-prompt-format', type=str, default="nemotron-h-aligned",
                        help='SFT prompt format.')
     group.add_argument('--ap-sft', action="store_true",
-                       help='Enable Apertus model SFT training. Assumes --calculate-per-token-loss is activated.')
+                       help='Enable Apertus model SFT training. Requires --calculate-per-token-loss. '
+                            'In a mixed blend, also auto-tags any unmarked --data-path entry as SFT '
+                            '(entries with an explicit "sft:"/"pretrain:" marker are unaffected).')
     group.add_argument('--ap-sft-pack-samples', action="store_true",
                        help='Pack multiple whole documents per sequence. Doesnt spread one document across sequences. '
                             'Only packs full sequences and adds padding to reach full seq len.')

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -606,6 +606,7 @@ def core_gpt_dataset_config_from_args(args):
         "sft_truncate_right": args.ap_sft_truncate_right,
         "pretraining_packing_strategy": args.pretraining_packing_strategy,
         "max_docs_per_bin": args.max_docs_per_bin,
+        "ap_sft_auto_tag": args.ap_sft,
     }
 
     # add FIM args to the config

--- a/scripts/tools/create_weighted_data_config.py
+++ b/scripts/tools/create_weighted_data_config.py
@@ -127,6 +127,14 @@ if __name__ == "__main__":
         default="megatron",
         help="Output format: 'megatron' outputs space-separated weights and prefixes, 'verbose' shows breakdown",
     )
+    parser.add_argument(
+        "--dataset-type",
+        type=str,
+        choices=["sft", "pretrain", "none"],
+        default="none",
+        help="Prepend an explicit dataset-type marker ('sft:' or 'pretrain:') to each emitted "
+             "prefix. 'none' (default) emits bare prefixes for backward compatibility.",
+    )
     args = parser.parse_args()
 
     paths = [x.strip() for x in args.paths.split(",")]
@@ -138,6 +146,8 @@ if __name__ == "__main__":
 
     weighted_prefixes = calculate_proportional_weights(prefixes, args.weight)
 
+    marker = f"{args.dataset_type}:" if args.dataset_type != "none" else ""
+
     if args.format == "verbose":
         print(f"Found {len(prefixes)} datasets with total weight {args.weight}")
         print(f"{'Weight':<12} {'Percentage':<12} {'Size':<15} {'Prefix'}")
@@ -145,7 +155,7 @@ if __name__ == "__main__":
         for weight, prefix in weighted_prefixes:
             size = get_dataset_size(prefix)
             percentage = (weight / args.weight) * 100
-            print(f"{weight:<12.6f} {percentage:<12.2f} {size:<15,} {prefix}")
+            print(f"{weight:<12.6f} {percentage:<12.2f} {size:<15,} {marker}{prefix}")
         print("-" * 80)
         total = sum(w for w, _ in weighted_prefixes)
         print(f"Total weight: {total:.6f}")
@@ -155,6 +165,6 @@ if __name__ == "__main__":
     # Output in Megatron format: weight1 prefix1 weight2 prefix2 ...
     output_parts = []
     for weight, prefix in weighted_prefixes:
-        output_parts.extend([f"{weight:.6f}", prefix])
+        output_parts.extend([f"{weight:.6f}", f"{marker}{prefix}"])
 
     print(*output_parts, sep=" ")

--- a/tests/unit_tests/data/test_dataset_type_marker.py
+++ b/tests/unit_tests/data/test_dataset_type_marker.py
@@ -89,6 +89,23 @@ def test_resolve_legacy_substring_emits_deprecation():
     assert path == "/data/legacy_apertus_sft_set"
 
 
+def test_resolve_legacy_apertus1p5_substring_emits_deprecation():
+    builder = _make_builder()
+    with pytest.warns(DeprecationWarning, match="apertus1p5_sft"):
+        cls, path = builder._resolve_dataset_class("/data/Apertus1p5_sft_v2")
+    assert cls is ApertusSFTDataset
+    assert path == "/data/Apertus1p5_sft_v2"
+
+
+def test_resolve_legacy_substring_case_insensitive():
+    builder = _make_builder()
+    with pytest.warns(DeprecationWarning):
+        cls, path = builder._resolve_dataset_class("/data/APERTUS_SFT_SET")
+    assert cls is ApertusSFTDataset
+    # Matching is case-insensitive but the original-cased path is preserved.
+    assert path == "/data/APERTUS_SFT_SET"
+
+
 def test_resolve_default_pretrain():
     cls, path = _make_builder()._resolve_dataset_class("/data/fineweb")
     assert cls is GPTDataset

--- a/tests/unit_tests/data/test_dataset_type_marker.py
+++ b/tests/unit_tests/data/test_dataset_type_marker.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the per-entry SFT/pretrain marker in blend paths."""
+
+import warnings
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.core.datasets.blended_megatron_dataset_builder import (
+    BlendedMegatronDatasetBuilder,
+)
+from megatron.core.datasets.gpt_dataset import GPTDataset, MockGPTDataset
+from megatron.core.datasets.utils import split_dataset_type_marker
+from megatron.training.datasets.apertus_sft_dataset import ApertusSFTDataset
+
+
+# ---------------------------------------------------------------------------
+# split_dataset_type_marker
+# ---------------------------------------------------------------------------
+
+
+def test_marker_sft():
+    assert split_dataset_type_marker("sft:/x/y") == ("sft", "/x/y")
+
+
+def test_marker_pretrain():
+    assert split_dataset_type_marker("pretrain:/x") == ("pretrain", "/x")
+
+
+def test_marker_none_prefix():
+    assert split_dataset_type_marker("/plain/path") == ("default", "/plain/path")
+
+
+def test_marker_none_value():
+    assert split_dataset_type_marker(None) == ("default", None)
+
+
+def test_marker_strips_only_once():
+    assert split_dataset_type_marker("sft:sft:/x") == ("sft", "sft:/x")
+
+
+def test_marker_case_insensitive():
+    assert split_dataset_type_marker("SFT:/x") == ("sft", "/x")
+    assert split_dataset_type_marker("Pretrain:/y") == ("pretrain", "/y")
+
+
+def test_marker_empty_path_after_marker_raises():
+    with pytest.raises(AssertionError, match="empty"):
+        split_dataset_type_marker("sft:")
+
+
+# ---------------------------------------------------------------------------
+# BlendedMegatronDatasetBuilder._resolve_dataset_class
+# ---------------------------------------------------------------------------
+
+
+def _make_builder(*, mock=False, ap_sft_auto_tag=False):
+    """Build a barebones builder instance without running __init__ (which
+    requires a fully populated GPTDatasetConfig)."""
+    builder = BlendedMegatronDatasetBuilder.__new__(BlendedMegatronDatasetBuilder)
+    builder.config = SimpleNamespace(mock=mock, ap_sft_auto_tag=ap_sft_auto_tag)
+    return builder
+
+
+def test_resolve_explicit_sft_marker():
+    cls, path = _make_builder()._resolve_dataset_class("sft:/data/a")
+    assert cls is ApertusSFTDataset
+    assert path == "/data/a"
+
+
+def test_resolve_explicit_pretrain_marker():
+    cls, path = _make_builder()._resolve_dataset_class("pretrain:/data/b")
+    assert cls is GPTDataset
+    assert path == "/data/b"
+
+
+def test_resolve_auto_tag_unmarked_path():
+    cls, path = _make_builder(ap_sft_auto_tag=True)._resolve_dataset_class("/data/c")
+    assert cls is ApertusSFTDataset
+    assert path == "/data/c"
+
+
+def test_resolve_legacy_substring_emits_deprecation():
+    builder = _make_builder()
+    with pytest.warns(DeprecationWarning, match="apertus_sft"):
+        cls, path = builder._resolve_dataset_class("/data/legacy_apertus_sft_set")
+    assert cls is ApertusSFTDataset
+    assert path == "/data/legacy_apertus_sft_set"
+
+
+def test_resolve_default_pretrain():
+    cls, path = _make_builder()._resolve_dataset_class("/data/fineweb")
+    assert cls is GPTDataset
+    assert path == "/data/fineweb"
+
+
+def test_resolve_mock_config_short_circuits():
+    cls, path = _make_builder(mock=True)._resolve_dataset_class("/data/anything")
+    assert cls is MockGPTDataset
+    assert path is None
+
+
+def test_resolve_none_path_short_circuits():
+    cls, path = _make_builder()._resolve_dataset_class(None)
+    assert cls is MockGPTDataset
+    assert path is None
+
+
+def test_explicit_marker_overrides_auto_tag():
+    cls, path = _make_builder(ap_sft_auto_tag=True)._resolve_dataset_class(
+        "pretrain:/data/d"
+    )
+    assert cls is GPTDataset
+    assert path == "/data/d"
+
+
+def test_explicit_marker_overrides_legacy_substring():
+    """A path with 'apertus_sft' in it but tagged pretrain: must NOT warn
+    and must dispatch as GPTDataset."""
+    builder = _make_builder()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        cls, path = builder._resolve_dataset_class("pretrain:/data/apertus_sft_legacy")
+    assert cls is GPTDataset
+    assert path == "/data/apertus_sft_legacy"


### PR DESCRIPTION
## What changed

**Old**: a substring check (`"apertus_sft" in dataset_path`) decided whether a dataset was `ApertusSFTDataset` or `GPTDataset`. It ignored `--ap-sft`.

**New**: an explicit per-entry marker `sft:<prefix>` / `pretrain:<prefix>` (case-insensitive). Mixed SFT + pretrain blends are now more explicit.

```bash
--data-path 0.3 sft:/data/dolly 0.7 pretrain:/data/fineweb
```

Applies to every blend arg (`--data-path`, `--{train,valid,test}-data-path`, `--data-args-path`, `--per-split-data-args-path`).

## Precedence (first match wins)

| # | Condition                                                       | Dispatch             | Warning              |
|---|-----------------------------------------------------------------|----------------------|----------------------|
| 1 | Marker `sft:` / `pretrain:` on the path                         | per marker           | —                    |
| 2 | No marker, `--ap-sft` set                                       | `ApertusSFTDataset`  | —                    |
| 3 | No marker, `--ap-sft` not set, path contains `apertus_sft`      | `ApertusSFTDataset`  | `DeprecationWarning` |
| 4 | Otherwise                                                       | `GPTDataset`         | —                    |
| — | Mock config / `None` path                                       | `MockGPTDataset`     | —                    |

Only the leading marker is stripped (`sft:sft:/x` → type `sft`, path `sft:/x`). Empty path after marker (`sft:`) raises `AssertionError`. Cache identity is keyed on the stripped path.

## Behavior diff vs before

| Scenario                                          | Old                                          | New                                |
|---------------------------------------------------|----------------------------------------------|------------------------------------|
| `--ap-sft --data-path 1.0 /data/dolly`            | `GPTDataset` (latent bug — flag was ignored) | `ApertusSFTDataset` (rule 2)       |
| Mixed `sft:` + `pretrain:` entries                | not supported                                | works                              |
| `--data-path 1.0 /data/apertus_sft_foo`           | SFT, silent                                  | SFT + `DeprecationWarning`         |
| `SFT:/data/x` (uppercase)                         | treated as literal path                      | `ApertusSFTDataset`                |
| Pure pretrain / all-pretrain                      | pretrain                                     | pretrain (unchanged)               |
| All-SFT with `apertus_sft` in path                | SFT                                          | SFT (unchanged, now warns)         |

## `--ap-sft` semantics

Still required for any SFT run. It now does two things:

1. Gates the `--calculate-per-token-loss` assertion + SFT loss-reduction paths (unchanged).
2. Auto-tags unmarked entries as SFT (new — rule 2 above).

Rule of thumb: all-SFT → set `--ap-sft`, no markers needed. Mixed → set `--ap-sft` + mark every entry explicitly. All-pretrain → neither.

## Migration

- Existing `--ap-sft` launchers: no change needed.
- Paths with `apertus_sft` in the name: still work, but emit `DeprecationWarning` — migrate to `sft:` when convenient.
- Pretrain datasets whose names happen to contain `apertus_sft`: prefix with `pretrain:` to opt out of the legacy fallback.

## Implementation

| Concern          | Location                                                                                  |
|------------------|-------------------------------------------------------------------------------------------|
| Marker parser    | `megatron/core/datasets/utils.py` — `split_dataset_type_marker()`                         |
| Builder dispatch | `megatron/core/datasets/blended_megatron_dataset_builder.py` — `_resolve_dataset_class()` |
| Config field     | `megatron/core/datasets/gpt_dataset.py` — `GPTDatasetConfig.ap_sft_auto_tag`              |
| Flag wiring      | `pretrain_gpt.py`, `initialize_sft_dataset.py`                                            |
| Argparse help    | `megatron/training/arguments.py` (`--data-path`, `--ap-sft`)                              |
| Helper           | `scripts/tools/create_weighted_data_config.py --dataset-type {sft,pretrain,none}`         |
| Tests            | `tests/unit_tests/data/test_dataset_type_marker.py`                                       |