### PR TITLE
Add FP8 Dispatch with NCCL All-to-All

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -57,6 +57,15 @@ try:
         CheckpointMetadataCache,
     )
 
+    # Probe the full async API that `get_async_strategy("nvrx")` requires (not just the
+    # two symbols above). An nvrx version that is present but missing newer symbols would
+    # otherwise leave HAVE_NVRX=True and crash *every* save -- including synchronous ones,
+    # which are implemented as `async_save(...).execute_sync()` and select the backend via
+    # HAVE_NVRX. Probing here makes an incompatible nvrx fall back to the mcore backend.
+    from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import (  # noqa: F401
+        get_write_results_queue as _nvrx_get_write_results_queue,
+    )
+
     HAVE_NVRX = True
 except (ImportError, ModuleNotFoundError):
     CheckpointMetadataCache = ABC

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -477,7 +477,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                     sequence_len_offset=sequence_len_offset,
                 )
                 if not isinstance(layer.mlp, MoELayer):
-                    return hidden_states, None, None, None
+                    return hidden_states, None, None, None, None
                 if layer.recompute_pre_mlp_layernorm:
                     layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
                     with off_interface(
@@ -496,12 +496,12 @@ def build_transformer_layer_callables(layer: TransformerLayer):
 
                 shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)
                 probs, routing_map = layer.mlp.route(pre_mlp_layernorm_output)
-                local_tokens, probs = layer.mlp.preprocess(
+                local_tokens, local_tokens_sf, probs = layer.mlp.preprocess(
                     pre_mlp_layernorm_output, probs, routing_map
                 )
-                return hidden_states, local_tokens, probs, shared_expert_output
+                return hidden_states, local_tokens, local_tokens_sf, probs, shared_expert_output
 
-        hidden_states, local_tokens, probs, shared_expert_output = forward_func(
+        hidden_states, local_tokens, local_tokens_sf, probs, shared_expert_output = forward_func(
             hidden_states=hidden_states,
             attention_mask=node.chunk_state.attention_mask,
             rotary_pos_emb=node.chunk_state.rotary_pos_emb,
@@ -519,10 +519,13 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             # Detach here for shared expert connection in moe_combine
             node.layer_state.shared_expert_output = node.detach(shared_expert_output)
 
-        return local_tokens, probs
+        return local_tokens, local_tokens_sf, probs
 
     def submodule_dispatch_forward(
-        node: ScheduleNode, local_tokens: torch.Tensor, probs: torch.Tensor
+        node: ScheduleNode,
+        local_tokens: torch.Tensor,
+        local_tokens_sf: Optional[torch.Tensor],
+        probs: torch.Tensor,
     ):
         """
         Dispatches tokens to the experts based on the router output.
@@ -533,15 +536,21 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             # backward graph from connecting to attn submodule
             token_dispatcher._comm_manager.token_probs = probs
 
-        dispatched_tokens, dispatched_probs = layer.mlp.dispatch(local_tokens, probs)
+        dispatched_tokens, dispatched_tokens_sf, dispatched_probs = layer.mlp.dispatch(
+            local_tokens, local_tokens_sf, probs
+        )
 
         # `dispatched_probs` is needed by backward pass of swiglu, therefore it's
         # passed to moe_forward within `layer_state` to avoid the free_input process
         # of the input tensors.
         node.layer_state.dispatched_probs = node.detach(dispatched_probs)
-        return dispatched_tokens
+        return dispatched_tokens, dispatched_tokens_sf
 
-    def submodule_moe_forward(node: ScheduleNode, dispatched_tokens: torch.Tensor):
+    def submodule_moe_forward(
+        node: ScheduleNode,
+        dispatched_tokens: torch.Tensor,
+        dispatched_tokens_sf: Optional[torch.Tensor],
+    ):
         """
         Run forward pass for computations between dispatch and combine:
             post dispatch->experts->combine preprocess
@@ -553,7 +562,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             # backward graph from connecting to dispatch submodule
             token_dispatcher._comm_manager.dispatched_probs = dispatched_probs
 
-        expert_output, _ = layer.mlp.routed_experts_compute(dispatched_tokens, dispatched_probs)
+        expert_output, _ = layer.mlp.routed_experts_compute(
+            dispatched_tokens, dispatched_tokens_sf, dispatched_probs
+        )
 
         # For HybridEP, tokens_per_expert is generated on comm stream, as the input to
         # `routed_experts_compute`, a ref is needed to prevent it from being freed.

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -180,15 +180,29 @@ class ScheduleNode:
 
     def default_backward_func(self, outputs, output_grad):
         """Default backward function"""
-        Variable._execution_engine.run_backward(
-            tensors=outputs,
-            grad_tensors=output_grad,
-            keep_graph=False,
-            create_graph=False,
-            inputs=tuple(),
-            allow_unreachable=True,
-            accumulate_grad=True,
-        )
+        # Some forward outputs are non-differentiable metadata rather than
+        # autograd-tracked activations, e.g. the FP8 scale factors produced by
+        # FP8 dispatch (a real tensor that does not require grad) or `None`
+        # placeholders. These must not be passed to the autograd engine as
+        # backward roots, otherwise run_backward raises "element N of tensors
+        # tuple is neither a Tensor nor a GradientEdge". Filter them and their
+        # corresponding grads out here.
+        roots_and_grads = [
+            (t, g)
+            for t, g in zip(outputs, output_grad)
+            if isinstance(t, torch.Tensor) and t.requires_grad
+        ]
+        if roots_and_grads:
+            tensors, grad_tensors = zip(*roots_and_grads)
+            Variable._execution_engine.run_backward(
+                tensors=tensors,
+                grad_tensors=grad_tensors,
+                keep_graph=False,
+                create_graph=False,
+                inputs=tuple(),
+                allow_unreachable=True,
+                accumulate_grad=True,
+            )
         return output_grad
 
     def forward(self, inputs=()):

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -48,6 +48,7 @@ from megatron.core.transformer.moe.experts_offloading_util import (
     offloading_grouped_swiglu_mlp,
 )
 from megatron.core.transformer.moe.experts_offloading_fp8_util import (
+    OffloadingFP8Config,
     offloading_fp8_grouped_swiglu_mlp,
 )
 
@@ -1172,6 +1173,9 @@ class OffloadingExpertsMLP(MegatronModule):
         self.chunk_size = num_local_experts // self.num_chunks # one chunk contains num_local_experts // self.num_chunks experts
         self.config.moe_offloading_chunk_size = self.chunk_size
 
+        # lightweight config for the FP8 offloading autograd function
+        self.fp8_config = OffloadingFP8Config.from_transformer_config(self.config)
+
         # allocate tensors for gpu buffers
         buffer_dtype = config.params_dtype if not self.config.moe_use_inplace_fp8_param else torch.float8_e4m3fn
         experts1_gpu_buffers_storage = torch.empty(
@@ -1391,7 +1395,7 @@ class OffloadingExpertsMLP(MegatronModule):
                     permuted_probs,
                     self.expert_wgrad_scheduler,
                     self.stream_manager,
-                    self.config,
+                    self.fp8_config,
                     self.wgrad_accumulation_and_reduce_hooks,
                 )
 
@@ -1445,13 +1449,13 @@ class OffloadingExpertsMLP(MegatronModule):
                     permuted_probs,
                     self.expert_wgrad_scheduler,
                     self.stream_manager,
-                    self.config,
+                    self.fp8_config,
                     self.wgrad_accumulation_and_reduce_hooks,
                 )
 
                 return output, None
-        
-            # NOTE: it should be safe to pass empty tensor to the custom function, 
+
+            # NOTE: it should be safe to pass empty tensor to the custom function,
             # but it will introduce meanless h2d transfer.
             # TODO: add cost free path for empty input
             output = offloading_grouped_swiglu_mlp(

--- a/megatron/core/transformer/moe/experts_offloading_fp8_util.py
+++ b/megatron/core/transformer/moe/experts_offloading_fp8_util.py
@@ -5,8 +5,11 @@ Utilities for MoE experts offloading with FP8 support, including:
 2) OffloadingExpertsFP8GroupedSwiMLP: an autograd function for the forward and backward pass of the grouped SwiGLU MLP in offloading experts with FP8 support
 """
 from __future__ import annotations
-import torch
+
 import itertools
+from dataclasses import dataclass
+
+import torch
 
 from megatron.core.transformer.transformer_config import TransformerConfig
 
@@ -16,11 +19,14 @@ except ImportError:
     grouped_gemm = None
 
 from megatron.core.transformer.moe.experts_offloading_util import StreamManager
-from megatron.core.transformer.moe.experts_util import ExpertsWgradScheduler, MergedSwiGLU
+from megatron.core.transformer.moe.experts_util import (
+    ExpertsWgradScheduler,
+    get_dummy_wgrad,
+    release,
+)
 from megatron.core.transformer.moe.fp8_utils import (
     m_grouped_fp8_gemm_nt_contiguous, 
     k_grouped_fp8_gemm_nt_contiguous,
-    release,
 )
 from megatron.core.transformer.moe.fp8_jit import (
     per_block_cast_to_fp8_gpu,
@@ -35,27 +41,70 @@ from megatron.core.transformer.moe.swiglu_jit import (
     swiglu_backward,
 )
 
-_dummy_wgrads = {}
+@dataclass(frozen=True)
+class OffloadingFP8Config:
+    """Lightweight config for OffloadingExpertsFP8GroupedSwiMLP.
 
-def get_dummy_wgrad(
-    shape: list, 
-    dtype: torch.dtype, 
-    device, 
-    zero=False
-) -> torch.Tensor:
-    """Returns a dummy tensor of given shape."""
-    global _dummy_wgrads
-    wgard_key = (*shape, dtype)
-    if wgard_key not in _dummy_wgrads:
-        _dummy_wgrads[wgard_key] = torch.empty(
-            shape,
-            dtype=dtype,
-            device=device,
-            requires_grad=False,
+    Extracts only the fields needed from TransformerConfig / ModelParallelConfig
+    and pre-computes derived values (e.g. ``fc1_out_size``) so callers never
+    repeat the ``moe_ffn_hidden_size * (2 if gated_linear_unit else 1)``
+    pattern.
+    """
+
+    # sizes
+    hidden_size: int
+    moe_latent_size: int
+    input_hidden_size: int
+    moe_ffn_hidden_size: int
+    gated_linear_unit: bool
+    fc1_out_size: int = 0
+
+    # offloading
+    moe_offloading_chunk_size: int = -1
+    moe_offloading_num_chunks: int = 1
+    moe_offloading_num_stages: int = 1
+    moe_offloading_experts_debug_mode: bool = False
+    moe_use_extra_fp8_param_storage: bool = False
+
+    # recomputation
+    recompute_granularity: str = "selective"
+    recompute_modules: list | None = None
+
+    # wgrad scheduling
+    delay_wgrad_compute: bool = False
+    gradient_accumulation_fusion: bool = False
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "input_hidden_size",
+            self.moe_latent_size if self.moe_latent_size is not None else self.hidden_size,
         )
-    if zero:
-        _dummy_wgrads[wgard_key].fill_(0)
-    return _dummy_wgrads[wgard_key].detach()
+        object.__setattr__(
+            self,
+            "fc1_out_size",
+            self.moe_ffn_hidden_size * (2 if self.gated_linear_unit else 1),
+        )
+
+    @classmethod
+    def from_transformer_config(cls, config: TransformerConfig) -> OffloadingFP8Config:
+        """Construct from a full TransformerConfig."""
+        return cls(
+            hidden_size=config.hidden_size,
+            input_hidden_size=config.hidden_size,  # default to hidden_size if moe_latent_size is not set
+            moe_latent_size=config.moe_latent_size,
+            moe_ffn_hidden_size=config.moe_ffn_hidden_size,
+            gated_linear_unit=config.gated_linear_unit,
+            moe_offloading_chunk_size=config.moe_offloading_chunk_size,
+            moe_offloading_num_chunks=config.moe_offloading_num_chunks,
+            moe_offloading_num_stages=config.moe_offloading_num_stages,
+            moe_offloading_experts_debug_mode=config.moe_offloading_experts_debug_mode,
+            moe_use_extra_fp8_param_storage=config.moe_use_extra_fp8_param_storage,
+            recompute_granularity=config.recompute_granularity,
+            recompute_modules=config.recompute_modules,
+            delay_wgrad_compute=config.delay_wgrad_compute,
+            gradient_accumulation_fusion=config.gradient_accumulation_fusion,
+        )
 
 def _dequant_packed_kmajor(
     fp8_packed: torch.Tensor,
@@ -207,7 +256,7 @@ class FP8ExpertsParameterManager:
     @classmethod
     def create_instance(
         cls,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
     ):
         if cls._instance is None:
             cls._instance = cls(config=config)
@@ -244,7 +293,7 @@ class FP8ExpertsParameterManager:
     def __init__(
         self,
         fp8_recipe: int = 128,
-        config: TransformerConfig = None,
+        config: OffloadingFP8Config = None,
     ):
         # wid is the data pointer of each expert weight
         self._wid_to_bf16_weight_map: dict[int, torch.nn.Parameter] = {}
@@ -261,29 +310,29 @@ class FP8ExpertsParameterManager:
         # pre-allocate quantization buffer for expert weights
         self.expert_quantization_buffer: dict[int, torch.Tensor] = {}
         self.expert_quantization_buffer[
-            config.moe_ffn_hidden_size * (2 if config.gated_linear_unit else 1) * config.hidden_size
+            config.fc1_out_size * config.input_hidden_size
         ] = (
             torch.empty(
-                config.moe_ffn_hidden_size * (2 if config.gated_linear_unit else 1) * config.hidden_size, 
-                device=torch.cuda.current_device(), 
+                config.fc1_out_size * config.input_hidden_size,
+                device=torch.cuda.current_device(),
                 dtype=torch.bfloat16
-            ), 
+            ),
             torch.empty(
-                config.moe_ffn_hidden_size * (2 if config.gated_linear_unit else 1) * config.hidden_size,
+                config.fc1_out_size * config.input_hidden_size,
                 device=torch.cuda.current_device(),
                 dtype=torch.float8_e4m3fn
             )
         )
         self.expert_quantization_buffer[
-            config.moe_ffn_hidden_size * config.hidden_size
+            config.moe_ffn_hidden_size * config.input_hidden_size
         ] = (
             torch.empty(
-                config.moe_ffn_hidden_size * config.hidden_size,
+                config.moe_ffn_hidden_size * config.input_hidden_size,
                 device=torch.cuda.current_device(),
                 dtype=torch.bfloat16
             ),
             torch.empty(
-                config.moe_ffn_hidden_size * config.hidden_size,
+                config.moe_ffn_hidden_size * config.input_hidden_size,
                 device=torch.cuda.current_device(),
                 dtype=torch.float8_e4m3fn
             )
@@ -493,12 +542,12 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         tokens_per_expert_chunks_psum: list[torch.Tensor],
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
     ):
         # allocate output buffer for the first linear layer
         fc1_output = torch.empty(
             permuted_local_hidden_states[0].shape[0],
-            config.moe_ffn_hidden_size * (2 if config.gated_linear_unit else 1),
+            config.fc1_out_size,
             device=permuted_local_hidden_states[0].device,
             dtype=torch.bfloat16,
         )
@@ -551,7 +600,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         permuted_probs: torch.Tensor,
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
     ):
         # prefetch the first chunk of expert weights to GPU
         curr_buffer_metadata = cls.prefetch_expert_weights(0, cpu_w2, gpu_w2_buffers, stream_manager, fp8_parameter_manager, config)
@@ -619,7 +668,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         permuted_probs: torch.Tensor,
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
     ):
         """
         ds [m, H] = grad_y [m, h] @ w2.T [H, h]
@@ -649,7 +698,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             fp8_experts_chunk = gpu_w2_chunks[curr_buffer_metadata[0]].view(
                 config.moe_offloading_chunk_size,
                 config.moe_ffn_hidden_size,
-                config.hidden_size,
+                config.input_hidden_size,
             )
             fp8_experts_chunk_scales = curr_buffer_metadata[2]
             fp8_grad_y_chunk = fp8_grad_y_per_chunk[chunk_idx]
@@ -683,7 +732,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         tokens_per_expert_chunks_psum: list[torch.Tensor],
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
     ):
         """
         dx [m, h] = a [m, 2*H] @ w1.T [h, 2*H]
@@ -692,7 +741,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         fp8_grad_a_scales_per_chunk = grad_a[2]
         grad_x = torch.empty(
             grad_a[0].shape[0],
-            config.hidden_size,
+            config.input_hidden_size,
             device=grad_a[0].device, 
             dtype=torch.bfloat16
         )
@@ -709,8 +758,8 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             # computation on the current GPU buffer
             fp8_experts_chunk = gpu_w1_chunks[curr_buffer_metadata[0]].view(
                 config.moe_offloading_chunk_size,
-                config.hidden_size,
-                config.moe_ffn_hidden_size * (2 if config.gated_linear_unit else 1),
+                config.input_hidden_size,
+                config.fc1_out_size,
             )
             fp8_experts_chunk_scales = curr_buffer_metadata[2]
             fp8_grad_a_chunk = fp8_grad_a_per_chunk[chunk_idx]
@@ -759,7 +808,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         permuted_probs: torch.Tensor,
         stream_manager: StreamManager,
         num_local_experts: int,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
         wgrad_scheduler: ExpertsWgradScheduler = None,
         delay_wgrad_compute: bool = False,
         fuse_gradient_accumulation: bool = False,
@@ -854,7 +903,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         gpu_buffers: list[list[torch.Tensor]],
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
-        config: TransformerConfig,
+        config: OffloadingFP8Config,
         transposed: bool = False,
     ) -> tuple:
         h2d_stream_idx = chunk_idx % config.moe_offloading_num_stages
@@ -916,7 +965,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         permuted_probs: torch.Tensor = args[-5]
         expert_wgrad_scheduler: ExpertsWgradScheduler = args[-4]
         stream_manager: StreamManager = args[-3]
-        config: TransformerConfig = args[-2]
+        config: OffloadingFP8Config = args[-2]
         wgrad_accumulation_and_reduce_hooks: list = args[-1]
         fp8_parameter_manager: FP8ExpertsParameterManager = FP8ExpertsParameterManager.get_instance()
         fp8_parameter_manager.config = config
@@ -1030,7 +1079,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         ctx, 
         *grad_outputs
     ):
-        config: TransformerConfig = ctx.config
+        config: OffloadingFP8Config = ctx.config
         cpu_w1: torch.nn.Parameter = ctx.cpu_w1
         cpu_w2: torch.nn.Parameter = ctx.cpu_w2
         cpu_w1_list: list[torch.Tensor] = ctx.cpu_w1_list
@@ -1200,7 +1249,7 @@ def offloading_fp8_grouped_swiglu_mlp(
     permuted_probs: torch.Tensor,
     expert_wgrad_scheduler: ExpertsWgradScheduler,
     stream_manager: StreamManager,
-    config: TransformerConfig,
+    config: OffloadingFP8Config,
     wgrad_accumulation_and_reduce_hooks: list,
 ) -> torch.Tensor:
     """Autograd function for Offloading Experts Grouped SwiGLU MLP.
@@ -1216,7 +1265,7 @@ def offloading_fp8_grouped_swiglu_mlp(
         permuted_probs (torch.Tensor): probability derived from router
         expert_wgrad_scheduler (ExpertsWgradScheduler): scheduler for expert weight gradients
         stream_manager (StreamManager): manager for CUDA streams
-        config (TransformerConfig): transformer configuration
+        config (OffloadingFP8Config): offloading FP8 configuration
 
     Returns:
         torch.Tensor: output of the MLP

--- a/megatron/core/transformer/moe/experts_util.py
+++ b/megatron/core/transformer/moe/experts_util.py
@@ -214,6 +214,30 @@ def release(t: torch.Tensor):
     """
     t.untyped_storage().resize_(0)
 
+
+_dummy_wgrads = {}
+
+def get_dummy_wgrad(
+    shape: list,
+    dtype: torch.dtype,
+    device,
+    zero=False
+) -> torch.Tensor:
+    """Returns a dummy tensor of given shape."""
+    global _dummy_wgrads
+    wgard_key = (*shape, dtype)
+    if wgard_key not in _dummy_wgrads:
+        _dummy_wgrads[wgard_key] = torch.empty(
+            shape,
+            dtype=dtype,
+            device=device,
+            requires_grad=False,
+        )
+    if zero:
+        _dummy_wgrads[wgard_key].fill_(0)
+    return _dummy_wgrads[wgard_key].detach()
+
+# deprecated legacy MLP implementation
 class GroupedSwiMLP(torch.autograd.Function):
     @classmethod
     def call_forward_a(

--- a/megatron/core/transformer/moe/fp8_utils.py
+++ b/megatron/core/transformer/moe/fp8_utils.py
@@ -9,6 +9,10 @@ except ImportError:
 import matplotlib.pyplot as plt
 
 from megatron.core.dist_checkpointing.mapping import ShardedTensor, ShardedTensorFactory
+from megatron.core.transformer.moe.fp8_jit import (
+    per_token_cast_to_fp8,
+    per_token_dequant_from_fp8,
+)
 
 def diff_tensor_norm(t1, t2):
     t1f = t1.to(torch.float)
@@ -302,3 +306,45 @@ def multi_stream_fp8_gemm_nt_1d1d(
                 disable_ue8m0_cast=True,
             )
     return output
+
+class FP8CastFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx, 
+        input,
+    ):
+        fp8_input, sf = per_token_cast_to_fp8(input, use_ue8m0=False)
+        return fp8_input, sf
+
+    @staticmethod
+    def backward(
+        ctx, 
+        fp8_input, 
+        sf,
+    ):
+        grad_input = per_token_dequant_from_fp8(fp8_input, sf)
+        return grad_input
+    
+def fp8_cast(input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return FP8CastFunction.apply(input)
+    
+class FP8DeCastFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx, 
+        fp8_input, 
+        sf,
+    ):
+        input = per_token_dequant_from_fp8(fp8_input, sf)
+        return input
+
+    @staticmethod
+    def backward(
+        ctx, 
+        grad_input,
+    ):
+        fp8_grad_input, sf = per_token_cast_to_fp8(grad_input, use_ue8m0=False)
+        return fp8_grad_input, sf
+    
+def fp8_decast(fp8_input: torch.Tensor, sf: torch.Tensor) -> torch.Tensor:
+    return FP8DeCastFunction.apply(fp8_input, sf)

--- a/megatron/core/transformer/moe/fp8_utils.py
+++ b/megatron/core/transformer/moe/fp8_utils.py
@@ -47,11 +47,6 @@ def plot_tensor_hist(tensor: torch.Tensor, name, bins=100, title="Tensor Value D
     plt.tight_layout()
     plt.savefig(f"./{name}_histogram.png")
 
-def release(t: torch.Tensor):
-    """Helper function to release tensors that are no longer needed to save memory.
-    """
-    t.untyped_storage().resize_(0)
-
 def build_offloading_expert_sharded_tensor(
     weight_slice: torch.Tensor,
     prefix: str,

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -423,19 +423,19 @@ class MoELayer(BaseMoELayer):
                 not self.shared_expert_overlap
             ), "Shared expert overlap not supported when MoE latent projections are used."
             hidden_states, _ = self.fc1_latent_proj(hidden_states)
-        hidden_states, probs = self.token_dispatcher.dispatch_preprocess(
+        hidden_states, hidden_states_sf, probs = self.token_dispatcher.dispatch_preprocess(
             hidden_states, routing_map, probs
         )
-        return hidden_states, probs
+        return hidden_states, hidden_states_sf, probs
 
-    def dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor):
+    def dispatch(self, hidden_states: torch.Tensor, hidden_states_sf: Optional[torch.Tensor], probs: torch.Tensor):
         """Dispatches tokens to assigned expert ranks via communication.
 
         This method performs the actual communication (e.g., All-to-All) to distribute
         tokens and their associated probabilities to the devices hosting their assigned
         experts.
         """
-        return self.token_dispatcher.token_dispatch(hidden_states, probs)
+        return self.token_dispatcher.token_dispatch(hidden_states, hidden_states_sf, probs)
 
     @maybe_skip_or_early_return_by_cudagraph("shared_experts_compute")
     def shared_experts_compute(self, hidden_states: torch.Tensor):
@@ -466,7 +466,12 @@ class MoELayer(BaseMoELayer):
         return shared_expert_output
 
     @internal_api
-    def routed_experts_compute(self, hidden_states: torch.Tensor, probs: torch.Tensor):
+    def routed_experts_compute(
+        self,
+        hidden_states: torch.Tensor,
+        hidden_states_sf: Optional[torch.Tensor],
+        probs: torch.Tensor,
+    ):
         """Computes the output of the routed experts on the dispatched tokens.
 
         This method first post-processes the dispatched input to get permuted tokens
@@ -474,7 +479,7 @@ class MoELayer(BaseMoELayer):
         The output from the experts is preprocessed for the combine step.
         """
         dispatched_input, tokens_per_expert, permuted_probs = (
-            self.token_dispatcher.dispatch_postprocess(hidden_states, probs)
+            self.token_dispatcher.dispatch_postprocess(hidden_states, hidden_states_sf, probs)
         )
         if (
             hasattr(self, "_inference_token_dispatcher")
@@ -518,8 +523,8 @@ class MoELayer(BaseMoELayer):
         """This method is a combined method of route and preprocess. Deprecated."""
 
         probs, routing_map = self.route(hidden_states)
-        hidden_states, probs, residual = self.preprocess(hidden_states, probs, routing_map)
-        return hidden_states, probs, residual
+        hidden_states, hidden_states_sf, probs = self.preprocess(hidden_states, probs, routing_map)
+        return hidden_states, hidden_states_sf, probs
 
     def forward(
         self,
@@ -558,10 +563,10 @@ class MoELayer(BaseMoELayer):
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)
                     probs, routing_map = self.route(hidden_states, padding_mask)
-                    hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
+                    hidden_states, hidden_states_sf, probs = self.preprocess(hidden_states, probs, routing_map)
 
                     if intermediate_tensors is not None:
-                        return hidden_states, probs, shared_expert_output
+                        return hidden_states, hidden_states_sf, probs, shared_expert_output
 
             except MoECudaGraphPartialCaptureSignal as e:
                 # This signal is raised from the maybe_skip_or_early_return_by_cudagraph decorator.
@@ -573,10 +578,10 @@ class MoELayer(BaseMoELayer):
 
             if "expert_compute" in self.fwd_execution_map:
                 if intermediate_tensors is not None:
-                    hidden_states, probs = intermediate_tensors
+                    hidden_states, hidden_states_sf, probs = intermediate_tensors
 
-                dispatched_input, probs = self.dispatch(hidden_states, probs)
-                output, mlp_bias = self.routed_experts_compute(dispatched_input, probs)
+                dispatched_input, dispatched_input_sf, probs = self.dispatch(hidden_states, hidden_states_sf, probs)
+                output, mlp_bias = self.routed_experts_compute(dispatched_input, dispatched_input_sf, probs)
                 assert (
                     mlp_bias is None
                 ), f"mlp_bias is not supported for {type(self.token_dispatcher)}"

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -34,6 +34,10 @@ from megatron.core.transformer.moe.moe_utils import (
     sort_chunks_by_idxs,
     unpermute,
 )
+from megatron.core.transformer.moe.fp8_utils import (
+    fp8_cast,
+    fp8_decast,
+)
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
 
@@ -102,12 +106,17 @@ class MoETokenDispatcher:
             probs (torch.Tensor): The routing probability tensor, [num_tokens, num_experts].
 
         Returns:
-            A tuple of preprocessed tokens and probabilities.
+            A tuple of preprocessed tokens, scale factor (or None), and probabilities.
         """
         raise NotImplementedError("dispatch_preprocess function not implemented.")
 
     @abstractmethod
-    def token_dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor):
+    def token_dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        hidden_states_sf: Optional[torch.Tensor],
+        probs: torch.Tensor,
+    ):
         """Dispatches tokens to expert devices using communication.
 
         This method performs the main communication (e.g., All-to-All) to send
@@ -115,15 +124,21 @@ class MoETokenDispatcher:
 
         Args:
             hidden_states (torch.Tensor): Preprocessed hidden states to be dispatched.
+            hidden_states_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             probs (torch.Tensor): Preprocessed probabilities for each token-expert pair.
 
         Returns:
-            A tuple of dispatched tokens and probabilities.
+            A tuple of dispatched tokens, scale factor (or None), and probabilities.
         """
         raise NotImplementedError("token_dispatch function not implemented.")
 
     @abstractmethod
-    def dispatch_postprocess(self, hidden_states: torch.Tensor, probs: torch.Tensor):
+    def dispatch_postprocess(
+        self,
+        hidden_states: torch.Tensor,
+        hidden_states_sf: Optional[torch.Tensor],
+        probs: torch.Tensor,
+    ):
         """Performs local processing after token dispatch communication.
 
         This method handles post-communication tasks like token reordering and
@@ -251,9 +266,9 @@ class MoEAllGatherTokenDispatcher(MoETokenDispatcher):
         # [S/TP, B, H] -> [S*B/TP, H]
         hidden_states = hidden_states.view(-1, self.hidden_shape[-1])
         self.routing_map = routing_map
-        return hidden_states, probs
+        return hidden_states, None, probs
 
-    def token_dispatch(self, hidden_states, probs):
+    def token_dispatch(self, hidden_states, hidden_states_sf, probs):
         """Gathers tokens from all TP*EP ranks using AllGather."""
 
         # Permute the tokens across the expert parallel devices.
@@ -275,9 +290,9 @@ class MoEAllGatherTokenDispatcher(MoETokenDispatcher):
                 hidden_states, group=self.tp_ep_group, use_global_buffer=True
             )
 
-        return hidden_states, probs
+        return hidden_states, hidden_states_sf, probs
 
-    def dispatch_postprocess(self, hidden_states, probs):
+    def dispatch_postprocess(self, hidden_states, hidden_states_sf, probs):
         """After gathering in token_dispatch, this method identifies tokens for local experts and
         permutes them for expert processing.
         """
@@ -388,38 +403,65 @@ class MoEAlltoAllTokenDispatcherFunction(torch.autograd.Function):
         output_splits,
         input_splits,
         permutated_local_input_tokens, 
+        permutated_local_input_tokens_sf,
         permuted_probs,
     ):
         ctx.ep_group = ep_group
         ctx.output_splits = output_splits
         ctx.input_splits = input_splits
+        ctx.fp8_dispatch = permutated_local_input_tokens_sf is not None
 
+        # dispatch probs
         global_probs = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
             ep_group, permuted_probs, output_splits, input_splits
         )
-        global_input_tokens = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
-            ep_group, permutated_local_input_tokens, output_splits, input_splits
-        )
-        return global_input_tokens, global_probs
+
+        # dispatch tokens
+        global_input_tokens_sf = None
+        if permutated_local_input_tokens_sf is not None:
+            global_input_tokens_sf = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
+                ep_group, permutated_local_input_tokens_sf, output_splits, input_splits
+            )
+            global_input_tokens = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
+                ep_group, permutated_local_input_tokens, output_splits, input_splits
+            )
+        else:
+            global_input_tokens = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
+                ep_group, permutated_local_input_tokens, output_splits, input_splits
+            )
+        return global_input_tokens, global_input_tokens_sf, global_probs
 
     @staticmethod
     def backward(
         ctx, 
         grad_hidden_states, 
+        grad_hidden_states_sf,
         grad_probs
     ):
         ep_group = ctx.ep_group
         output_splits = ctx.output_splits
         input_splits = ctx.input_splits
+        fp8_dispatch = ctx.fp8_dispatch
 
         # The backward of token dispatch is the same as token combine.
         global_grad_probs = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
             ep_group, grad_probs, input_splits, output_splits
         )
-        global_grad_hidden_states = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
-            ep_group, grad_hidden_states, input_splits, output_splits
-        )
-        return None, None, None, global_grad_hidden_states, global_grad_probs
+
+        global_grad_hidden_states_sf = None
+        if fp8_dispatch and grad_hidden_states_sf is not None:
+            global_grad_hidden_states_sf = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
+                ep_group, grad_hidden_states_sf, input_splits, output_splits
+            )
+            global_grad_hidden_states = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
+                ep_group, grad_hidden_states, input_splits, output_splits
+            )
+        else:
+            global_grad_hidden_states = MoEAlltoAllTokenDispatcherFunction.all2all_dispatch(
+                ep_group, grad_hidden_states, input_splits, output_splits
+            )
+        # Trailing None corresponds to the non-tensor `fp8_dispatch` forward arg.
+        return None, None, None, global_grad_hidden_states, global_grad_hidden_states_sf, global_grad_probs
 
 class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
     """
@@ -720,9 +762,21 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
             fused=self.config.moe_permute_fusion,
             drop_and_pad=self.drop_and_pad,
         )
-        return permutated_local_input_tokens, permuted_probs
 
-    def token_dispatch(self, permutated_local_input_tokens, permuted_probs):
+        permutated_local_input_tokens_sf = None
+        if self.config.moe_use_fp8_dispatch:
+            permutated_local_input_tokens, permutated_local_input_tokens_sf = fp8_cast(
+                permutated_local_input_tokens
+            )
+
+        return permutated_local_input_tokens, permutated_local_input_tokens_sf, permuted_probs
+
+    def token_dispatch(
+        self,
+        permutated_local_input_tokens,
+        permutated_local_input_tokens_sf,
+        permuted_probs,
+    ):
         """
         Perform all-to-all communication for dispatching tokens.
 
@@ -732,10 +786,11 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
 
         Args:
             permutated_local_input_tokens (torch.Tensor): Pre-permuted input tokens.
+            permutated_local_input_tokens_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             permuted_probs (torch.Tensor): Pre-permuted probabilities.
 
         Returns:
-            A tuple of tokens and probabilities after All-to-All.
+            A tuple of tokens, scale factor (or None), and probabilities after All-to-All.
         """
 
         # Perform expert parallel AlltoAll communication
@@ -762,23 +817,18 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
                 f"hidden_shape={self.hidden_shape}"
             )
         # ---- END DEBUG ----
-        global_input_tokens, global_probs = MoEAlltoAllTokenDispatcherFunction.apply(
+        global_input_tokens, global_input_tokens_sf, global_probs = MoEAlltoAllTokenDispatcherFunction.apply(
             self.ep_group,
             self.output_splits,
             self.input_splits,
             permutated_local_input_tokens,
+            permutated_local_input_tokens_sf,
             permuted_probs,
         )
-        # global_probs = all_to_all(
-        #     self.ep_group, permuted_probs, self.output_splits, self.input_splits
-        # )
-        # global_input_tokens = all_to_all(
-        #     self.ep_group, permutated_local_input_tokens, self.output_splits, self.input_splits
-        # )
 
-        return global_input_tokens, global_probs
+        return global_input_tokens, global_input_tokens_sf, global_probs
 
-    def dispatch_postprocess(self, global_input_tokens, global_probs):
+    def dispatch_postprocess(self, global_input_tokens, global_input_tokens_sf, global_probs):
         """Post-processes tokens after All-to-All communication.
 
         This involves an All-Gather in the tensor parallel dimension and sorting
@@ -786,11 +836,14 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
 
         Args:
             global_input_tokens (torch.Tensor): Tokens after All-to-All.
+            global_input_tokens_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             global_probs (torch.Tensor): Probabilities after All-to-All.
 
         Returns:
             A tuple of processed tokens, token counts per expert, and processed probabilities.
         """
+        if self.config.moe_use_fp8_dispatch:
+            global_input_tokens = fp8_decast(global_input_tokens, global_input_tokens_sf)
         if self.shared_experts is not None:
             self.shared_experts.linear_fc1_forward_and_act(global_input_tokens)
 
@@ -1540,11 +1593,12 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         routing_map, probs = self._initialize_metadata(routing_map, probs)
 
         self._comm_manager.setup_metadata(routing_map, probs)
-        return hidden_states, self._comm_manager.token_probs
+        return hidden_states, None, self._comm_manager.token_probs
 
     def token_dispatch(
         self,
         hidden_states: torch.Tensor,
+        hidden_states_sf: Optional[torch.Tensor],
         probs: Optional[torch.Tensor] = None,
         async_finish: bool = True,
         allocate_on_comm_stream: bool = True,
@@ -1559,19 +1613,21 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
 
         Args:
             hidden_states (torch.Tensor): Preprocessed hidden states to be dispatched
+            hidden_states_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             probs (torch.Tensor): Routing probabilities (unused in current implementation)
             async_finish (bool): Whether to use asynchronous communication completion
             allocate_on_comm_stream (bool): Whether to allocate buffers on communication stream
 
         Returns:
-            A tuple of dispatched tokens and probabilities.
+            A tuple of dispatched tokens, scale factor (or None), and probabilities.
         """
         return (
             self._comm_manager.dispatch(hidden_states, async_finish, allocate_on_comm_stream),
+            hidden_states_sf,
             self._comm_manager.dispatched_probs,
         )
 
-    def dispatch_postprocess(self, hidden_states: torch.Tensor, probs: torch.Tensor):
+    def dispatch_postprocess(self, hidden_states: torch.Tensor, hidden_states_sf: Optional[torch.Tensor], probs: torch.Tensor):
         """Converts dispatched tokens to a per-expert format for expert processing.
 
         This method transforms the output of the fused dispatch into the tensor
@@ -1579,6 +1635,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
 
         Args:
             hidden_states (torch.Tensor): Hidden states after fused dispatch
+            hidden_states_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             probs (torch.Tensor): Routing probabilities after fused dispatch
 
         Returns:

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -157,7 +157,7 @@ class InferenceCUDAGraphTokenDispatcher(MoEAllGatherTokenDispatcher):
         ).maybe_get_tensor(list(x.size()), dtype=x.dtype)
         return symm_mem_buffer
 
-    def token_dispatch(self, hidden_states, probs):
+    def token_dispatch(self, hidden_states, hidden_states_sf, probs):
         """Gathers tokens from all EP ranks using AllGather.
 
         Performs all-gather on routing_map (stored in self.routing_map), probs,
@@ -168,19 +168,21 @@ class InferenceCUDAGraphTokenDispatcher(MoEAllGatherTokenDispatcher):
         Args:
             hidden_states (torch.Tensor): Local hidden states,
                 shape [local_tokens, hidden_dim].
+            hidden_states_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             probs (torch.Tensor): Local routing probabilities,
                 shape [local_tokens, topk]. Normalized weights for each token's
                 selected experts.
 
         Returns:
-            tuple: (hidden_states, probs) gathered across all EP ranks.
+            tuple: (hidden_states, hidden_states_sf, probs) gathered across all EP ranks.
                 - hidden_states (torch.Tensor): Shape [global_tokens, hidden_dim].
+                - hidden_states_sf (torch.Tensor or None): Scale factor for FP8 tokens.
                 - probs (torch.Tensor): Shape [global_tokens, topk].
                 Also updates self.routing_map in-place to the gathered
                 shape [global_tokens, topk].
         """
         if self.ep_size == 1:
-            return hidden_states, probs
+            return hidden_states, hidden_states_sf, probs
 
         # 1. Check inputs only: if inputs are 16-byte divisible,
         #  outputs (world_size * input) are too.
@@ -241,9 +243,9 @@ class InferenceCUDAGraphTokenDispatcher(MoEAllGatherTokenDispatcher):
                 hidden_states, group=self.tp_ep_group
             )
 
-        return hidden_states, probs
+        return hidden_states, hidden_states_sf, probs
 
-    def dispatch_postprocess(self, hidden_states, probs):
+    def dispatch_postprocess(self, hidden_states, hidden_states_sf, probs):
         """Pass-through: returns inputs directly without permutation.
 
         Unlike the training dispatcher, this does not permute tokens or compute
@@ -254,6 +256,7 @@ class InferenceCUDAGraphTokenDispatcher(MoEAllGatherTokenDispatcher):
         Args:
             hidden_states (torch.Tensor): Gathered hidden states,
                 shape [global_tokens, hidden_dim].
+            hidden_states_sf (torch.Tensor or None): Scale factor for FP8 tokens.
             probs (torch.Tensor): Gathered routing probabilities,
                 shape [global_tokens, topk].
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -750,6 +750,10 @@ class TransformerConfig(ModelParallelConfig):
     GEMM feature introduced since CUTLASS 2.8 (https://github.com/fanshiqing/grouped_gemm).
     """
 
+    moe_use_fp8_dispatch: bool = False
+    """Whether to use FP8 for MoE dispatch. Specifically, the token tensors will be
+    quantized into FP8 before dispatch and dequantized back to original precision after dispatch."""
+
     moe_use_fp8_activation: bool = False
     """Whether to use FP8 activation for MoE layer. Specifically, the activations of MoE layer will
     be quantized into FP8 for storage."""

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1205,9 +1205,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # and should be skipped here.
             if self.config.overlap_moe_expert_parallel_comm:
                 probs, routing_map = self.mlp.route(hidden_states)
-                hidden_states, probs = self.mlp.preprocess(hidden_states, probs, routing_map)
+                hidden_states, hidden_states_sf, probs = self.mlp.preprocess(hidden_states, probs, routing_map)
                 nvtx_range_pop(suffix="mlp")
-                return residual, hidden_states, probs, shared_expert_output
+                return residual, hidden_states, hidden_states_sf, probs, shared_expert_output
             mlp_output_with_bias = self.mlp(hidden_states)
             self.mlp.cudagraph_tensor_store.clear()
             nvtx_range_pop(suffix="mlp")
@@ -1224,7 +1224,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 assert len(cuda_graph_output) == 1, "CUDA Graph output should be the layer output."
                 residual = cuda_graph_output.pop()
                 if not self.is_moe_layer:
-                    return residual, None, None, None
+                    return residual, None, None, None, None
                 hidden_states = apply_module(self.pre_mlp_layernorm)(residual)
                 if isinstance(hidden_states, tuple):
                     if len(hidden_states) != 2:
@@ -1237,8 +1237,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
                 shared_expert_output = self.mlp.shared_experts_compute(hidden_states)
                 probs, routing_map = self.mlp.route(hidden_states)
-                hidden_states, probs = self.mlp.preprocess(hidden_states, probs, routing_map)
-                return residual, hidden_states, probs, shared_expert_output
+                hidden_states, hidden_states_sf, probs = self.mlp.preprocess(hidden_states, probs, routing_map)
+                return residual, hidden_states, hidden_states_sf, probs, shared_expert_output
 
             # CUDA Graph does not capture the MLP/MoE part at all.
             output = self._forward_mlp(*cuda_graph_output)
@@ -1475,7 +1475,7 @@ class MoETransformerLayer(TransformerLayer):
 
         return residual, *router_outputs
 
-    def _forward_mlp_expert_compute(self, hidden_states, probs):
+    def _forward_mlp_expert_compute(self, hidden_states, hidden_states_sf, probs):
         """
         Executes the actual computation of the experts.
 
@@ -1492,7 +1492,7 @@ class MoETransformerLayer(TransformerLayer):
             setattr(obj, hier_attr_name[-1], attr)
 
         self.mlp.fwd_execution_map = "expert_compute"
-        return self.mlp(None, intermediate_tensors=(hidden_states, probs))
+        return self.mlp(None, intermediate_tensors=(hidden_states, hidden_states_sf, probs))
 
     def _forward_mlp_postprocess(self, residual, output, shared_expert_output, mlp_bias):
         """
@@ -1532,7 +1532,7 @@ class MoETransformerLayer(TransformerLayer):
         def _forward_mlp_partial_cudagraphs(
             hidden_states, inference_context=None, padding_mask=None
         ):
-            residual, hidden_states, probs, shared_expert_output = self._forward_mlp_router(
+            residual, hidden_states, hidden_states_sf, probs, shared_expert_output = self._forward_mlp_router(
                 hidden_states, padding_mask=padding_mask
             )
 
@@ -1545,7 +1545,7 @@ class MoETransformerLayer(TransformerLayer):
             for name, attr in self.token_dispatcher_attrs.items():
                 setattr(self.mlp.token_dispatcher, name, attr)
 
-            expert_output, mlp_bias = self._forward_mlp_expert_compute(hidden_states, probs)
+            expert_output, mlp_bias = self._forward_mlp_expert_compute(hidden_states, hidden_states_sf, probs)
             return self._forward_mlp_postprocess(
                 residual, expert_output, shared_expert_output, mlp_bias
             )

--- a/megatron/training/theoretical_memory_usage.py
+++ b/megatron/training/theoretical_memory_usage.py
@@ -103,30 +103,35 @@ def compute_weight_and_optimizer_memory(args, verbose=False):
         )
         + self_attn_term
     )
+    # Routed experts run on moe_latent_size when it is set; the shared expert and the
+    # pre-MLP layernorm always run on hidden_size (is_expert=False, see mlp.py).
+    expert_hidden_size = (
+        args.hidden_size if args.moe_latent_size is None else args.moe_latent_size
+    )
+    # Shared fc1/fc2 latent projections (hidden->latent and latent->hidden) per MoE layer.
+    latent_proj_term = (
+        0 if args.moe_latent_size is None else 2 * args.hidden_size * args.moe_latent_size
+    )
     num_parameters_in_transformer_layer_moe = (
-        2
+        # Routed experts (on moe_latent_size when set).
+        2 * expert_hidden_size * (moe_ffn_hidden_size * num_experts * gated_linear_multiplier)
+        # Shared MoE MLP + transformer layernorms (on hidden_size).
+        + 2
         * args.hidden_size
-        * (
-            # MoE MLP.
-            + (moe_ffn_hidden_size * num_experts * gated_linear_multiplier)
-            # Shared MoE MLP.
-            + (shared_expert_ffn_hidden_size * gated_linear_multiplier)
-            # Transformer layernorms.
-            + norm_size
-        )
+        * ((shared_expert_ffn_hidden_size * gated_linear_multiplier) + norm_size)
+        # Latent projections.
+        + latent_proj_term
         + self_attn_term
     )
     num_active_parameters_in_transformer_layer_moe = (
+        # Routed experts (on moe_latent_size when set).
         2
-        * args.hidden_size
-        * (
-            # MoE MLP.
-            + (moe_ffn_hidden_size * args.moe_router_topk * gated_linear_multiplier)
-            # Shared MoE MLP.
-            + (shared_expert_ffn_hidden_size * gated_linear_multiplier)
-            # Transformer layernorms.
-            + (2)
-        )
+        * expert_hidden_size
+        * (moe_ffn_hidden_size * args.moe_router_topk * gated_linear_multiplier)
+        # Shared MoE MLP + transformer layernorms (on hidden_size).
+        + 2 * args.hidden_size * ((shared_expert_ffn_hidden_size * gated_linear_multiplier) + 2)
+        # Latent projections (shared, always active).
+        + latent_proj_term
         + self_attn_term
     )
     embedding_size = args.hidden_size * args.padded_vocab_size

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1849,7 +1849,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             and args.moe_use_inplace_fp8_param
             and not config.moe_offloading_experts_debug_mode
         ):
-            FP8ExpertsParameterManager.create_instance(config)
+            FP8ExpertsParameterManager.create_instance(OffloadingFP8Config.from_transformer_config(config))
             FP8ExpertsParameterManager.mark_first_microbatch()
 
         if (

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -195,6 +195,7 @@ from megatron.core.transformer.moe import upcycling_utils
 from megatron.core.transformer.moe.moe_utils import track_moe_metrics, clear_aux_losses_tracker
 from megatron.core.transformer.moe.experts_offloading_fp8_util import (
     FP8ExpertsParameterManager,
+    OffloadingFP8Config,
 )
 from megatron.core.transformer.moe.experts_fp8_util import (
     FP8GPUExpertsParameterManager,

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -17,11 +17,19 @@ from megatron.training.initialize import _set_random_seed
 from tests.unit_tests.test_utilities import Utils
 
 
+def rel_diff(actual, reference):
+    """Relative L2 difference: ||actual - ref|| / ||ref||."""
+    return (
+        torch.norm(actual.float() - reference.float()).item()
+        / torch.norm(reference.float()).item()
+    )
+
+
 def token_permutation(token_dispatcher, hidden_states, probs, indices):
-    hidden_states, probs = token_dispatcher.dispatch_preprocess(hidden_states, indices, probs)
-    hidden_states, probs = token_dispatcher.token_dispatch(hidden_states, probs)
+    hidden_states, hidden_states_sf, probs = token_dispatcher.dispatch_preprocess(hidden_states, indices, probs)
+    hidden_states, hidden_states_sf, probs = token_dispatcher.token_dispatch(hidden_states, hidden_states_sf, probs)
     hidden_states, tokens_per_expert, permuted_probs = token_dispatcher.dispatch_postprocess(
-        hidden_states, probs
+        hidden_states, hidden_states_sf, probs
     )
     return hidden_states, tokens_per_expert, permuted_probs
 
@@ -153,6 +161,49 @@ class MoEModelTestContainer:
         torch.testing.assert_close(
             hidden_states.grad, ans
         ), "Restored hidden states do not match original hidden states"
+
+    @pytest.mark.internal
+    def dispatcher_fp8_test(self, rel_tol=0.03):
+        """Test the FP8 all-to-all token dispatch round-trip.
+
+        Tokens are quantized to FP8 (e4m3) before the dispatch all-to-all and
+        dequantized afterwards, so the round-trip is lossy. Instead of an exact
+        match we require the relative L2 error of the restored hidden states
+        (and the gradient) to stay within ``rel_tol``.
+        """
+        moe_layer = self.new_moe_layer(moe_use_fp8_dispatch=True)
+        bs = 32
+        seql = 8
+        hidden_states = torch.randn((bs, seql, moe_layer.config.hidden_size), dtype=self.test_dtype)
+        hidden_states = hidden_states.cuda()
+        # Permute and then unpermute data are supposed to (approximately) restore original data.
+        ans = hidden_states
+        hidden_states.requires_grad = True
+        probs, indices = apply_module(moe_layer.router)(hidden_states)
+        probs = torch.ones_like(probs) / moe_layer.router.topk
+
+        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+            moe_layer.token_dispatcher, hidden_states, probs, indices
+        )
+
+        permuted_local_hidden_states = permuted_local_hidden_states * permuted_probs.unsqueeze(-1)
+        permuted_local_hidden_states = permuted_local_hidden_states.to(dtype=self.test_dtype)
+
+        restored_hidden_states, restored_bias = token_unpermutation(
+            moe_layer.token_dispatcher, permuted_local_hidden_states
+        )
+
+        # reduce across TP rank equals to multiply data by a scale of ETP
+        scale = moe_layer.config.expert_tensor_parallel_size
+        restored_hidden_states = restored_hidden_states / scale
+
+        fwd_diff = rel_diff(restored_hidden_states, ans)
+        assert fwd_diff < rel_tol, f"forward rel_diff={fwd_diff:.4f} exceeds {rel_tol}"
+
+        # check if the grad of the hidden states is (approximately) the same as the hidden states
+        torch.autograd.backward(restored_hidden_states, hidden_states)
+        grad_diff = rel_diff(hidden_states.grad, ans)
+        assert grad_diff < rel_tol, f"backward rel_diff={grad_diff:.4f} exceeds {rel_tol}"
 
     @pytest.mark.internal
     def dispatcher_capacity_test(self):
@@ -400,6 +451,42 @@ class TestAllgatherDispatcher:
         )
 
         container.dispatcher_dropless_test()
+
+
+def is_fp8_dispatch_available():
+    """FP8 dispatch needs CUDA and an FP8-capable GPU (compute capability >= 8.9)."""
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return (major, minor) >= (8, 9)
+
+
+class TestAlltoAllFp8Dispatcher:
+    def setup_method(self, method):
+        pass
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not is_fp8_dispatch_available(),
+        reason="FP8 dispatch requires an FP8-capable GPU (compute capability >= 8.9)",
+    )
+    @pytest.mark.internal
+    @pytest.mark.parametrize("tp_size,ep_size", [(1, 4), (2, 2), (4, 1)])
+    def test_fp8_forward_backward(self, tp_size, ep_size):
+        container = MoEModelTestContainer(
+            tp_size=tp_size,
+            ep_size=ep_size,
+            pp_size=1,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_token_dispatcher_type="alltoall",
+            hidden_size=256,
+            test_dtype=torch.bfloat16,
+        )
+        container.dispatcher_fp8_test()
 
 
 def is_deep_ep_available():


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the Mixture-of-Experts (MoE) FP8 offloading infrastructure:

**MoE FP8 Dispatch with NCCL All-to-all**

* Support fp8_e4m3 dtype dispatch using NCCL all-to-all. Added quantization/dequantization autograd function before and after the dispatch communication:
    * fp8_cast --> dispatch fp8 tensor --> dispatch scale factor --> fp8_decast
* Updated the MoE forward, dispatch, and expert computation callables in `fine_grained_callables.py` to propagate and handle additional tensor metadata (such as scale factors for FP8), and updated their signatures and return values accordingly. [[1]](diffhunk://#diff-4550b4a545b6aeb7ef82616f380f3a189343727bc13c3fab38b9762554810d40L480-R480) [[2]](diffhunk://#diff-4550b4a545b6aeb7ef82616f380f3a189343727bc13c3fab38b9762554810d40L499-R504) [[3]](diffhunk://#diff-4550b4a545b6aeb7ef82616f380f3a189343727bc13c3fab38b9762554810d40L522-R528) [[4]](diffhunk://#diff-4550b4a545b6aeb7ef82616f380f3a189343727bc13c3fab38b9762554810d40L536-R553) [[5]](diffhunk://#diff-4550b4a545b6aeb7ef82616f380f3a189343727bc13c3fab38b9762554810d40L556-R567)
* Updated `megatron/core/pipeline_parallel/utils.py` to support the backward pass for scale factor tensor which does not require grad.

**MoE FP8 Offloading Configuration Refactor:**

* Introduced `OffloadingFP8Config`, a lightweight dataclass that extracts and precomputes only the fields needed for FP8 offloading from `TransformerConfig`, and refactored all relevant code paths to use this new config instead of the full `TransformerConfig`. This reduces coupling and clarifies which settings are actually used in FP8 offloading. [[1]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L38-L58) [[2]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1176-R1178) [[3]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L210-R259) [[4]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L247-R296) [[5]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L264-R335) [[6]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15L1394-R1398) [[7]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15L1448-R1452) [[8]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L496-R550) [[9]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L554-R603) [[10]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L622-R671) [[11]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L652-R701) [[12]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L686-R735) [[13]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L695-R744) [[14]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L712-R762)
