### PR TITLE
Multimodality/sft tool masking

### DIFF
--- a/megatron/training/datasets/apertus_sft_dataset.py
+++ b/megatron/training/datasets/apertus_sft_dataset.py
@@ -287,11 +287,12 @@ class ApertusSFTDataset(GPTDataset):
         # add_emu3_tokens_llama3_vision_instruct.py. Some models use separate assistant/user
         # end sequences, others share a common eot token.
 
-
         special_tokens = {
             "assistant_begin": "<|assistant_start|>",
             "assistant_end": "<|assistant_end|>",
-            "system_start": "<|system_start|>"
+            "system_start": "<|system_start|>",
+            "tool_output_start": "<|tool_output_start|>",
+            "tool_output_end": "<|tool_output_end|>", 
         }
 
         for attr, string in special_tokens.items():
@@ -901,6 +902,18 @@ class ApertusSFTDataset(GPTDataset):
                 loss_mask[: sys_pos[0].item() + sys_start_seq.numel()] = 1
 
             loss_mask[get_matching_mask(data, sys_start_seq, only_begin=False)] = 0
+
+        # 1b) Mask tool output tokens from both loss_mask and assistant_mask.
+        # Tool output spans (<|tool_output_start|> ... <|tool_output_end|>) must never
+        # be trained on, regardless of whether the loss mask was loaded from disk or built
+        # on the fly, and must not be counted as assistant tokens.
+        tool_output_start_seq = self._sft_tool_output_start_sequence.to(dtype=data.dtype, device=data.device)
+        tool_output_end_seq   = self._sft_tool_output_end_sequence.to(dtype=data.dtype, device=data.device)
+        tool_output_mask = get_matching_mask_by_start_end(data, tool_output_start_seq, tool_output_end_seq)
+
+        loss_mask[tool_output_mask] = 0.0
+        if assistant_mask is not None:
+            assistant_mask[tool_output_mask] = False
 
         # 2) Mask loss for special tokens (if activated) - only if not load loss from disk
         if preloaded_loss_mask is None:

--- a/megatron/training/datasets/apertus_sft_dataset.py
+++ b/megatron/training/datasets/apertus_sft_dataset.py
@@ -903,17 +903,15 @@ class ApertusSFTDataset(GPTDataset):
 
             loss_mask[get_matching_mask(data, sys_start_seq, only_begin=False)] = 0
 
-        # 1b) Mask tool output tokens from both loss_mask and assistant_mask.
-        # Tool output spans (<|tool_output_start|> ... <|tool_output_end|>) must never
-        # be trained on, regardless of whether the loss mask was loaded from disk or built
-        # on the fly, and must not be counted as assistant tokens.
-        tool_output_start_seq = self._sft_tool_output_start_sequence.to(dtype=data.dtype, device=data.device)
-        tool_output_end_seq   = self._sft_tool_output_end_sequence.to(dtype=data.dtype, device=data.device)
-        tool_output_mask = get_matching_mask_by_start_end(data, tool_output_start_seq, tool_output_end_seq)
+            # 1b) Mask tool output tokens from both loss_mask and assistant_mask.
+            # Tool output spans (<|tool_output_start|> ... <|tool_output_end|>)
+            tool_output_start_seq = self._sft_tool_output_start_sequence.to(dtype=data.dtype, device=data.device)
+            tool_output_end_seq   = self._sft_tool_output_end_sequence.to(dtype=data.dtype, device=data.device)
+            tool_output_mask = get_matching_mask_by_start_end(data, tool_output_start_seq, tool_output_end_seq)
 
-        loss_mask[tool_output_mask] = 0.0
-        if assistant_mask is not None:
-            assistant_mask[tool_output_mask] = False
+            loss_mask[tool_output_mask] = 0.0
+            if assistant_mask is not None:
+                assistant_mask[tool_output_mask] = False
 
         # 2) Mask loss for special tokens (if activated) - only if not load loss from disk
         if preloaded_loss_mask is None:


### PR DESCRIPTION
## Motivation

Tool outputs are embedded directly inside assistant messages, between <|tools_suffix|> and the next <|tools_prefix|>:
```
...<|assistant_start|>I'll help you find rhyming options for your birthday poem! Let me start by getting rhyming words for "smile" and counting the syllables in your current line.<|tools_prefix|>[{"lyrical-mcp-find_rhymes": {"input_word": "smile"}}]<|tools_suffix|>[{
  "1_syllable": [
    "aisle",
    "bile",
    "bille",
    "cheil",
    "deihl",
    "dial",
    "file",
    "geil",
    "gile",
    "gille",
    "guile",
    "heil",
    "hile",
    "hyle",
    "i'll",
    "isle",
    "kile",
    "kyl",
    "kyle",
    "lile"
  ],
  "2_syllable": [
    "argyll",
    "awhile",
    "beguile",
    "compile",
    "delisle",
    "fertile",
    "hostile",
    "kurzweil",
    "marseille",
    "mikhail",
    "monteil",
    "nevile",
    "panfile",
    "refile",
    "restyle",
    "revile",
    "soleil",
    "vantuyl",
    "worthwhile"
  ],
  "3_syllable": [
    "versatile"
  ]
}]<|tools_prefix|>[{"lyrical-mcp-count_syllables": {"input_string": "With joy that leaps from every smile"}}]<|tools_suffix|>[9]Great! Here's what I found:

## Rhyming Options for "smile":
- **1 syllable**: aisle, file, guile, isle, kyle, tile, while
- **2 syllables**: awhile, beguile, compile, fertile, hostile, worthwhile
- **3 syllables**: versatile
...
```
Previously, loss masking only needed to unmask everything between `<|assistant_start|>` and `<|assistant_end|>`. Tool outputs now sit inside that span and must be excluded from the training loss, otherwise the model is trained to predict deterministic tool responses it has no control over.

## Problem

Bracket matching on raw token IDs is not straightforward: `[` and `]` appear in hundreds of compound tokens (`[{`, `"}]`, `"]["`, `],` ...). A naïve check against the single-character token ID silently misses all of them, producing incorrect bracket depth and thus wrong mask boundaries.

## Implementation

**1. Bracket delta lookup table** (`__init__`): a tensor of shape `(vocab_size,)` is built once at dataset initialisation. For every token in the vocabulary, its entry stores the net bracket contribution (`count('[') - count(']')`), covering all compound forms correctly.

**2. Cumsum bracket matching** (`_get_ltor_masks_and_position_ids`): for each `<|tools_suffix|>` position, a depth-tracking cumulative sum over the lookup values is computed once for the full sequence in O(N). The closing `]` is then found with a single `torch.where` call per tool call rather than a Python loop over tokens. Both `loss_mask` and `assistant_mask` are zeroed over the matched span.