### PR TITLE
Energy Monitor Fix + Sandwich Norm + Weight Decay on 1D/Scalar Parameters

### DIFF
--- a/gpt_builders.py
+++ b/gpt_builders.py
@@ -136,12 +136,14 @@ def _get_transformer_layer_spec(use_te, config):
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
             mla_down_proj_fusion=getattr(config, "mla_down_proj_fusion", False),
+            sandwich_norm=config.sandwich_norm,
         )
     elif config.transformer_impl == "inference_optimized":
         return get_gpt_layer_with_inference_spec(
             config.qk_layernorm,
             config.multi_latent_attention,
             qk_l2_norm=config.qk_l2_norm,
+            sandwich_norm=config.sandwich_norm,
         )
     else:
         return get_gpt_layer_local_spec(
@@ -154,4 +156,5 @@ def _get_transformer_layer_spec(use_te, config):
             use_kitchen=config.use_kitchen,
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
+            sandwich_norm=config.sandwich_norm,
         )

--- a/megatron/core/energy_monitor.py
+++ b/megatron/core/energy_monitor.py
@@ -33,31 +33,41 @@ class EnergyMonitor:
         self._lap_energy = 0
         self._last_energy = 0
         self._handle = None
+        self._active = False
+
+    def _is_active(self) -> bool:
+        """Return whether NVML has been initialized for this monitor."""
+        return has_nvml and self._active and self._handle is not None
 
     def setup(self) -> None:
         """Setup the NVML Handler."""
         if has_nvml:
             nvmlInit()
             self._handle = nvmlDeviceGetHandleByIndex(torch.cuda.current_device())
+            self._active = True
 
     def shutdown(self) -> None:
         """Shutdown NVML."""
-        if has_nvml:
+        if self._is_active():
             nvmlShutdown()
+            self._handle = None
+            self._active = False
 
     def pause(self) -> None:
         """Pause energy monitor (must resume afterward)."""
-        if has_nvml:
+        if self._is_active():
             energy = self._get_energy()
             self._lap_energy += energy - self._last_energy
 
     def resume(self) -> None:
         """Resume/start energy monitor."""
-        if has_nvml:
+        if self._is_active():
             self._last_energy = self._get_energy()
 
     def _get_energy(self) -> int:
         """Get current energy consumption from NVML."""
+        if not self._is_active():
+            return self._last_energy
         try:
             return nvmlDeviceGetTotalEnergyConsumption(self._handle)
         except NVMLError:
@@ -65,7 +75,7 @@ class EnergyMonitor:
 
     def lap(self) -> float:
         """Returns lap (iteration) energy (J) and updates total energy."""
-        if not has_nvml:
+        if not self._is_active():
             return 0.0
 
         energy = self._get_energy()
@@ -82,7 +92,7 @@ class EnergyMonitor:
 
     def get_total(self) -> float:
         """Get total energy consumption (J) across all GPUs."""
-        if not has_nvml:
+        if not self._is_active():
             return 0.0
 
         energy_tensor = torch.tensor([self._total_energy], dtype=torch.int64, device='cuda')

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -77,12 +77,15 @@ def get_gpt_layer_with_inference_submodules(
     num_experts: Optional[int] = None,
     moe_grouped_gemm: Optional[bool] = False,
     moe_use_legacy_grouped_gemm: Optional[bool] = False,
+    sandwich_norm: bool = False,
 ) -> TransformerLayerSubmodules:
     """Use these submodules for inference optimized linear layers.
     Args:
         qk_layernorm (bool, optional): To use layernorm for queries/keys. Defaults to False.
         multi_latent_attention (bool, optional): To use MLA. Defaults to False.
         qk_l2_norm (bool, optional): To use l2 norm for queries/keys. Defaults to False.
+        sandwich_norm (bool, optional): Add a normalization to each sublayer's output before the
+            residual add (sandwich norm). Defaults to False.
     """
     assert HAVE_TE, "--transformer-impl inference_optimized requires transformer engine"
     backend = InferenceSpecProvider()
@@ -94,6 +97,9 @@ def get_gpt_layer_with_inference_submodules(
         use_te_op_fuser=False,
         use_te_activation_func=False,
     )
+
+    # Sandwich norm: a standalone norm on each sublayer output, before the residual add.
+    post_layer_norm = backend.layer_norm() if sandwich_norm else IdentityOp
 
     if multi_latent_attention:
         assert qk_l2_norm is False, "qk_l2_norm is not supported with MLA."
@@ -125,9 +131,11 @@ def get_gpt_layer_with_inference_submodules(
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
+            post_self_attn_layernorm=post_layer_norm,
             pre_mlp_layernorm=IdentityOp,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            post_mlp_layernorm=post_layer_norm,
         )
     else:
         qk_norm = backend.layer_norm(for_qk=True)
@@ -148,9 +156,11 @@ def get_gpt_layer_with_inference_submodules(
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
+            post_self_attn_layernorm=post_layer_norm,
             pre_mlp_layernorm=backend.layer_norm() if num_experts else IdentityOp,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            post_mlp_layernorm=post_layer_norm,
             sharded_state_dict_keys_map={
                 "mlp.0.weight": "mlp.linear_fc1.layer_norm_weight",
                 "mlp.0.bias": "mlp.linear_fc1.layer_norm_bias",
@@ -183,6 +193,7 @@ def get_gpt_layer_with_transformer_engine_submodules(
     use_kitchen_attention: bool = False,
     kitchen_attention_backend: str = "sdpa",
     mla_down_proj_fusion: bool = False,
+    sandwich_norm: bool = False,
 ) -> TransformerLayerSubmodules:
     """Use these submodules to use lower-level Transformer Engine modules (required for fp8
     training).
@@ -200,6 +211,8 @@ def get_gpt_layer_with_transformer_engine_submodules(
         mla_down_proj_fusion (bool, optional): Enable fused q/kv down-projection and fused input
                                                layernorm when backend supports. Otherwise fall back
                                                to the unfused MLA.
+        sandwich_norm (bool, optional): Add a normalization to each sublayer's output before the
+                                        residual add (sandwich norm). Defaults to False.
 
     Returns:
         TransformerLayerSubmodules: TE modules to construct a TransformerLayer
@@ -232,6 +245,10 @@ def get_gpt_layer_with_transformer_engine_submodules(
         use_te_op_fuser=use_te_op_fuser,
         use_te_activation_func=use_te_activation_func,
     )
+
+    # Sandwich norm: a standalone norm on each sublayer output, before the residual add.
+    # TENorm picks LayerNorm/RMSNorm from config.normalization at build time.
+    post_layer_norm = backend.layer_norm() if sandwich_norm else IdentityOp
 
     if multi_latent_attention:
         assert qk_l2_norm is False, "qk_l2_norm is not supported with MLA."
@@ -271,9 +288,11 @@ def get_gpt_layer_with_transformer_engine_submodules(
                     ),
                 ),
                 self_attn_bda=get_bias_dropout_add,
+                post_self_attn_layernorm=post_layer_norm,
                 pre_mlp_layernorm=backend.layer_norm() if num_experts else IdentityOp,
                 mlp=mlp,
                 mlp_bda=get_bias_dropout_add,
+                post_mlp_layernorm=post_layer_norm,
                 sharded_state_dict_keys_map=(
                     {
                         "self_attention.linear_q_down_proj.layer_norm_": "input_layernorm.",
@@ -302,9 +321,11 @@ def get_gpt_layer_with_transformer_engine_submodules(
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
+            post_self_attn_layernorm=post_layer_norm,
             pre_mlp_layernorm=backend.layer_norm(has_residual=True) if num_experts else IdentityOp,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            post_mlp_layernorm=post_layer_norm,
         )
     else:
         qk_norm = backend.layer_norm(for_qk=True)
@@ -325,9 +346,11 @@ def get_gpt_layer_with_transformer_engine_submodules(
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
+            post_self_attn_layernorm=post_layer_norm,
             pre_mlp_layernorm=backend.layer_norm(has_residual=True) if num_experts else IdentityOp,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            post_mlp_layernorm=post_layer_norm,
             sharded_state_dict_keys_map={
                 "mlp.0.weight": "mlp.linear_fc1.layer_norm_weight",
                 "mlp.0.bias": "mlp.linear_fc1.layer_norm_bias",
@@ -359,6 +382,7 @@ def get_gpt_layer_local_submodules(
     use_kitchen: bool = False,
     use_kitchen_attention: bool = False,
     kitchen_attention_backend: str = "sdpa",
+    sandwich_norm: bool = False,
 ) -> TransformerLayerSubmodules:
     """Use these submodules for an implementation using only modules in Megatron-Core.
 
@@ -370,6 +394,8 @@ def get_gpt_layer_local_submodules(
         multi_latent_attention (bool, optional): To use MLA. Defaults to False.
         fp8 (str, optional): Deprecated. For temporary Nemo compatibility.
         qk_l2_norm (bool, optional): To use l2 norm for queries/keys. Defaults to False.
+        sandwich_norm (bool, optional): Add a normalization to each sublayer's output before the
+            residual add (sandwich norm). Defaults to False.
 
     Returns:
         TransformerLayerSubmodules: Megatron-Core modules to construct a TransformerLayer
@@ -402,6 +428,10 @@ def get_gpt_layer_local_submodules(
         backend=backend, num_experts=num_experts, moe_grouped_gemm=moe_grouped_gemm
     )
 
+    # Sandwich norm: a standalone norm on each sublayer output, before the residual add. Reuse the
+    # same (LayerNorm/RMSNorm) implementation already selected for the layer's other norms.
+    post_layer_norm = layer_norm if sandwich_norm else IdentityOp
+
     if multi_latent_attention:
         assert qk_l2_norm is False, "qk_l2_norm is not supported with MLA."
         return TransformerLayerSubmodules(
@@ -422,9 +452,11 @@ def get_gpt_layer_local_submodules(
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
+            post_self_attn_layernorm=post_layer_norm,
             pre_mlp_layernorm=layer_norm,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            post_mlp_layernorm=post_layer_norm,
         )
     else:
         return TransformerLayerSubmodules(
@@ -445,9 +477,11 @@ def get_gpt_layer_local_submodules(
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
+            post_self_attn_layernorm=post_layer_norm,
             pre_mlp_layernorm=layer_norm,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            post_mlp_layernorm=post_layer_norm,
             sharded_state_dict_keys_map={
                 "input_layernorm.": "self_attention.linear_qkv.layer_norm_",
                 "pre_mlp_layernorm.": "mlp.linear_fc1.layer_norm_",
@@ -568,6 +602,7 @@ def get_gpt_decoder_layer_specs(
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
             mla_down_proj_fusion=getattr(config, "mla_down_proj_fusion", False),
+            sandwich_norm=config.sandwich_norm,
         )
         moe_layer_spec = get_gpt_layer_with_transformer_engine_spec(
             num_experts=config.num_moe_experts,
@@ -580,6 +615,7 @@ def get_gpt_decoder_layer_specs(
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
             mla_down_proj_fusion=getattr(config, "mla_down_proj_fusion", False),
+            sandwich_norm=config.sandwich_norm,
         )
     elif config.transformer_impl == "inference_optimized":
         layer_norm_impl = TENorm
@@ -587,6 +623,7 @@ def get_gpt_decoder_layer_specs(
             qk_layernorm=config.qk_layernorm,
             multi_latent_attention=config.multi_latent_attention,
             qk_l2_norm=qk_l2_norm,
+            sandwich_norm=config.sandwich_norm,
         )
         moe_layer_spec = get_gpt_layer_with_inference_spec(
             qk_layernorm=config.qk_layernorm,
@@ -595,6 +632,7 @@ def get_gpt_decoder_layer_specs(
             num_experts=config.num_moe_experts,
             moe_grouped_gemm=config.moe_grouped_gemm,
             moe_use_legacy_grouped_gemm=config.moe_use_legacy_grouped_gemm,
+            sandwich_norm=config.sandwich_norm,
         )
     else:
         layer_norm_impl = LNImpl
@@ -608,6 +646,7 @@ def get_gpt_decoder_layer_specs(
             use_kitchen=config.use_kitchen,
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
+            sandwich_norm=config.sandwich_norm,
         )
         moe_layer_spec = get_gpt_layer_local_spec(
             num_experts=config.num_moe_experts,
@@ -619,6 +658,7 @@ def get_gpt_decoder_layer_specs(
             use_kitchen=config.use_kitchen,
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
+            sandwich_norm=config.sandwich_norm,
         )
 
     # Parse config.moe_layer_freq to determine the pattern of expert/dense layers.

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -428,9 +428,15 @@ def get_gpt_layer_local_submodules(
         backend=backend, num_experts=num_experts, moe_grouped_gemm=moe_grouped_gemm
     )
 
-    # Sandwich norm: a standalone norm on each sublayer output, before the residual add. Reuse the
-    # same (LayerNorm/RMSNorm) implementation already selected for the layer's other norms.
-    post_layer_norm = layer_norm if sandwich_norm else IdentityOp
+    # Sandwich norm: a standalone norm on each sublayer output, before the residual add. Built with
+    # has_residual=False: unlike the pre-norms it does not sit on the residual stream (the residual
+    # add happens after it, in the bias-dropout-add), so it must stay a plain single-tensor norm and
+    # not the residual-fused variant. Matches the model's LayerNorm/RMSNorm type.
+    post_layer_norm = (
+        backend.layer_norm(rms_norm=(normalization == "RMSNorm"), for_qk=False, has_residual=False)
+        if sandwich_norm
+        else IdentityOp
+    )
 
     if multi_latent_attention:
         assert qk_l2_norm is False, "qk_l2_norm is not supported with MLA."

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -91,23 +91,26 @@ def get_standard_config_overrides(config: OptimizerConfig) -> Dict[ParamKey, Par
         Dict[ParamKey, ParamGroupOverride]: standard config overrides.
     """
     config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]] = {}
-    # First, figure out how we are going to do wd skipping. The two main approaches are:
+    # First, figure out how we are going to do wd skipping. The main approaches are:
     #  1. The classic megatron approach of skipping all len 1 and bias parameters.
     #  2. The Qwen3-Next approach of doing 1, other than qk layernorm parameters.
-    if config.apply_wd_to_qk_layernorm:
-        shape_1_not_qkln_param = ParamWithNamePredicate(
-            name="s1_not_qkln",
-            fn=lambda param, name: (len(param.shape) == 1 or name.endswith(".bias"))
-            and not ("q_layernorm." in name or "k_layernorm." in name),
-        )
-        param_wd_mult_key = ParamKey(with_name_predicate=shape_1_not_qkln_param)
-    else:
-        param_length_1_match = ParamPredicate(
-            name="param_len_1", fn=lambda param: len(param.shape) == 1
-        )
-        param_wd_mult_key = ParamKey(name="*.bias", predicate=param_length_1_match)
+    #  3. Applying weight decay to every parameter (weight_decay_all_param), in which case we
+    #     register no wd_mult=0.0 override at all. This takes precedence over 1 and 2.
+    if not config.weight_decay_all_param:
+        if config.apply_wd_to_qk_layernorm:
+            shape_1_not_qkln_param = ParamWithNamePredicate(
+                name="s1_not_qkln",
+                fn=lambda param, name: (len(param.shape) == 1 or name.endswith(".bias"))
+                and not ("q_layernorm." in name or "k_layernorm." in name),
+            )
+            param_wd_mult_key = ParamKey(with_name_predicate=shape_1_not_qkln_param)
+        else:
+            param_length_1_match = ParamPredicate(
+                name="param_len_1", fn=lambda param: len(param.shape) == 1
+            )
+            param_wd_mult_key = ParamKey(name="*.bias", predicate=param_length_1_match)
 
-    config_overrides[param_wd_mult_key] = ParamGroupOverride(wd_mult=0.0)
+        config_overrides[param_wd_mult_key] = ParamGroupOverride(wd_mult=0.0)
 
     if config.decoupled_lr is not None:
         decoupled_lr_config: ParamGroupOverride = {"max_lr": config.decoupled_lr}

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -165,6 +165,11 @@ class OptimizerConfig:
     apply_wd_to_qk_layernorm: bool = False
     """If true, apply weight decay to qk layernorm as a special case."""
 
+    weight_decay_all_param: bool = False
+    """If true, apply weight decay to all parameters, including the scalar/1d parameters
+       (e.g. biases and norm weights) that Megatron skips by default. Takes precedence over
+       apply_wd_to_qk_layernorm."""
+
     ##############
     # Precision
     ##############

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -220,6 +220,13 @@ class TransformerConfig(ModelParallelConfig):
     normalization: Literal['LayerNorm', 'RMSNorm'] = "LayerNorm"
     """Which norm to use for normalization layers, valid options are `LayerNorm` and `RMSNorm`."""
 
+    sandwich_norm: bool = False
+    """If True, apply an extra `normalization`-type norm to each sublayer's output before it is
+    added back to the residual stream (a.k.a. sandwich norm / post-norm), so that each layer
+    computes `x = x + Norm(Sublayer(Norm(x)))`. This normalizes the residual-branch contribution
+    while leaving the residual stream itself untouched, which bounds activation growth in deep
+    networks. Applies to the self-attention and MLP sublayers."""
+
     qk_layernorm: bool = False
     """Whether to apply `normalization` type of normalization to the query and key embeddings."""
 
@@ -1039,6 +1046,14 @@ class TransformerConfig(ModelParallelConfig):
         # Apply BF16 matmul precision setting if needed
         if self.bf16 and self.disable_bf16_reduced_precision_matmul:
             torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+
+        if self.sandwich_norm and self.inference_fuse_tp_communication:
+            raise ValueError(
+                "sandwich_norm is not compatible with inference_fuse_tp_communication: the "
+                "fused TP inference kernel folds the residual add into the attention/MLP output "
+                "projection, leaving no point at which to normalize the sublayer output before "
+                "the residual add."
+            )
 
         if self.num_attention_heads % self.tensor_model_parallel_size != 0:
             raise ValueError(

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -213,6 +213,8 @@ class TransformerLayerSubmodules:
         self_attention (Union[ModuleSpec, type]): Specification for the self-attention mechanism.
         self_attn_bda (Union[ModuleSpec, type]): Specification for the bias-dropout-add operation
             after self-attention.
+        post_self_attn_layernorm: Specification for the (sandwich-norm) layer normalization applied
+            to the self-attention output before the residual add. Defaults to a no-op.
         pre_cross_attn_layernorm: Specification for the layer
             normalization before cross-attention.
         cross_attention (Union[ModuleSpec, type]): Specification for the cross-attention mechanism.
@@ -223,6 +225,8 @@ class TransformerLayerSubmodules:
         mlp (Union[ModuleSpec, type]): Specification for the MLP in Dense layer.
         mlp_bda (Union[ModuleSpec, type]): Specification for the bias-dropout-add operation
             after the MLP.
+        post_mlp_layernorm: Specification for the (sandwich-norm) layer normalization applied to
+            the MLP output before the residual add. Defaults to a no-op.
         sharded_state_dict_keys_map (Dict[str, str]): Mapping for sharded tensor keys to be applied
             in the `sharded_state_dict` method.
     """
@@ -230,6 +234,7 @@ class TransformerLayerSubmodules:
     input_layernorm: LayerNormBuilder = IdentityOp
     self_attention: Union[ModuleSpec, type] = IdentityOp
     self_attn_bda: Union[ModuleSpec, type] = IdentityFuncOp
+    post_self_attn_layernorm: LayerNormBuilder = IdentityOp
 
     pre_cross_attn_layernorm: LayerNormBuilder = IdentityOp
     cross_attention: Union[ModuleSpec, type] = IdentityOp
@@ -238,6 +243,7 @@ class TransformerLayerSubmodules:
     pre_mlp_layernorm: LayerNormBuilder = IdentityOp
     mlp: Union[ModuleSpec, type] = IdentityOp
     mlp_bda: Union[ModuleSpec, type] = IdentityFuncOp
+    post_mlp_layernorm: LayerNormBuilder = IdentityOp
 
     # Mapping for sharded tensor keys to be applied in `sharded_state_dict` method
     sharded_state_dict_keys_map: Dict[str, str] = field(default_factory=dict)
@@ -335,6 +341,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # [Module 3: BiasDropoutFusion]
         self.self_attn_bda = build_module(submodules.self_attn_bda)
 
+        # [Module 3.5: Post SelfAttention Layernorm] Optional sandwich-norm applied to the
+        # self-attention output before the residual add. IdentityOp (no-op) unless enabled.
+        self.post_self_attn_layernorm = submodules.post_self_attn_layernorm(
+            config=self.config,
+            hidden_size=self.config.hidden_size,
+            eps=self.config.layernorm_epsilon,
+        )
+
         # [Module 4: Post SelfAttention] Optional Layernorm after self-attn
         self.pre_cross_attn_layernorm = submodules.pre_cross_attn_layernorm(
             config=self.config,
@@ -398,6 +412,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         # [Module 9: BiasDropoutFusion]
         self.mlp_bda = build_module(submodules.mlp_bda)
+
+        # [Module 9.5: Post MLP Layernorm] Optional sandwich-norm applied to the MLP output
+        # before the residual add. IdentityOp (no-op) unless enabled.
+        self.post_mlp_layernorm = submodules.post_mlp_layernorm(
+            config=self.config,
+            hidden_size=self.config.hidden_size,
+            eps=self.config.layernorm_epsilon,
+        )
 
         self.is_moe_layer = isinstance(self.mlp, MoELayer)
 
@@ -525,6 +547,25 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
         return get_transformer_layer_offset(config)
 
+    @staticmethod
+    def _apply_post_norm(output_with_bias, post_norm):
+        """Apply a sandwich-norm to a sublayer's output before the residual add.
+
+        ``output_with_bias`` is the ``(output, bias)`` pair produced by a sublayer (attention
+        or MLP). When sandwich norm is enabled, ``post_norm`` is a real normalization module:
+        the bias (if any) is folded into the output, the result is normalized, and
+        ``(normed, None)`` is returned so the downstream bias-dropout-add simply applies dropout
+        and the residual add, yielding ``residual + dropout(Norm(output + bias))``. When sandwich
+        norm is disabled, ``post_norm`` is an ``IdentityOp`` and the pair is returned unchanged,
+        preserving the fused bias-dropout-add path exactly (no extra work, no behavior change).
+        """
+        if isinstance(post_norm, IdentityOp):
+            return output_with_bias
+        output, bias = output_with_bias
+        if bias is not None:
+            output = output + bias
+        return apply_module(post_norm)(output), None
+
     def _forward_attention(
         self,
         hidden_states: Tensor,
@@ -632,6 +673,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             self.input_layernorm_checkpoint.discard_output_and_register_recompute(
                 attention_output_with_bias[0]
             )
+
+        # Optional sandwich norm: normalize the self-attention output before the residual add.
+        attention_output_with_bias = self._apply_post_norm(
+            attention_output_with_bias, self.post_self_attn_layernorm
+        )
 
         # TODO: could we move `bias_dropout_add_exec_handler` itself
         # inside the module provided in the `bias_dropout_add_spec` module?
@@ -864,6 +910,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             self.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(
                 mlp_output_with_bias[0]
             )
+
+        # Optional sandwich norm: normalize the MLP output before the residual add.
+        mlp_output_with_bias = self._apply_post_norm(
+            mlp_output_with_bias, self.post_mlp_layernorm
+        )
 
         # TODO: could we move `bias_dropout_add_exec_handler` itself
         # inside the module provided in the `bias_dropout_add_spec` module?

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2210,6 +2210,10 @@ def _add_regularization_args(parser):
                        help='Weight decay coefficient for L2 regularization.')
     group.add_argument('--apply-wd-to-qk-layernorm', action='store_true',
                        help='Apply weight decay to qk layernorm as a special case.')
+    group.add_argument('--weight-decay-all-param', action='store_true',
+                       help='Apply weight decay to all parameters, including the scalar/1d '
+                       'parameters (e.g. biases and norm weights) that are skipped by default. '
+                       'Takes precedence over --apply-wd-to-qk-layernorm.')
     group.add_argument('--clip-grad', type=float, default=1.0,
                        help='Gradient clipping based on global L2 norm.')
     group.add_argument('--adam-beta1', type=float, default=0.9,

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -286,6 +286,35 @@ def test_get_param_groups_appling_wd_to_qk_layernorm(apply_wd_to_qk_layernorm: b
     )
 
 
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_get_param_groups_weight_decay_all_param(mock_get_world_size):
+    """With weight_decay_all_param=True, every parameter (including scalar/1d params such as
+    biases and norm weights) receives weight decay (wd_mult=1.0). No wd_mult=0.0 override is
+    registered, so all parameters collapse into a single param group."""
+
+    # Initialize the model with layernorm so we also cover norm weights.
+    net = Net(add_layernorm=True)
+
+    config = OptimizerConfig(optimizer='adam', lr=0.01, weight_decay_all_param=True)
+    config_overrides = get_standard_config_overrides(config=config)
+
+    # No weight-decay-skipping override should be registered.
+    assert config_overrides == {}
+
+    param_groups = _get_param_groups([net], config, config_overrides)
+
+    # All parameters share the default config, so there is exactly one param group.
+    assert len(param_groups) == 1
+    assert param_groups[0]['wd_mult'] == 1.0
+
+    p_set = set(net.parameters())
+    assert set(param_groups[0]['params']) == p_set
+    assert len(param_groups[0]['params']) == len(p_set)
+
+
 def test_chained_optimizer():
     net = Net()
     optimizer_1 = Adam(list(net.parameters())[:2], lr=0.01)

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -11,6 +11,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import (
     TransformerLayer,
@@ -313,3 +314,99 @@ def get_tensor_shapes_for_tp(transformer_config, tp_size):
         'self_attention.linear_qkv.weight': (hs * 3 // tp_size, hs),
         'self_attention.linear_qkv.bias': (hs * 3 // tp_size,),
     }
+
+
+def test_apply_post_norm_sandwich_norm_math():
+    """Unit-test the core sandwich-norm hook (CPU only, no model parallel / TE required).
+
+    When enabled, the hook must fold the bias into the sublayer output, normalize the result,
+    and drop the bias (so the downstream bias-dropout-add only adds the residual). When disabled
+    it must return the ``(output, bias)`` pair unchanged so the fused bias-dropout-add is intact.
+    """
+    torch.manual_seed(0)
+    hidden = 8
+    output = torch.randn(4, 2, hidden)
+    bias = torch.randn(hidden)
+    norm = torch.nn.LayerNorm(hidden)
+    norm.weight.data.normal_()
+    norm.bias.data.normal_()
+
+    # Disabled (IdentityOp): the (output, bias) pair is returned unchanged.
+    out_disabled, bias_disabled = TransformerLayer._apply_post_norm((output, bias), IdentityOp())
+    assert out_disabled is output
+    assert bias_disabled is bias
+
+    # Enabled with a bias: bias is folded in, output is normalized, bias is dropped.
+    out_enabled, bias_enabled = TransformerLayer._apply_post_norm((output, bias), norm)
+    assert bias_enabled is None
+    torch.testing.assert_close(out_enabled, norm(output + bias))
+
+    # Enabled without a bias: just normalize the output.
+    out_no_bias, bias_no_bias = TransformerLayer._apply_post_norm((output, None), norm)
+    assert bias_no_bias is None
+    torch.testing.assert_close(out_no_bias, norm(output))
+
+
+class TestSandwichNormTransformerLayer:
+    """Integration tests for the --sandwich-norm option (requires GPU + Transformer Engine)."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _build_layer(sandwich_norm):
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            sandwich_norm=sandwich_norm,
+            use_cpu_initialization=True,
+        )
+        return TransformerLayer(
+            config,
+            get_gpt_layer_with_transformer_engine_submodules(sandwich_norm=sandwich_norm),
+        )
+
+    def test_post_norms_wired(self):
+        # Disabled: both post-norms are no-ops.
+        off = self._build_layer(sandwich_norm=False)
+        assert isinstance(off.post_self_attn_layernorm, IdentityOp)
+        assert isinstance(off.post_mlp_layernorm, IdentityOp)
+
+        # Enabled: both post-norms are real normalization modules with their own parameters.
+        on = self._build_layer(sandwich_norm=True)
+        assert not isinstance(on.post_self_attn_layernorm, IdentityOp)
+        assert not isinstance(on.post_mlp_layernorm, IdentityOp)
+        assert sum(p.numel() for p in on.parameters()) > sum(p.numel() for p in off.parameters())
+
+    @pytest.mark.parametrize("sandwich_norm", [False, True])
+    def test_gpu_forward(self, sandwich_norm):
+        layer = self._build_layer(sandwich_norm=sandwich_norm).cuda()
+        config = layer.config
+        sequence_length, micro_batch_size = 32, 2
+        hidden_states = torch.ones((sequence_length, micro_batch_size, config.hidden_size)).cuda()
+        attention_mask = torch.ones((1, 1, sequence_length, sequence_length), dtype=bool).cuda()
+
+        output, _ = layer(hidden_states=hidden_states, attention_mask=attention_mask)
+        assert output.shape == (sequence_length, micro_batch_size, config.hidden_size)
+
+    def test_sandwich_norm_changes_output(self):
+        # Sandwich norm normalizes each sublayer's contribution, so the layer output must differ
+        # from the standard pre-norm layer given identical inputs and seeded weights.
+        sequence_length, micro_batch_size, hidden = 32, 2, 12
+        hidden_states = torch.rand((sequence_length, micro_batch_size, hidden)).cuda()
+        attention_mask = torch.ones((1, 1, sequence_length, sequence_length), dtype=bool).cuda()
+
+        model_parallel_cuda_manual_seed(123)
+        baseline = self._build_layer(sandwich_norm=False).cuda()
+        out_baseline, _ = baseline(hidden_states=hidden_states, attention_mask=attention_mask)
+
+        model_parallel_cuda_manual_seed(123)
+        sandwiched = self._build_layer(sandwich_norm=True).cuda()
+        out_sandwiched, _ = sandwiched(hidden_states=hidden_states, attention_mask=attention_mask)
+
+        assert not torch.allclose(out_baseline, out_sandwiched)


### PR DESCRIPTION
Added energy monitor fix from multimodality/main otherwise checkpointing is broken

`--sandwich-norm`
Added sandwich norm which will be used for Apertus2

`--weight-decay-all-param`
Added weight decay for all parameters. Default MegatronLM skips weight decay on normalization gain. May need to implement a custom weight decay config for the new optimizer.