### PR TITLE
Fix FP8 quantization and Layerwise Optimizer all-gather

### DIFF
--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -235,13 +235,21 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         def _allgather_helper_experts_param(params_list, group):
             rank = get_pg_rank(group)
             world_size = get_pg_size(group)
-            # fall back to the GPU path if there are no params or they aren't on CPU
-            if len(params_list[rank]) == 0 or params_list[rank][0].device.type != 'cpu':
+
+            # Parameter assignment may leave some ranks with an empty shard. Determine the
+            # communication path from all shards rather than indexing the local shard.
+            first_param = next((p for shard in params_list for p in shard), None)
+            if first_param is None:
+                return
+
+            # The generic path requires every tensor to be accepted by the process-group
+            # backend. Stage through CUDA whenever any expert parameter is CPU-offloaded.
+            if not any(p.device.type == 'cpu' for shard in params_list for p in shard):
                 _allgather_helper(params_list, group)
                 return
 
             dest_device = torch.cuda.current_device()
-            dtype = params_list[rank][0].dtype
+            dtype = first_param.dtype
 
             # Rank-by-rank broadcast through a single flat GPU scratch buffer
             # to reduce peak GPU memory usage

--- a/megatron/core/transformer/moe/fp8_jit.py
+++ b/megatron/core/transformer/moe/fp8_jit.py
@@ -558,7 +558,7 @@ def _per_channel_cast_to_fp8_kernel(
     # (a denormal sf otherwise saturates the column to 448 and turns exact zeros
     # into 0*inf = NaN). See _pack_kmajor_per_channel_fp8_kernel for details.
     sf = row_amax / 448.0
-    sf = tl.where(sf == 0.0, 1.0, sf)
+    sf = tl.where(sf == 0.0, 1e-30, sf)
     sf = tl.maximum(sf, 1e-30)
     if use_ue8m0:
         sf = _ceil_to_ue8m0(sf)
@@ -757,7 +757,7 @@ def _pack_kmajor_per_channel_fp8_kernel(
         row_amax = tl.maximum(row_amax, tl.max(tl.abs(x), axis=0))
 
     sf = row_amax / 448.0
-    sf = tl.where(sf == 0.0, 1.0, sf)
+    sf = tl.where(sf == 0.0, 1e-30, sf)
     # Guard the fp32 reciprocal. If a channel's amax is tiny but nonzero, sf
     # underflows to a denormal and inv_sf = 1/sf overflows to +inf. After that
     # the amax element saturates to 448 (the whole per-channel spread collapses
@@ -766,7 +766,7 @@ def _pack_kmajor_per_channel_fp8_kernel(
     # surface as an exploding grad norm. The 1e-30 floor keeps inv_sf finite and
     # normal while only touching channels whose amax < ~4.5e-28, i.e. ~18 orders
     # of magnitude below the training activation scale (negligible).
-    sf = tl.maximum(sf, 1e-7)
+    sf = tl.maximum(sf, 1e-30)
     if use_ue8m0:
         sf = _ceil_to_ue8m0(sf)
     inv_sf = 1.0 / sf

--- a/tests/unit_tests/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/test_layer_wise_optimizer.py
@@ -471,6 +471,24 @@ class TestLayerWiseOptimizer:
         """
         self._run_parameter_update_test(model_class=TinyModel)
 
+    def test_cpu_expert_allgather_with_empty_local_shards(self):
+        """CPU expert gather works when only one expert-DP rank owns parameters."""
+        _, optimizer, pg_collection = self.create_model_and_optimizer(model_class=TinyModel)
+        expt_dp_size = get_pg_size(pg_collection.expt_dp)
+        if expt_dp_size < 2:
+            pytest.skip("Test requires at least two expert-DP ranks")
+
+        expt_dp_rank = get_pg_rank(pg_collection.expt_dp)
+        cpu_param = nn.Parameter(
+            torch.full((4,), float(expt_dp_rank), dtype=torch.bfloat16, device='cpu')
+        )
+        optimizer.dp_cp_params_list = None
+        optimizer.expt_dp_params_list = [[cpu_param]] + [[] for _ in range(expt_dp_size - 1)]
+
+        optimizer.allgather_params()
+
+        torch.testing.assert_close(cpu_param, torch.zeros_like(cpu_param), rtol=0, atol=0)
+
     def test_broadcast_vs_allgather(self):
         """Test LayerWiseDistributedOptimizer allgather code agains broadcast code."""
         model, optimizer, pg_collection = self.create_model_and_optimizer(model_class=SimpleModel)


### PR DESCRIPTION
This pull request improves the robustness of FP8 quantization scaling and the all-gather logic for CPU-offloaded expert parameters, and adds a new unit test to cover edge cases in distributed training. The changes ensure more stable numerical behavior during quantization and fix potential failures when handling empty parameter shards across distributed ranks.

**Numerical stability improvements in FP8 quantization:**

* Lowered the minimum scaling factor (`sf`) from `1.0` or `1e-7` to `1e-30` in both `_per_channel_cast_to_fp8_kernel` and `_pack_kmajor_per_channel_fp8_kernel` to avoid NaNs and infinities when handling tiny or zero values. This change ensures that even extremely small channel activations do not destabilize training. [[1]](diffhunk://#diff-fa195e47971b6a9302adc2b9c8793b445d35a4fabfc29d43b210de6f4bde590bL561-R561) [[2]](diffhunk://#diff-fa195e47971b6a9302adc2b9c8793b445d35a4fabfc29d43b210de6f4bde590bL760-R760) [[3]](diffhunk://#diff-fa195e47971b6a9302adc2b9c8793b445d35a4fabfc29d43b210de6f4bde590bL769-R769)

**Distributed optimizer robustness:**

* Updated `_allgather_helper_experts_param` in `layer_wise_optimizer.py` to correctly handle cases where some ranks have empty parameter shards, preventing index errors and ensuring correct device/dtype handling even when only one rank owns parameters.

* Added a unit test `test_cpu_expert_allgather_with_empty_local_shards` to verify that CPU expert parameter all-gather works correctly when only one expert-DP rank owns parameters, increasing test coverage for distributed edge cases.