### PR TITLE
Integrate pnglu with offloading expert implementation

### DIFF
--- a/megatron/core/fusions/fused_polynorm_glu.py
+++ b/megatron/core/fusions/fused_polynorm_glu.py
@@ -200,6 +200,40 @@ class FusedPolyNormGLUFunction(torch.autograd.Function):
     coefficients of shape ``(M,)``; ``score`` is an optional per-token multiplier of shape ``(M,)``.
     """
 
+    @classmethod
+    def call_forward(
+        cls, x_glu, x_linear, a1, a2, eps, score
+    ):
+        M, D = x_glu.shape
+        out = torch.empty((M, D), dtype=x_glu.dtype, device=x_glu.device)
+        inv = torch.empty((M, 2), dtype=torch.float32, device=x_glu.device)
+        has_score = score is not None
+        score_arg = score if has_score else x_glu  # dummy pointer when unused
+
+        block = triton.next_power_of_2(D)
+        _polynorm_glu_fwd_kernel[(M,)](
+            out,
+            inv,
+            x_glu,
+            x_linear,
+            a1,
+            a2,
+            score_arg,
+            x_glu.stride(0),
+            x_glu.stride(1),
+            x_linear.stride(0),
+            x_linear.stride(1),
+            out.stride(0),
+            out.stride(1),
+            D,
+            1.0 / D,
+            eps,
+            HAS_SCORE=has_score,
+            BLOCK_SIZE=block,
+            num_warps=_num_warps_for(block),
+        )
+        return out, inv
+
     @staticmethod
     def forward(ctx, x_glu, x_linear, a1, a2, eps, score):
         M, D = x_glu.shape
@@ -238,6 +272,62 @@ class FusedPolyNormGLUFunction(torch.autograd.Function):
         ctx.has_score = has_score
         ctx.eps = eps
         return out
+    
+    @classmethod
+    def call_backward(
+        cls, 
+        grad_output, 
+        saved
+    ):
+        x_glu, x_linear, a1, a2, inv = saved[:5]
+        score = saved[5] if len(saved) > 5 else None
+        M, D = x_glu.shape
+
+        grad_output = grad_output.contiguous()
+        dx = torch.empty((M, D), dtype=x_glu.dtype, device=x_glu.device)
+        dm = torch.empty((M, D), dtype=x_linear.dtype, device=x_linear.device)
+        da1 = torch.empty((M,), dtype=a1.dtype, device=x_glu.device)
+        da2 = torch.empty((M,), dtype=a2.dtype, device=x_glu.device)
+        has_score = score is not None
+        if has_score:
+            dscore = torch.empty((M,), dtype=score.dtype, device=score.device)
+            score_arg = score
+        else:
+            dscore = None
+            score_arg = x_glu  # dummy pointer
+
+        block = triton.next_power_of_2(D)
+        _polynorm_glu_bwd_kernel[(M,)](
+            dx,
+            dm,
+            da1,
+            da2,
+            dscore if has_score else x_glu,
+            grad_output,
+            x_glu,
+            x_linear,
+            inv,
+            a1,
+            a2,
+            score_arg,
+            grad_output.stride(0),
+            grad_output.stride(1),
+            x_glu.stride(0),
+            x_glu.stride(1),
+            x_linear.stride(0),
+            x_linear.stride(1),
+            dx.stride(0),
+            dx.stride(1),
+            dm.stride(0),
+            dm.stride(1),
+            D,
+            1.0 / D,
+            HAS_SCORE=has_score,
+            BLOCK_SIZE=block,
+            num_warps=_num_warps_for(block),
+        )
+
+        return dx, dm, da1, da2, None, (dscore if has_score else None)
 
     @staticmethod
     def backward(ctx, grad_output):
@@ -337,3 +427,89 @@ def fused_polynorm_glu_impl(
 
     out = FusedPolyNormGLUFunction.apply(x2, m2, a1, a2, eps, score2)
     return out.reshape(ori_shape)
+
+
+def _split_glu_halves(fc1_output: torch.Tensor):
+    """Split a fused ``(..., 2D)`` fc1 output into its gate / linear ``(M, D)`` halves.
+    """
+    ori_shape = fc1_output.shape
+    two_d = ori_shape[-1]
+    assert two_d % 2 == 0, "fc1 output last dim must be 2*D for a gated linear unit"
+    d = two_d // 2
+    flat = fc1_output.reshape(-1, two_d)
+    x_glu, x_linear = torch.split(flat, d, dim=-1)
+    return x_glu, x_linear, ori_shape[:-1], d
+
+
+def _per_token_coeffs(a1: torch.Tensor, a2: torch.Tensor, num_tokens: int):
+    """Normalize ``a1``/``a2`` to per-token ``(M,)`` coefficients for the row-indexed kernels.
+
+    Mirrors :func:`fused_polynorm_glu_impl`: a single shared coefficient is expanded to one per
+    token (the ``expand`` keeps the autograd link), and already-per-token coefficients pass
+    through unchanged.
+    """
+    a1 = a1.reshape(-1)
+    a2 = a2.reshape(-1)
+    if a1.numel() == 1:
+        a1 = a1.expand(num_tokens).contiguous()
+        a2 = a2.expand(num_tokens).contiguous()
+    return a1, a2
+
+
+def fused_polynorm_glu_forward(
+    fc1_output: torch.Tensor,
+    a1: torch.Tensor,
+    a2: torch.Tensor,
+    eps: float,
+    score: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """2nd-order PolyNorm GLU forward.
+    """
+    x_glu, x_linear, lead_shape, d = _split_glu_halves(fc1_output)
+    a1, a2 = _per_token_coeffs(a1, a2, x_glu.shape[0])
+    score2 = score.reshape(-1) if score is not None else None
+    out, inv = FusedPolyNormGLUFunction.call_forward(x_glu, x_linear, a1, a2, eps, score2)
+    return out.reshape(lead_shape + (d,)), inv
+
+
+def fused_polynorm_glu_backward(
+    grad_output: torch.Tensor,
+    fc1_output: torch.Tensor,
+    a1: torch.Tensor,
+    a2: torch.Tensor,
+    inv: torch.Tensor,
+    eps: float,
+    score: Optional[torch.Tensor] = None,
+):
+    """2nd-order PolyNorm GLU backward.
+
+    Recomputes the inverse-RMS state from fc1_output then runs the fused backward kernel.
+    """
+    x_glu, x_linear, lead_shape, d = _split_glu_halves(fc1_output)
+    # A single shared coefficient receives the summed per-token gradient (mirrors the
+    # expand-backward in ``fused_polynorm_glu_impl``); a per-token coefficient keeps its shape.
+    shared_coeff = a1.numel() == 1
+    a1_c, a2_c = _per_token_coeffs(a1, a2, x_glu.shape[0])
+    score2 = score.reshape(-1) if score is not None else None
+
+    # Recompute inverse-RMS.
+    # _, to_save = FusedPolyNormGLUFunction.call_forward(x_glu, x_linear, a1_c, a2_c, eps, None)
+    # inv = to_save[4]
+    
+    # reconstruct the tensors
+    assert inv is not None
+    saved = [x_glu, x_linear, a1_c, a2_c, inv]
+    if score2 is not None:
+        saved.append(score2)
+
+    grad_flat = grad_output.reshape(-1, d)
+    dx, dm, da1, da2, _, dscore = FusedPolyNormGLUFunction.call_backward(grad_flat, saved)
+    grad_fc1 = torch.cat([dx, dm], dim=-1).reshape(lead_shape + (2 * d,))
+    if shared_coeff:
+        da1 = da1.sum(0, keepdim=True).reshape(a1.shape)
+        da2 = da2.sum(0, keepdim=True).reshape(a2.shape)
+    else:
+        da1 = da1.reshape(a1.shape)
+        da2 = da2.reshape(a2.shape)
+    grad_score = dscore.reshape(score.shape[:-1]) if score is not None else None
+    return grad_fc1, da1, da2, grad_score

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -1031,6 +1031,13 @@ class OffloadingExpertsMLP(MegatronModule):
             self.input_size,
             fc2_input_size,
         )
+
+        if self.config.pnglu:
+            self.polynorm_glu = PolyNorm(
+                num_local_experts=self.num_local_experts,
+                config=self.config,
+                tp_group=self.tp_group,
+            )
         
         # For now all expert weights are offloaded in CPU.
         # NOTE: when FP8 is enabled, we allocate experts as a single tensor
@@ -1362,6 +1369,30 @@ class OffloadingExpertsMLP(MegatronModule):
             output = self.quantization_unpadding(output, tokens_per_expert_list)
         return output
     
+    def _polynorm_glu_coeffs(self, tokens_per_expert):
+        """Per-token positive PolyNorm-GLU coefficients.
+
+        abs and repeat_interleave run outside the offloading autograd Function so the 
+        gradients of alpha parameters flow back via standard autograd. 
+        """
+        if not self.config.pnglu:
+            return None, None
+        assert (
+            self.config.activation_func_clamp_value is None
+            and self.config.glu_linear_offset == 0.0
+        ), (
+            "PolyNorm GLU on the FP8 offloading path does not yet support "
+            "activation_func_clamp_value / glu_linear_offset."
+        )
+        device = self.polynorm_glu.alpha_1.device
+        if isinstance(tokens_per_expert, torch.Tensor):
+            tpe_tensor = tokens_per_expert.to(device=device)
+        else:
+            tpe_tensor = torch.tensor(tokens_per_expert, device=device)
+        a1 = torch.repeat_interleave(torch.abs(self.polynorm_glu.alpha_1), tpe_tensor)
+        a2 = torch.repeat_interleave(torch.abs(self.polynorm_glu.alpha_2), tpe_tensor)
+        return a1, a2
+
     def forward(
         self,
         permuted_local_hidden_states: torch.Tensor,
@@ -1391,7 +1422,10 @@ class OffloadingExpertsMLP(MegatronModule):
                     permuted_probs.unsqueeze(-1), tokens_per_expert_list
                 )
                 tokens_per_expert_padded = torch.tensor(tokens_per_expert_padded, dtype=torch.int32, device='cpu')
-                
+
+                # Per-token PolyNorm coefficients computation
+                a1, a2 = self._polynorm_glu_coeffs(tokens_per_expert_padded)
+
                 output = offloading_fp8_grouped_swiglu_mlp(
                     self.weight1,
                     self.weight2,
@@ -1409,6 +1443,8 @@ class OffloadingExpertsMLP(MegatronModule):
                     self.stream_manager,
                     self.fp8_config,
                     self.wgrad_accumulation_and_reduce_hooks,
+                    a1,
+                    a2,
                 )
 
                 output = self.quantization_unpadding(output, tokens_per_expert_list)
@@ -1445,7 +1481,10 @@ class OffloadingExpertsMLP(MegatronModule):
                     self.weight1_list = list(torch.unbind(self.weight1, dim=0))
                 if self.weight2_list is None:
                     self.weight2_list = list(torch.unbind(self.weight2, dim=0))
-                
+
+                # Empty input: counts sum to 0, so a1/a2 are length-0 (None on the SwiGLU path).
+                a1, a2 = self._polynorm_glu_coeffs(tokens_per_expert)
+
                 output = offloading_fp8_grouped_swiglu_mlp(
                     self.weight1,
                     self.weight2,
@@ -1463,6 +1502,8 @@ class OffloadingExpertsMLP(MegatronModule):
                     self.stream_manager,
                     self.fp8_config,
                     self.wgrad_accumulation_and_reduce_hooks,
+                    a1,
+                    a2,
                 )
 
                 return output, None

--- a/megatron/core/transformer/moe/experts_offloading_fp8_util.py
+++ b/megatron/core/transformer/moe/experts_offloading_fp8_util.py
@@ -40,6 +40,10 @@ from megatron.core.transformer.moe.swiglu_jit import (
     swiglu_forward,
     swiglu_backward,
 )
+from megatron.core.fusions.fused_polynorm_glu import (
+    fused_polynorm_glu_forward,
+    fused_polynorm_glu_backward,
+)
 
 @dataclass(frozen=True)
 class OffloadingFP8Config:
@@ -57,6 +61,8 @@ class OffloadingFP8Config:
     input_hidden_size: int
     moe_ffn_hidden_size: int
     gated_linear_unit: bool
+    gated_polynorm_linear_unit: bool
+    polynorm_eps: float = 1e-6
     fc1_out_size: int = 0
 
     # offloading
@@ -95,6 +101,8 @@ class OffloadingFP8Config:
             moe_latent_size=config.moe_latent_size,
             moe_ffn_hidden_size=config.moe_ffn_hidden_size,
             gated_linear_unit=config.gated_linear_unit,
+            gated_polynorm_linear_unit=config.pnglu,
+            polynorm_eps=getattr(config, "polynorm_eps", 1e-6),
             moe_offloading_chunk_size=config.moe_offloading_chunk_size,
             moe_offloading_num_chunks=config.moe_offloading_num_chunks,
             moe_offloading_num_stages=config.moe_offloading_num_stages,
@@ -601,14 +609,27 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
         config: OffloadingFP8Config,
+        a1: torch.Tensor = None,
+        a2: torch.Tensor = None,
     ):
         # prefetch the first chunk of expert weights to GPU
         curr_buffer_metadata = cls.prefetch_expert_weights(0, cpu_w2, gpu_w2_buffers, stream_manager, fp8_parameter_manager, config)
 
-        s = swiglu_forward(
-            fc1_output,
-            permuted_probs.unsqueeze(-1)
-        )
+
+        if config.gated_polynorm_linear_unit:
+            # PolyNorm GLU gate + GLU multiply + per-token probs in one fused kernel
+            s, inv = fused_polynorm_glu_forward(
+                fc1_output,
+                a1,
+                a2,
+                config.polynorm_eps,
+                permuted_probs.unsqueeze(-1),
+            )
+        else:
+            s = swiglu_forward(
+                fc1_output,
+                permuted_probs.unsqueeze(-1)
+            )
 
         # quantize the swiglu output to FP8
         # fp8_s = per_token_cast_to_fp8(s, use_ue8m0=False, gran_k=128, use_packed_ue8m0=False)
@@ -652,7 +673,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             # update current buffer metadata
             curr_buffer_metadata = next_buffer_metadata if chunk_idx + 1 < config.moe_offloading_num_chunks else None
         
-        return fc2_output, fp8_s
+        return fc2_output, fp8_s, inv if config.gated_polynorm_linear_unit else None
 
 
     @classmethod
@@ -669,11 +690,14 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         stream_manager: StreamManager,
         fp8_parameter_manager: FP8ExpertsParameterManager,
         config: OffloadingFP8Config,
+        a1: torch.Tensor = None,
+        a2: torch.Tensor = None,
+        inv: torch.Tensor = None,
     ):
         """
         ds [m, H] = grad_y [m, h] @ w2.T [H, h]
 
-        da [m, 2*H] = backward_swiglu(da, a, permuted_probs)
+        da [m, 2*H] = backward_activation(ds, a, permuted_probs)
         """
         fp8_grad_y_per_chunk = grad_y[1]
         fp8_grad_y_scales_per_chunk = grad_y[2]
@@ -719,7 +743,14 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             # update current buffer metadata
             curr_buffer_metadata = next_buffer_metadata if chunk_idx + 1 < config.moe_offloading_num_chunks else None
         
-        return swiglu_backward(grad_s, a, permuted_probs.unsqueeze(-1))
+        if config.gated_polynorm_linear_unit:
+            grad_a, grad_a1, grad_a2, grad_probs = fused_polynorm_glu_backward(
+                grad_s, a, a1, a2, inv, config.polynorm_eps, permuted_probs.unsqueeze(-1)
+            )
+            return grad_a, grad_probs, grad_a1, grad_a2
+        else:
+            grad_a, grad_probs = swiglu_backward(grad_s, a, permuted_probs.unsqueeze(-1))
+            return grad_a, grad_probs, None, None
 
     @classmethod
     def call_backward_grad_x(
@@ -812,12 +843,19 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         wgrad_scheduler: ExpertsWgradScheduler = None,
         delay_wgrad_compute: bool = False,
         fuse_gradient_accumulation: bool = False,
+        a1: torch.Tensor = None,
+        a2: torch.Tensor = None,
     ):
         """
         dw2 [h, H] = grad_y.T [h, m] @ s.T [H, m]
         with k_grouped_fp8_gemm: grad_y [m, h] @ s [m, H]
         """
-        s = swiglu_forward(a, permuted_probs.unsqueeze(-1))
+        if config.gated_polynorm_linear_unit:
+            s, _ = fused_polynorm_glu_forward(
+                a, a1, a2, config.polynorm_eps, permuted_probs.unsqueeze(-1)
+            )
+        else:
+            s = swiglu_forward(a, permuted_probs.unsqueeze(-1))
         fp8_s = guarded_per_channel_cast_to_fp8_pack_kmajor(
             s, tokens_per_expert_list, tokens_per_expert_cuda, tokens_per_expert_cumsum,
             name="w2_s", config=config, gran_k=128, free_input=True,
@@ -950,6 +988,10 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
     ):
         if len(args) < 9:
             raise ValueError(f"Insufficient arguments for forward pass of GroupedSwiMLP. Expected at least 9, got {len(args)}")
+
+        # Leading differentiable inputs: per-token PolyNorm GLU coefficients (None for SwiGLU).
+        a1: torch.Tensor = args[0]
+        a2: torch.Tensor = args[1]
         
         cpu_w1: torch.nn.Parameter =  args[-16]
         cpu_w2: torch.nn.Parameter =  args[-15]
@@ -1010,7 +1052,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         )
 
         # activation and forward for the second linear layer
-        y, _ = OffloadingExpertsFP8GroupedSwiMLP.call_forward_y(
+        y, _, inv = OffloadingExpertsFP8GroupedSwiMLP.call_forward_y(
             cpu_w2_list,
             gpu_w2_buffers,
             gpu_w2_chunks,
@@ -1022,7 +1064,14 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             stream_manager,
             fp8_parameter_manager,
             config,
+            a1,
+            a2,
         )
+
+        # context saving for polynorm GLU
+        ctx.a1 = a1
+        ctx.a2 = a2
+        ctx.inv = inv
 
         # context saving
         ctx.fp8_parameter_manager = fp8_parameter_manager
@@ -1141,7 +1190,7 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
         fp8_grad_y_full, fp8_grad_y_chunks, fp8_grad_y_sf_chunks = per_token_cast_to_fp8_chunked_fused(
             grad_y, total_token_num_per_chunk, gran_k=128,
         )
-        grad_a, grad_probs = OffloadingExpertsFP8GroupedSwiMLP.call_backward_grad_a(
+        grad_a, grad_probs, grad_a1, grad_a2 = OffloadingExpertsFP8GroupedSwiMLP.call_backward_grad_a(
             (fp8_grad_y_full, fp8_grad_y_chunks, fp8_grad_y_sf_chunks),
             fc1_output,
             cpu_w2_list,
@@ -1153,6 +1202,9 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             stream_manager,
             fp8_parameter_manager,
             config,
+            ctx.a1,
+            ctx.a2,
+            ctx.inv,
         )
 
         # backward grad_x computation
@@ -1190,6 +1242,8 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             expert_wgrad_scheduler,
             config.delay_wgrad_compute,
             config.gradient_accumulation_fusion,
+            ctx.a1,
+            ctx.a2,
         )
 
         # backward grad_w1 computation
@@ -1228,7 +1282,8 @@ class OffloadingExpertsFP8GroupedSwiMLP(torch.autograd.Function):
             for hook_fn in ctx.wgrad_accumulation_and_reduce_hooks:
                 hook_fn()
 
-        return grad_w1_ret, grad_w2_ret, None, None, None, None, None, None, grad_x, None, None, grad_probs, None, None, None, None
+        # Leading grads correspond to the a1/a2 PolyNorm coefficient inputs (None for SwiGLU)
+        return grad_a1, grad_a2, grad_w1_ret, grad_w2_ret, None, None, None, None, None, None, grad_x, None, None, grad_probs, None, None, None, None
 
 
 
@@ -1251,6 +1306,8 @@ def offloading_fp8_grouped_swiglu_mlp(
     stream_manager: StreamManager,
     config: OffloadingFP8Config,
     wgrad_accumulation_and_reduce_hooks: list,
+    a1: torch.Tensor = None,
+    a2: torch.Tensor = None,
 ) -> torch.Tensor:
     """Autograd function for Offloading Experts Grouped SwiGLU MLP.
 
@@ -1271,6 +1328,8 @@ def offloading_fp8_grouped_swiglu_mlp(
         torch.Tensor: output of the MLP
     """
     output, _ = OffloadingExpertsFP8GroupedSwiMLP.apply(
+        a1,
+        a2,
         cpu_w1,
         cpu_w2,
         cpu_w1_list,

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1267,10 +1267,7 @@ class TransformerConfig(ModelParallelConfig):
             if self.use_fused_weighted_squared_relu:
                 raise ValueError("pnglu=True is incompatible with use_fused_weighted_squared_relu.")
             if self.moe_use_offloading_experts:
-                raise ValueError(
-                    "pnglu=True is not supported with moe_use_offloading_experts (the offloading "
-                    "experts use custom fused SwiGLU CUDA kernels)."
-                )
+                assert self.moe_use_inplace_fp8_param, "pnglu=True with offloading experts currently only supports fp8 path"
             if self.transformer_impl == "inference_optimized":
                 raise ValueError(
                     "pnglu=True is not supported with transformer_impl='inference_optimized' "


### PR DESCRIPTION
This pull request adds support for PolyNorm GLU (Generalized Linear Unit) activation in the Mixture-of-Experts (MoE) transformer codebase, particularly in the FP8 offloading path. It introduces new forward and backward implementations for PolyNorm GLU, integrates per-token coefficient handling, and modifies the expert and offloading utility code to support this activation. 

## Overview
**PolyNorm GLU support and integration:**

* Added `call_forward` and `call_backward` classmethods to `FusedPolyNormGLUFunction`, providing modular, reusable forward and backward logic for PolyNorm GLU, including handling of per-token coefficients and optional score tensors. [[1]](diffhunk://#diff-e247425d48572a7462a02e98ab7951c797f0abd761c071efbc72231231e0ec98R203-R236) [[2]](diffhunk://#diff-e247425d48572a7462a02e98ab7951c797f0abd761c071efbc72231231e0ec98R276-R331)
* Introduced `fused_polynorm_glu_forward` and `fused_polynorm_glu_backward` functions, with helpers for splitting GLU outputs and normalizing per-token coefficients, to encapsulate PolyNorm GLU logic for both forward and backward passes.

**Expert and offloading infrastructure updates:**

* Modified `MoEExpert` to initialize PolyNorm GLU when enabled in the config, and to compute per-token PolyNorm coefficients using `_polynorm_glu_coeffs`, ensuring gradients flow correctly through these parameters. [[1]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1035-R1041) [[2]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1372-R1395)
* Updated the `forward` method in `MoEExpert` to compute and pass PolyNorm coefficients (`a1`, `a2`) into the offloading FP8 grouped SwiGLU MLP path, supporting both padded and unpadded input cases. [[1]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1426-R1428) [[2]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1446-R1447) [[3]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1485-R1487) [[4]](diffhunk://#diff-3a38ef3e496b989642f1d13f4181b6274c457e2962794259fbc84e766ac61a15R1505-R1506)

**Offloading FP8 utility modifications:**

* Extended `OffloadingFP8Config` to include PolyNorm GLU options and epsilon, and updated its construction from the transformer config. [[1]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R64-R65) [[2]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R104-R105)
* Integrated PolyNorm GLU logic into the offloading FP8 forward and backward utility functions (`call_forward_y`, `call_backward_grad_a`, `call_backward_grad_w2`), ensuring the correct activation is used and all necessary tensors and coefficients are passed and saved for autograd. [[1]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R612-R628) [[2]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L655-R676) [[3]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R693-R700) [[4]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L722-R753) [[5]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R846-R857) [[6]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R992-R995) [[7]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L1013-R1055) [[8]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R1067-R1075) [[9]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27L1144-R1193) [[10]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R1205-R1207) [[11]](diffhunk://#diff-5a69b7ad72171046fcea5804b729efd33cf7f0711b48f6f047a1514940184d27R1245-R1246)

These changes collectively enable the use of PolyNorm GLU as a drop-in replacement for SwiGLU in the MoE codebase, with correct handling of per-token coefficients and support for the FP8 offloading execution path.

## Correctness
<img width="1010" height="591" alt="image" src="https://github.com/user-attachments/assets/c848f1cc-b584-4cd9-933a-4b79997aaaf9" />
