### PR TITLE
Add token mapping script for datasets

### DIFF
--- a/tools/observability_mapping/generate_metadata.py
+++ b/tools/observability_mapping/generate_metadata.py
@@ -2,16 +2,20 @@
 Post-hoc provenance metadata generator.
 
 Reads the same parquet files that were tokenized and produces a .meta.parquet
-file for each .bin file, mapping doc_index → (parquet_path, parquet_row).
+file for each .bin file, mapping doc_index → (parquet_path, doc_key|parquet_row).
 
-parquet_row is the ABSOLUTE raw row index in the parquet file, enabling O(1)
-lookup: pq.read_table(parquet_path).slice(parquet_row, 1)
+Without --key-col: parquet_row is the ABSOLUTE raw row index in the parquet file,
+enabling O(1) lookup: pq.read_table(parquet_path).slice(parquet_row, 1)
+
+With --key-col: doc_key stores the value of the specified unique-identifier column
+from the original dataset (e.g. an HuggingFace dataset ID field), allowing
+provenance lookup via the dataset's own primary key rather than a positional index.
 
 Two-phase approach:
   Phase 1 — rebuild dump assignments by replicating prepare_dumps.py's greedy
              bin-packing (sort parquets by size descending, assign each to the
              smallest-so-far dump). The --filter-in and --filter-out parameters
-             can also be specified if those were used when initially creating the 
+             can also be specified if those were used when initially creating the
              dumps. This helps with getting the correct number of dumps for phase 2.
   Phase 2 — for each dump, stride-assign files to ranks (same as DataTrove)
              and emit .meta.parquet sidecars.
@@ -21,6 +25,13 @@ Usage:
         --tokenized-folder /path/to/datasets_tokenized/MyDataset \
         --data-folder /path/to/raw/MyDataset \
         --text-col text
+
+    # Map to a unique key column instead of a raw row index:
+    python3 scripts/generate_metadata.py \
+        --tokenized-folder /path/to/datasets_tokenized/MyDataset \
+        --data-folder /path/to/raw/MyDataset \
+        --text-col text \
+        --key-col id
 
     # With filters matching the original prepare_dumps.py call:
     python3 scripts/generate_metadata.py \
@@ -132,6 +143,7 @@ def generate_rank_metadata(
     text_col: str,
     output_folder: str,
     rehydrate: bool = False,
+    key_col: str | None = None,
 ) -> None:
     bin_path = os.path.join(tokenized_folder, f"{rank:05d}_tokens.bin")
     idx_path = os.path.join(tokenized_folder, f"{rank:05d}_tokens.idx")
@@ -145,10 +157,14 @@ def generate_rank_metadata(
 
     doc_indices: list[int] = []
     parquet_paths: list[str] = []
-    parquet_rows: list[int] = []
+    # Stores parquet row indices (no key_col) or unique key values (key_col set)
+    id_values: list = []
 
     doc_index = 0
     read_cols = [text_col] + (["minhash_cluster_size"] if rehydrate else [])
+    if key_col and key_col not in read_cols:
+        read_cols.append(key_col)
+
     for relative_path in assigned:
         abs_path = os.path.abspath(os.path.join(data_folder, relative_path))
         table = pq.read_table(abs_path, columns=read_cols)
@@ -156,20 +172,24 @@ def generate_rank_metadata(
         non_empty_mask = pc.greater(pc.utf8_length(table.column(text_col)), 0)
         raw_rows = np.nonzero(non_empty_mask.to_numpy())[0]
 
+        if key_col:
+            keys = table.column(key_col).filter(non_empty_mask).to_pylist()
+
         if not rehydrate:
             n = len(raw_rows)
             doc_indices.extend(range(doc_index, doc_index + n))
             parquet_paths.extend([abs_path] * n)
-            parquet_rows.extend(raw_rows.tolist())
+            id_values.extend(keys if key_col else raw_rows.tolist())
             doc_index += n
         else:
             cluster_sizes = table.column("minhash_cluster_size").filter(non_empty_mask).to_pylist()
-            for raw_row, cluster_size in zip(raw_rows.tolist(), cluster_sizes):
+            for i, (raw_row, cluster_size) in enumerate(zip(raw_rows.tolist(), cluster_sizes)):
                 weight = rehydrate_weight(cluster_size)
+                id_val = keys[i] if key_col else raw_row
                 for _ in range(weight):
                     doc_indices.append(doc_index)
                     parquet_paths.append(abs_path)
-                    parquet_rows.append(raw_row)
+                    id_values.append(id_val)
                     doc_index += 1
 
     if doc_index != expected:
@@ -180,11 +200,18 @@ def generate_rank_metadata(
         )
 
     os.makedirs(output_folder, exist_ok=True)
-    out_table = pa.table({
-        "doc_index":    pa.array(doc_indices,    pa.int64()),
-        "parquet_path": pa.array(parquet_paths,  pa.string()),
-        "parquet_row":  pa.array(parquet_rows,   pa.int64()),
-    })
+    if key_col:
+        out_table = pa.table({
+            "doc_index":    pa.array(doc_indices,   pa.int64()),
+            "parquet_path": pa.array(parquet_paths, pa.string()),
+            "doc_key":      pa.array(id_values),
+        })
+    else:
+        out_table = pa.table({
+            "doc_index":    pa.array(doc_indices,   pa.int64()),
+            "parquet_path": pa.array(parquet_paths, pa.string()),
+            "parquet_row":  pa.array(id_values,     pa.int64()),
+        })
     pq.write_table(out_table, meta_path)
     print(f"rank {rank:05d}: wrote {doc_index} entries → {meta_path}", flush=True)
 
@@ -204,6 +231,7 @@ def _build_worker_kwargs(
     text_col: str,
     output_folder_override: str | None,
     rehydrate: bool,
+    key_col: str | None,
 ) -> list[dict]:
     n_tasks = n_tasks_arg or _infer_n_tasks(tokenized_folder)
     if n_tasks == 0:
@@ -212,7 +240,8 @@ def _build_worker_kwargs(
     return [
         dict(rank=rank, n_tasks=n_tasks, tokenized_folder=tokenized_folder,
              data_folder=data_folder, dump_paths=dump_paths,
-             text_col=text_col, output_folder=out, rehydrate=rehydrate)
+             text_col=text_col, output_folder=out, rehydrate=rehydrate,
+             key_col=key_col)
         for rank in range(n_tasks)
     ]
 
@@ -237,6 +266,10 @@ def get_args():
                         help="File extension to scan for (default: .parquet)")
     parser.add_argument("--output-folder", default=None,
                         help="Where to write .meta.parquet files (default: same as dump folder)")
+    parser.add_argument("--key-col", default=None,
+                        help="Parquet column whose value uniquely identifies a document "
+                             "(e.g. 'id' for HuggingFace datasets). When set, the metadata "
+                             "stores the column's value as 'doc_key' instead of 'parquet_row'.")
     parser.add_argument("--rehydrate", action="store_true",
                         help="Replicate Rehydrater duplication via minhash_cluster_size")
     parser.add_argument("--workers", type=int, default=None,
@@ -277,6 +310,7 @@ def main(args):
         all_kwargs.extend(_build_worker_kwargs(
             str(dump_dir), args.data_folder, all_dump_paths[dump_idx],
             args.n_tasks, args.text_col, args.output_folder, args.rehydrate,
+            args.key_col,
         ))
 
     n_workers = args.workers or len(all_kwargs)

--- a/tools/observability_mapping/generate_metadata.py
+++ b/tools/observability_mapping/generate_metadata.py
@@ -1,0 +1,290 @@
+"""
+Post-hoc provenance metadata generator.
+
+Reads the same parquet files that were tokenized and produces a .meta.parquet
+file for each .bin file, mapping doc_index → (parquet_path, parquet_row).
+
+parquet_row is the ABSOLUTE raw row index in the parquet file, enabling O(1)
+lookup: pq.read_table(parquet_path).slice(parquet_row, 1)
+
+Two-phase approach:
+  Phase 1 — rebuild dump assignments by replicating prepare_dumps.py's greedy
+             bin-packing (sort parquets by size descending, assign each to the
+             smallest-so-far dump). The --filter-in and --filter-out parameters
+             can also be specified if those were used when initially creating the 
+             dumps. This helps with getting the correct number of dumps for phase 2.
+  Phase 2 — for each dump, stride-assign files to ranks (same as DataTrove)
+             and emit .meta.parquet sidecars.
+
+Usage:
+    python3 scripts/generate_metadata.py \
+        --tokenized-folder /path/to/datasets_tokenized/MyDataset \
+        --data-folder /path/to/raw/MyDataset \
+        --text-col text
+
+    # With filters matching the original prepare_dumps.py call:
+    python3 scripts/generate_metadata.py \
+        --tokenized-folder /path/to/datasets_tokenized/MyDataset \
+        --data-folder /path/to/raw/MyDataset \
+        --filter-in train \
+        --filter-out test valid
+"""
+
+import argparse
+import bisect
+import os
+import struct
+from multiprocessing import Pool
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+# Must match Rehydrater.upsampling_weights exactly
+_REHYDRATE_LIMITS = [1, 2, 3, 5, 100, 1000]
+_REHYDRATE_WEIGHTS = {1: 1, 2: 2, 3: 3, 5: 5, 100: 8, 1000: 1}
+
+
+def rehydrate_weight(minhash_cluster_size: int) -> int:
+    key = _REHYDRATE_LIMITS[bisect.bisect_right(_REHYDRATE_LIMITS, minhash_cluster_size) - 1]
+    return _REHYDRATE_WEIGHTS[key]
+
+
+_INDEX_HEADER = b"MMIDIDX\x00\x00"
+
+
+def read_num_sequences(idx_path: str) -> int:
+    with open(idx_path, "rb") as f:
+        assert f.read(9) == _INDEX_HEADER, f"Invalid .idx header in {idx_path}"
+        f.read(8)  # version
+        f.read(1)  # dtype
+        return struct.unpack("<Q", f.read(8))[0]
+
+
+# ── Phase 1: rebuild dump→file assignment ────────────────────────────────────
+
+def rebuild_dump_paths(
+    data_folder: str,
+    n_dumps: int,
+    filter_in: list[str] | None,
+    filter_out: list[str] | None,
+    extension: str,
+) -> list[list[str]]:
+    """
+    Replicate prepare_dumps.py's greedy bin-packing.
+    Returns dump_paths[i] = list of relative paths (from data_folder) for dump i.
+    """
+    all_files = []
+    for dirpath, _, filenames in os.walk(data_folder, followlinks=True):
+        for fn in filenames:
+            if fn.lower().endswith(extension):
+                all_files.append(os.path.join(dirpath, fn))
+
+    if not all_files:
+        raise ValueError(f"No *{extension} files found in {data_folder}")
+
+    if filter_in:
+        filtered = []
+        for term in filter_in:
+            filtered.extend(f for f in all_files if term in f and f not in filtered)
+        all_files = filtered
+
+    if filter_out:
+        for term in filter_out:
+            all_files = [f for f in all_files if term not in f]
+
+    if not all_files:
+        raise ValueError(f"No files remain after filtering in {data_folder}")
+
+    sizes = [os.path.getsize(f) for f in all_files]
+    # Same sort as prepare_dumps.py: largest file first
+    files_sizes = sorted(zip(all_files, sizes), key=lambda x: x[1], reverse=True)
+
+    dump_files: list[list[str]] = [[] for _ in range(n_dumps)]
+    dump_sizes = [0] * n_dumps
+
+    for f, size in files_sizes:
+        min_idx = dump_sizes.index(min(dump_sizes))
+        dump_files[min_idx].append(os.path.relpath(f, data_folder))
+        dump_sizes[min_idx] += size
+
+    for i, (files, size) in enumerate(zip(dump_files, dump_sizes)):
+        print(f"  dump-{i}: {len(files)} files, {size / 1e9:.2f} GB", flush=True)
+
+    return dump_files
+
+
+# ── Phase 2: generate metadata per rank ──────────────────────────────────────
+
+def get_rank_paths(dump_paths: list[str], rank: int, n_tasks: int) -> list[str]:
+    """Stride-based assignment matching DataTrove's LocalPipelineExecutor."""
+    return [p for i, p in enumerate(dump_paths) if (i - rank) % n_tasks == 0]
+
+
+def generate_rank_metadata(
+    rank: int,
+    n_tasks: int,
+    tokenized_folder: str,
+    data_folder: str,
+    dump_paths: list[str],
+    text_col: str,
+    output_folder: str,
+    rehydrate: bool = False,
+) -> None:
+    bin_path = os.path.join(tokenized_folder, f"{rank:05d}_tokens.bin")
+    idx_path = os.path.join(tokenized_folder, f"{rank:05d}_tokens.idx")
+    meta_path = os.path.join(output_folder, f"{rank:05d}_tokens.meta.parquet")
+
+    if not os.path.exists(bin_path):
+        return
+
+    expected = read_num_sequences(idx_path)
+    assigned = get_rank_paths(dump_paths, rank, n_tasks)
+
+    doc_indices: list[int] = []
+    parquet_paths: list[str] = []
+    parquet_rows: list[int] = []
+
+    doc_index = 0
+    read_cols = [text_col] + (["minhash_cluster_size"] if rehydrate else [])
+    for relative_path in assigned:
+        abs_path = os.path.abspath(os.path.join(data_folder, relative_path))
+        table = pq.read_table(abs_path, columns=read_cols)
+
+        non_empty_mask = pc.greater(pc.utf8_length(table.column(text_col)), 0)
+        raw_rows = np.nonzero(non_empty_mask.to_numpy())[0]
+
+        if not rehydrate:
+            n = len(raw_rows)
+            doc_indices.extend(range(doc_index, doc_index + n))
+            parquet_paths.extend([abs_path] * n)
+            parquet_rows.extend(raw_rows.tolist())
+            doc_index += n
+        else:
+            cluster_sizes = table.column("minhash_cluster_size").filter(non_empty_mask).to_pylist()
+            for raw_row, cluster_size in zip(raw_rows.tolist(), cluster_sizes):
+                weight = rehydrate_weight(cluster_size)
+                for _ in range(weight):
+                    doc_indices.append(doc_index)
+                    parquet_paths.append(abs_path)
+                    parquet_rows.append(raw_row)
+                    doc_index += 1
+
+    if doc_index != expected:
+        raise ValueError(
+            f"rank {rank}: doc count mismatch — generated {doc_index} entries "
+            f"but .idx reports {expected} sequences in {tokenized_folder}. "
+            f"The rebuilt dump assignment may not match the original tokenization run."
+        )
+
+    os.makedirs(output_folder, exist_ok=True)
+    out_table = pa.table({
+        "doc_index":    pa.array(doc_indices,    pa.int64()),
+        "parquet_path": pa.array(parquet_paths,  pa.string()),
+        "parquet_row":  pa.array(parquet_rows,   pa.int64()),
+    })
+    pq.write_table(out_table, meta_path)
+    print(f"rank {rank:05d}: wrote {doc_index} entries → {meta_path}", flush=True)
+
+def _worker(kwargs: dict) -> None:
+    generate_rank_metadata(**kwargs)
+
+
+def _infer_n_tasks(tokenized_folder: str) -> int:
+    return len(list(Path(tokenized_folder).glob("*_tokens.bin")))
+
+
+def _build_worker_kwargs(
+    tokenized_folder: str,
+    data_folder: str,
+    dump_paths: list[str],
+    n_tasks_arg: int | None,
+    text_col: str,
+    output_folder_override: str | None,
+    rehydrate: bool,
+) -> list[dict]:
+    n_tasks = n_tasks_arg or _infer_n_tasks(tokenized_folder)
+    if n_tasks == 0:
+        raise ValueError(f"No *_tokens.bin files in {tokenized_folder} and --n-tasks not set")
+    out = output_folder_override or tokenized_folder
+    return [
+        dict(rank=rank, n_tasks=n_tasks, tokenized_folder=tokenized_folder,
+             data_folder=data_folder, dump_paths=dump_paths,
+             text_col=text_col, output_folder=out, rehydrate=rehydrate)
+        for rank in range(n_tasks)
+    ]
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokenized-folder", required=True,
+                        help="Root folder with dump-* subdirs (or a single dump folder)")
+    parser.add_argument("--data-folder", required=True,
+                        help="Root folder of raw parquet files")
+    parser.add_argument("--n-dumps", type=int, default=None,
+                        help="Number of dumps (default: inferred from dump-* subdir count)")
+    parser.add_argument("--n-tasks", type=int, default=None,
+                        help="DataTrove tasks per dump (default: inferred from .bin file count)")
+    parser.add_argument("--text-col", default="text",
+                        help="Parquet column containing document text (default: text)")
+    parser.add_argument("--filter-in", nargs="+", default=None,
+                        help="Keep only parquet paths containing these substrings (same as prepare_dumps.py)")
+    parser.add_argument("--filter-out", nargs="+", default=None,
+                        help="Exclude parquet paths containing these substrings (same as prepare_dumps.py)")
+    parser.add_argument("--extension", default=".parquet",
+                        help="File extension to scan for (default: .parquet)")
+    parser.add_argument("--output-folder", default=None,
+                        help="Where to write .meta.parquet files (default: same as dump folder)")
+    parser.add_argument("--rehydrate", action="store_true",
+                        help="Replicate Rehydrater duplication via minhash_cluster_size")
+    parser.add_argument("--workers", type=int, default=None,
+                        help="Parallel workers (default: total rank count across all dumps)")
+    return parser.parse_args()
+
+
+def main(args):
+    tokenized_root = Path(args.tokenized_folder)
+    dump_dirs = sorted(tokenized_root.glob("dump-*"))
+
+    if dump_dirs:
+        n_dumps = args.n_dumps or len(dump_dirs)
+    else:
+        # Single flat dump folder — treat as dump-0
+        dump_dirs = [tokenized_root]
+        n_dumps = args.n_dumps or 1
+
+    # ── Phase 1: rebuild dump→file assignment ────────────────────────────────
+    print(f"Phase 1: rebuilding dump assignment for {n_dumps} dumps from {args.data_folder} ...", flush=True)
+    all_dump_paths = rebuild_dump_paths(
+        args.data_folder, n_dumps, args.filter_in, args.filter_out, args.extension,
+    )
+
+    # ── Phase 2: build worker kwargs for every rank across all dumps ─────────
+    print("Phase 2: generating metadata ...", flush=True)
+    all_kwargs: list[dict] = []
+    for dump_dir in dump_dirs:
+        dump_num_str = dump_dir.name[len("dump-"):] if dump_dir.name.startswith("dump-") else "0"
+        try:
+            dump_idx = int(dump_num_str)
+        except ValueError:
+            print(f"WARNING: cannot parse dump index from {dump_dir.name}, skipping", flush=True)
+            continue
+        if dump_idx >= len(all_dump_paths):
+            print(f"WARNING: dump-{dump_idx} has no rebuilt paths (only {len(all_dump_paths)} dumps), skipping", flush=True)
+            continue
+        all_kwargs.extend(_build_worker_kwargs(
+            str(dump_dir), args.data_folder, all_dump_paths[dump_idx],
+            args.n_tasks, args.text_col, args.output_folder, args.rehydrate,
+        ))
+
+    n_workers = args.workers or len(all_kwargs)
+    with Pool(n_workers) as pool:
+        pool.map(_worker, all_kwargs)
+
+    print("Done.", flush=True)
+
+
+if __name__ == "__main__":
+    main(get_args())

--- a/tools/observability_mapping/lookup_training_samples.py
+++ b/tools/observability_mapping/lookup_training_samples.py
@@ -1,8 +1,9 @@
 """
-Maps BlendedDataset training steps back to original source documents.
+Maps BlendedDataset training steps back to original source documents and tokens.
 
 A single training sequence can span multiple documents (packed sequences), so
-this returns all source documents (parquet_path + parquet_row) per step.
+this returns all source documents (parquet_path + doc_key/parquet_row) and the
+exact token IDs that were fed to the model at each step.
 
 Lookup chain:
   step
@@ -11,7 +12,8 @@ Lookup chain:
     → GPTDataset sample_index             (datasets/cache/)
     → GPTDataset document_index           (datasets/cache/)
     → .meta.parquet sidecar               (alongside .bin files)
-    → (parquet_path, parquet_row)
+    → (parquet_path, doc_key|parquet_row)
+    → .bin / .idx indexed dataset         (actual token IDs)
 
 Usage:
     python3 scripts/tools/lookup_training_sample.py \
@@ -23,11 +25,83 @@ Usage:
 
 import argparse
 import json
+import struct
 import time
 from pathlib import Path
 
 import numpy as np
 import pyarrow.parquet as pq
+
+
+# ── Indexed dataset reader ────────────────────────────────────────────────────
+
+_INDEX_HEADER = b"MMIDIDX\x00\x00"
+
+_DTYPE_MAP = {
+    1: np.uint8,
+    2: np.int8,
+    3: np.int16,
+    4: np.int32,
+    5: np.int64,
+    6: np.float32,
+    7: np.float64,
+    8: np.uint16,
+}
+
+
+class IndexedDatasetReader:
+    """Lightweight reader for a Megatron MMapIndexedDataset (.bin/.idx pair).
+
+    Keeps the .bin file memory-mapped for O(1) random token access.
+    """
+
+    def __init__(self, dataset_path: str) -> None:
+        idx_path = dataset_path + ".idx"
+        bin_path = dataset_path + ".bin"
+
+        with open(idx_path, "rb") as f:
+            assert f.read(9) == _INDEX_HEADER, f"Invalid .idx header: {idx_path}"
+            f.read(8)  # version
+            dtype_code = struct.unpack("<B", f.read(1))[0]
+            self.dtype = _DTYPE_MAP[dtype_code]
+            self.itemsize: int = self.dtype().itemsize
+            n_seqs = struct.unpack("<Q", f.read(8))[0]
+            struct.unpack("<Q", f.read(8))[0]  # n_docs (unused)
+            offset = f.tell()
+
+        idx_mmap = np.memmap(idx_path, mode="r", order="C")
+        buf = memoryview(idx_mmap)
+        self.sequence_lengths  = np.frombuffer(buf, dtype=np.int32, count=n_seqs, offset=offset)
+        self.sequence_pointers = np.frombuffer(
+            buf, dtype=np.int64, count=n_seqs,
+            offset=offset + self.sequence_lengths.nbytes,
+        )
+        self._bin = np.memmap(bin_path, dtype=self.dtype, mode="r")
+
+    def read_tokens(
+        self,
+        document_index: np.ndarray,
+        j_start: int,
+        k_start: int,
+        j_end: int,
+        k_end: int,
+        add_extra_token: int = 1,
+    ) -> list[int]:
+        """Return the exact token IDs for one packed training sample.
+
+        Mirrors GPTDataset.__getitem__: for each document j in [j_start, j_end],
+        read from k_start (first doc) or 0 (middle docs) to k_end+add_extra_token
+        (last doc) or end-of-document (middle docs).
+        """
+        parts: list[np.ndarray] = []
+        for j in range(j_start, j_end + 1):
+            doc_idx = int(document_index[j])
+            ptr_elem = int(self.sequence_pointers[doc_idx]) // self.itemsize
+            doc_len  = int(self.sequence_lengths[doc_idx])
+            tok_lo = k_start if j == j_start else 0
+            tok_hi = k_end + add_extra_token if j == j_end else doc_len
+            parts.append(self._bin[ptr_elem + tok_lo : ptr_elem + tok_hi])
+        return np.concatenate(parts).tolist() if parts else []
 
 
 class TrainingDataLookup:
@@ -40,9 +114,10 @@ class TrainingDataLookup:
         self.blend_sample_idx  = np.load(str(blend) + "-dataset_sample_index.npy", mmap_mode="r")
 
         # Populated on first access per dataset
-        self._gpt_prefix: dict[str, Path]  = {}
-        self._gpt_arrays: dict[int, tuple] = {}
-        self._meta:       dict[str, dict]  = {}
+        self._gpt_prefix: dict[str, Path]           = {}
+        self._gpt_arrays: dict[int, tuple]          = {}
+        self._meta:       dict[str, dict]           = {}
+        self._readers:    dict[str, IndexedDatasetReader] = {}
 
     def _find_gpt_prefix(self, dataset_path: str) -> Path:
         if dataset_path not in self._gpt_prefix:
@@ -66,6 +141,11 @@ class TrainingDataLookup:
                 np.load(str(p) + "-document_index.npy"),
             )
         return self._gpt_arrays[dataset_idx]
+
+    def _reader_for(self, dataset_path: str) -> IndexedDatasetReader:
+        if dataset_path not in self._readers:
+            self._readers[dataset_path] = IndexedDatasetReader(dataset_path)
+        return self._readers[dataset_path]
 
     def _meta_for(self, dataset_path: str) -> dict:
         if dataset_path not in self._meta:
@@ -98,7 +178,8 @@ class TrainingDataLookup:
 
             dataset_path = self.blend_desc["datasets"][unique_di]["dataset_path"]
             shuffle_index, sample_index, document_index = self._gpt_arrays_for(unique_di)
-            meta = self._meta_for(dataset_path)
+            meta   = self._meta_for(dataset_path)
+            reader = self._reader_for(dataset_path)
 
             pos_arr = shuffle_index[si]
             starts  = sample_index[pos_arr]
@@ -113,17 +194,22 @@ class TrainingDataLookup:
                 docs = []
                 for j in range(j_start, j_end + 1):
                     doc_idx = int(document_index[j])
-                    docs.append({
+                    entry = {
                         "doc_idx":      doc_idx,
                         "parquet_path": meta["parquet_path"][doc_idx],
-                        "parquet_row":  meta["parquet_row"][doc_idx],
-                    })
+                    }
+                    if "doc_key" in meta:
+                        entry["doc_key"] = meta["doc_key"][doc_idx]
+                    else:
+                        entry["parquet_row"] = meta["parquet_row"][doc_idx]
+                    docs.append(entry)
+
+                tokens = reader.read_tokens(document_index, j_start, k_start, j_end, k_end)
 
                 results[offset] = {
                     "step":         step_start + int(offset),
                     "dataset_path": dataset_path,
-                    "token_start":  (j_start, k_start),
-                    "token_end":    (j_end,   k_end),
+                    "tokens":       tokens,
                     "docs":         docs,
                 }
 

--- a/tools/observability_mapping/lookup_training_samples.py
+++ b/tools/observability_mapping/lookup_training_samples.py
@@ -1,0 +1,160 @@
+"""
+Maps BlendedDataset training steps back to original source documents.
+
+A single training sequence can span multiple documents (packed sequences), so
+this returns all source documents (parquet_path + parquet_row) per step.
+
+Lookup chain:
+  step
+    → blend dataset_index / sample_index  (.npy files)
+    → GPTDataset shuffle_index            (datasets/cache/)
+    → GPTDataset sample_index             (datasets/cache/)
+    → GPTDataset document_index           (datasets/cache/)
+    → .meta.parquet sidecar               (alongside .bin files)
+    → (parquet_path, parquet_row)
+
+Usage:
+    python3 scripts/tools/lookup_training_sample.py \
+        --blend-metadata datasets/cache/1c7ca61109a69a7d2975edb01b361cb9-BlendedDataset-train \
+        --cache-dir datasets/cache \
+        --step-start 0 --step-end 9 \
+        --output results.json
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+
+
+class TrainingDataLookup:
+    def __init__(self, blend_prefix: str, cache_dir: str):
+        self.cache_dir = Path(cache_dir)
+
+        blend = Path(blend_prefix)
+        self.blend_desc        = json.load(open(str(blend) + "-description.txt"))
+        self.blend_dataset_idx = np.load(str(blend) + "-dataset_index.npy",        mmap_mode="r")
+        self.blend_sample_idx  = np.load(str(blend) + "-dataset_sample_index.npy", mmap_mode="r")
+
+        # Populated on first access per dataset
+        self._gpt_prefix: dict[str, Path]  = {}
+        self._gpt_arrays: dict[int, tuple] = {}
+        self._meta:       dict[str, dict]  = {}
+
+    def _find_gpt_prefix(self, dataset_path: str) -> Path:
+        if dataset_path not in self._gpt_prefix:
+            for f in self.cache_dir.glob("*-GPTDataset-train-description.txt"):
+                if json.load(open(f)).get("dataset_path") == dataset_path:
+                    self._gpt_prefix[dataset_path] = f.parent / f.name.replace("-description.txt", "")
+                    break
+            else:
+                raise FileNotFoundError(f"No GPTDataset cache for {dataset_path}")
+        return self._gpt_prefix[dataset_path]
+
+    def _gpt_arrays_for(self, dataset_idx: int) -> tuple:
+        if dataset_idx not in self._gpt_arrays:
+            path = self.blend_desc["datasets"][dataset_idx]["dataset_path"]
+            p = self._find_gpt_prefix(path)
+            # No mmap: these are < 15 MB each; mmap causes one network roundtrip per
+            # random page fault on Lustre (~10 ms each), which dominates at scale.
+            self._gpt_arrays[dataset_idx] = (
+                np.load(str(p) + "-shuffle_index.npy"),
+                np.load(str(p) + "-sample_index.npy"),
+                np.load(str(p) + "-document_index.npy"),
+            )
+        return self._gpt_arrays[dataset_idx]
+
+    def _meta_for(self, dataset_path: str) -> dict:
+        if dataset_path not in self._meta:
+            meta_path = dataset_path + ".meta.parquet"
+            if not Path(meta_path).exists():
+                raise FileNotFoundError(
+                    f"Missing metadata sidecar: {meta_path}\n"
+                    f"Generate it with:\n"
+                    f"  python3 scripts/tokenization/generate_metadata.py \\\n"
+                    f"      --tokenized-folder <tokenized_folder> \\\n"
+                    f"      --data-folder <raw_data_folder>"
+                )
+            self._meta[dataset_path] = pq.read_table(meta_path).to_pydict()
+        return self._meta[dataset_path]
+
+    def lookup_range(self, step_start: int, step_end: int) -> list[dict]:
+        n = step_end - step_start + 1
+        t0 = time.perf_counter()
+
+        # Contiguous slice → one sequential read, no per-element page faults
+        dataset_idxs = np.asarray(self.blend_dataset_idx[step_start:step_end + 1])
+        sample_idxs  = np.asarray(self.blend_sample_idx[step_start:step_end + 1])
+
+        results = [None] * n
+        for unique_di in np.unique(dataset_idxs):
+            unique_di     = int(unique_di)
+            mask          = dataset_idxs == unique_di
+            local_offsets = np.where(mask)[0]
+            si            = sample_idxs[mask]
+
+            dataset_path = self.blend_desc["datasets"][unique_di]["dataset_path"]
+            shuffle_index, sample_index, document_index = self._gpt_arrays_for(unique_di)
+            meta = self._meta_for(dataset_path)
+
+            pos_arr = shuffle_index[si]
+            starts  = sample_index[pos_arr]
+            ends    = sample_index[pos_arr + 1]
+
+            for offset, sample_idx, pos, start, end in zip(
+                local_offsets, si, pos_arr, starts, ends
+            ):
+                j_start, k_start = int(start[0]), int(start[1])
+                j_end,   k_end   = int(end[0]),   int(end[1])
+
+                docs = []
+                for j in range(j_start, j_end + 1):
+                    doc_idx = int(document_index[j])
+                    docs.append({
+                        "doc_idx":      doc_idx,
+                        "parquet_path": meta["parquet_path"][doc_idx],
+                        "parquet_row":  meta["parquet_row"][doc_idx],
+                    })
+
+                results[offset] = {
+                    "step":         step_start + int(offset),
+                    "dataset_path": dataset_path,
+                    "token_start":  (j_start, k_start),
+                    "token_end":    (j_end,   k_end),
+                    "docs":         docs,
+                }
+
+        t1 = time.perf_counter()
+        print(f"[timing] {n} steps in {t1-t0:.3f}s")
+        return results
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--blend-metadata", required=True,
+                        help="Prefix of BlendedDataset cache files")
+    parser.add_argument("--cache-dir", required=True,
+                        help="Directory containing GPTDataset cache files")
+    parser.add_argument("--step-start", type=int, default=0,
+                        help="First training step to look up (default: 0)")
+    parser.add_argument("--step-end", type=int, default=None,
+                        help="Last training step inclusive (default: same as --step-start)")
+    parser.add_argument("--output", required=True,
+                        help="Path to write results JSON file")
+    return parser.parse_args()
+
+
+def main(args):
+    step_end = args.step_end if args.step_end is not None else args.step_start
+    lookup = TrainingDataLookup(args.blend_metadata, args.cache_dir)
+    results = lookup.lookup_range(args.step_start, step_end)
+    with open(args.output, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"wrote {len(results)} results → {args.output}")
+
+
+if __name__ == "__main__":
+    main(get_args())


### PR DESCRIPTION
# Usage

The user will first run the generate_metadata for a dataset that has been tokenized. Then, using the script lookup_training_samples and the indexes created by Megatron for a training run they can map back the different steps used in a range of steps. 

# Summary of PR

### Dataset Provenance Tooling for Megatron Training

Adds two scripts that together allow tracing any training step back to its original source documents in the raw parquet database.

### scripts/tokenization/generate_metadata.py

Generates a .meta.parquet sidecar for each .bin/.idx pair produced by the Megatron tokenization pipeline. The sidecar maps each document index within the .bin file to its original (parquet_path, parquet_row), satisfying the invariant:

Decoding the token range [.idx[doc_index], .idx[doc_index+1]) from the .bin file must reproduce the text at parquet_path row parquet_row.

The script works by retracing how DataTrove distributed parquet files across dumps and tasks (the same greedy bin-packing + stride-assignment used during tokenization), so no re-tokenization is needed. The --filter-in/--filter-out options mirror those passed to prepare_dumps.py if they were used.

###### Tested with:

Full wikitext encoding (Llama tokenizer) + metadata generation + exhaustive round-trip check over all documents
legal-mc4 dataset: metadata generated and 5 samples spot-checked per .bin/.idx pair

### scripts/tokenization/lookup_training_samples.py

Given a range of Megatron training steps, resolves each step to the set of source documents that contributed tokens to it, using the BlendedDataset cache files and the .meta.parquet sidecars. Returns (parquet_path, parquet_row) per document, written to a JSON file.

The lookup chain is:


step → dataset_index.npy / dataset_sample_index.npy
     → shuffle_index.npy → sample_index.npy → document_index.npy
     → .meta.parquet → (parquet_path, parquet_row)
Note: Megatron packs tokens contiguously across documents, so a single training sequence can span multiple source documents. The script handles this — docs in the output is a list.

# (Optional): Extra Context about how Megatron generates training run 

### Transforming datasets into Megatron Format

The first step in processing the data is to get the HuggingFace and transfer them into Megatron data format. A given dataset will be transformed into pairs of two files:
1. `.bin` file which is just the raw token IDs concatenated 
2. `.idx` file which gives the structure, so entry `i` in `.idx` tells you that document `i` starts at byte X where X is the value in entry $i$. So entry `i` says "document `i` starts at byte X and has length L".

### Generating the data shuffle from Megatron Format Datasets 

Megatron from now on works as if a single (.bin,.idx) pair of files is a single dataset. Before training, it gets all of the datasets and creates a description file named BlendedDataset-description.txt (or something similar) in which you can see the ordering of all .token files. Then this BlendedDataset contains each training step in the `dataset_index.npy` and `dataset_sample_index.npy` files , practically:

`dataset_index.npy` tells you which dataset you will use at a certain step and `dataset_sample_index.npy` tells you which sample will be used at a certain step from that dataset. 

Finally, inside a single dataset which is a .bin file with .idx file, you will have three generated files:
1. `document_index.npy` -> This is a shuffling of documents order which are the concatenated in order to get samples.
2. `sample_index.npy` -> These are the boundaries of fixed-length sequences in the document_index fully concatenated document. You can see that because the sequence length is fixed, a sample might span multiple documents. 
3. `shuffle_index.npy` -> This is another shuffle at the sample index, so that the n-th used sample at training is shuffle_index\[n\]

So let's say you want to find out what documents you have used at step $n$: 
1. Look into $d_{idx}$=dataset_index\[n\] to find the dataset from which you picked the sample and $s_{idx}$=dataset_sample_index\[n\] to find the sample you used. 
2. Then inside the $d_{idx}$ dataset get the actual sample used from the derandomized `shuffle_index` by doing $k=shuffle_{index}\[s_{idx}\]$. Finally, you have to look for the $k$-th entry in `sample_index.npy` which tells you the boundaries of the fixed-length sequences. Let this entry be called $T$.
3. The $T$ actually contains 2 things: $(a,b)$ which says that the $T$ sample starts at $b$-th token in the document $a$. Therefore, you can look at the next sample at which document it ends and then this sample is created from the samples in th range. 
