### PR TITLE
Add MLA Muon projection splitting

### DIFF
--- a/megatron/core/optimizer/muon.py
+++ b/megatron/core/optimizer/muon.py
@@ -75,6 +75,13 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         split_qkv: bool = False,
         is_qkv_fn: Callable[[torch.Tensor], bool] | None = None,
         qkv_split_shapes: tuple[int, int, int] | None = None,
+        is_kv_up_proj_fn: Callable[[torch.Tensor], bool] | None = None,
+        kv_up_proj_split_shapes: tuple[int, int] | None = None,
+        is_qkv_down_proj_fn: Callable[[torch.Tensor], bool] | None = None,
+        qkv_down_proj_split_shapes: tuple[int, int] | None = None,
+        split_mla_per_head: bool = False,
+        is_q_up_proj_fn: Callable[[torch.Tensor], bool] | None = None,
+        q_up_proj_head_dim: int | None = None,
         fp32_matmul_prec: str = "medium",
         coefficient_type: str = "quintic",
         num_ns_steps: int = 5,
@@ -118,6 +125,13 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         self.split_qkv = split_qkv
         self.is_qkv_fn = is_qkv_fn
         self.qkv_split_shapes = qkv_split_shapes
+        self.is_kv_up_proj_fn = is_kv_up_proj_fn
+        self.kv_up_proj_split_shapes = kv_up_proj_split_shapes
+        self.is_qkv_down_proj_fn = is_qkv_down_proj_fn
+        self.qkv_down_proj_split_shapes = qkv_down_proj_split_shapes
+        self.split_mla_per_head = split_mla_per_head
+        self.is_q_up_proj_fn = is_q_up_proj_fn
+        self.q_up_proj_head_dim = q_up_proj_head_dim
 
         weight_decay_method = "decoupled" if use_decoupled_weight_decay else "l2"
         nesterov_kwarg = (
@@ -160,7 +174,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             # emerging-optimizers use None instead of -1 to indicate no tensor parallel
             partition_dim = None
 
-        if self.split_qkv and self.is_qkv_fn(p):  # type: ignore[misc]
+        if self.split_qkv and self.is_qkv_fn is not None and self.is_qkv_fn(p):
             # split grouped attention parameters (e.g., QKV, GQA, etc.)
             grad_shape = grad.shape
             log_single_rank(
@@ -168,6 +182,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
                 logging.DEBUG,
                 f'qkv split grad shape {grad_shape}, split shapes {self.qkv_split_shapes}',
             )
+            assert self.qkv_split_shapes is not None
             num_query_groups = grad_shape[0] // sum(self.qkv_split_shapes)
             qkv_grads = torch.split(
                 grad.view(num_query_groups, sum(self.qkv_split_shapes), -1),
@@ -184,6 +199,91 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
                 for g in qkv_grads
             ]
             grad = torch.cat(qkv_grads, dim=1).view(grad_shape)
+        elif (
+            self.split_qkv
+            and self.is_qkv_down_proj_fn is not None
+            and self.is_qkv_down_proj_fn(p)
+        ):
+            # MLA fused path: split linear_qkv_down_proj into Q and KV/RoPE blocks.
+            # TODO: Validate whether this down-projection split is the right Muon
+            # treatment for fused MLA.
+            grad_shape = grad.shape
+            log_single_rank(
+                logger,
+                logging.DEBUG,
+                f'qkv_down_proj split grad shape {grad_shape}, '
+                f'split shapes {self.qkv_down_proj_split_shapes}',
+            )
+            assert self.qkv_down_proj_split_shapes is not None
+            qkv_down_grads = torch.split(grad, self.qkv_down_proj_split_shapes, dim=0)
+            qkv_down_grads = [
+                self.scaled_orthogonalize_fn(g, tp_group, partition_dim)
+                for g in qkv_down_grads
+            ]
+            grad = torch.cat(qkv_down_grads, dim=0)
+        elif (
+            self.split_qkv
+            and self.is_kv_up_proj_fn is not None
+            and self.is_kv_up_proj_fn(p)
+        ):
+            grad_shape = grad.shape
+            log_single_rank(
+                logger,
+                logging.DEBUG,
+                f'kv_up_proj split grad shape {grad_shape}, '
+                f'split shapes {self.kv_up_proj_split_shapes}',
+            )
+            assert self.kv_up_proj_split_shapes is not None
+            if self.split_mla_per_head:
+                num_heads = grad_shape[0] // sum(self.kv_up_proj_split_shapes)
+                kv_grads = torch.split(
+                    grad.view(num_heads, sum(self.kv_up_proj_split_shapes), -1),
+                    self.kv_up_proj_split_shapes,
+                    dim=1,
+                )
+                kv_grads = [g.reshape(-1, grad_shape[-1]) for g in kv_grads]
+                kv_grads = [
+                    self.scaled_orthogonalize_fn(g, tp_group, partition_dim).view(
+                        num_heads, -1, grad_shape[-1]
+                    )
+                    for g in kv_grads
+                ]
+                grad = torch.cat(kv_grads, dim=1).view(grad_shape)
+            else:
+                num_groups = grad_shape[0] // sum(self.kv_up_proj_split_shapes)
+                kv_grads = torch.split(
+                    grad.view(num_groups, sum(self.kv_up_proj_split_shapes), -1),
+                    self.kv_up_proj_split_shapes,
+                    dim=1,
+                )
+                kv_grads = [g.reshape(-1, grad_shape[-1]) for g in kv_grads]
+                kv_grads = [
+                    self.scaled_orthogonalize_fn(g, tp_group, partition_dim).view(
+                        num_groups, -1, grad_shape[-1]
+                    )
+                    for g in kv_grads
+                ]
+                grad = torch.cat(kv_grads, dim=1).view(grad_shape)
+        elif (
+            self.split_qkv
+            and self.split_mla_per_head
+            and self.is_q_up_proj_fn is not None
+            and self.is_q_up_proj_fn(p)
+        ):
+            grad_shape = grad.shape
+            log_single_rank(
+                logger,
+                logging.DEBUG,
+                f'q_up_proj per-head split grad shape {grad_shape}, '
+                f'head dim {self.q_up_proj_head_dim}',
+            )
+            assert self.q_up_proj_head_dim is not None
+            num_heads = grad_shape[0] // self.q_up_proj_head_dim
+            q_grads = grad.view(num_heads, self.q_up_proj_head_dim, -1).unbind(0)
+            q_grads = [
+                self.scaled_orthogonalize_fn(g, tp_group, partition_dim) for g in q_grads
+            ]
+            grad = torch.stack(q_grads, dim=0).view(grad_shape)
         else:
             grad = self.scaled_orthogonalize_fn(grad, tp_group, partition_dim)
         return grad
@@ -280,6 +380,26 @@ def get_megatron_muon_optimizer(
             kv_channels,
             kv_channels,
         ]
+        mla_config = model_chunk.config
+        is_mla = getattr(mla_config, 'multi_latent_attention', False)
+        if is_mla and config.muon_split_mla_per_head:
+            kv_up_proj_split_shapes = (mla_config.qk_head_dim, mla_config.v_head_dim)
+            q_up_proj_head_dim = mla_config.qk_head_dim + mla_config.qk_pos_emb_head_dim
+        elif is_mla:
+            kv_up_proj_split_shapes = (
+                num_attention_heads * mla_config.qk_head_dim,
+                num_attention_heads * mla_config.v_head_dim,
+            )
+            q_up_proj_head_dim = None
+        else:
+            kv_up_proj_split_shapes = None
+            q_up_proj_head_dim = None
+
+        qkv_down_proj_split_shapes = (
+            mla_config.q_lora_rank,
+            mla_config.kv_lora_rank + mla_config.qk_pos_emb_head_dim,
+        ) if is_mla and getattr(mla_config, 'q_lora_rank', None) is not None else None
+
         for name, param in model_chunk.named_parameters():
             if not param.requires_grad:
                 continue
@@ -288,10 +408,15 @@ def get_megatron_muon_optimizer(
             # change in optimizer
             if 'experts' in name and 'shared' not in name:
                 param.expert_tp = True
-            # add flag for qkv parameter
-            # TODO(deyuf): support MLA
+            # add flags for grouped QKV and MLA projection parameters
             if 'linear_qkv.weight' in name and len(param.shape) == 2:
                 param.is_qkv = True
+            if 'linear_kv_up_proj.weight' in name and len(param.shape) == 2:
+                param.is_kv_up_proj = True
+            if 'linear_q_up_proj.weight' in name and len(param.shape) == 2:
+                param.is_q_up_proj = True
+            if 'linear_qkv_down_proj.weight' in name and len(param.shape) == 2:
+                param.is_qkv_down_proj = True
             # TODO(deyuf): currently only allow 2D non-embedding weight to avoid breaking
             if (
                 not getattr(param, 'is_embedding_or_output_parameter', False)
@@ -313,6 +438,13 @@ def get_megatron_muon_optimizer(
         "split_qkv": config.muon_split_qkv,
         "is_qkv_fn": lambda p: getattr(p, "is_qkv", False),
         "qkv_split_shapes": qkv_split_shapes,
+        "is_kv_up_proj_fn": lambda p: getattr(p, "is_kv_up_proj", False),
+        "kv_up_proj_split_shapes": kv_up_proj_split_shapes,
+        "is_qkv_down_proj_fn": lambda p: getattr(p, "is_qkv_down_proj", False),
+        "qkv_down_proj_split_shapes": qkv_down_proj_split_shapes,
+        "split_mla_per_head": config.muon_split_mla_per_head,
+        "is_q_up_proj_fn": lambda p: getattr(p, "is_q_up_proj", False),
+        "q_up_proj_head_dim": q_up_proj_head_dim,
         "extra_scale_factor": config.muon_extra_scale_factor,
         "pg_collection": pg_collection,
         "mode": config.muon_tp_mode,

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -268,6 +268,9 @@ class OptimizerConfig:
     muon_split_qkv: bool = True
     """Whether to split QKV parameters for Muon optimizer."""
 
+    muon_split_mla_per_head: bool = False
+    """Whether to split MLA up-projection parameters per attention head for Muon optimizer."""
+
     muon_use_nesterov: bool = False
     """Whether to use Nesterov-style momentum in the internal SGD."""
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -60,6 +60,9 @@ except ImportError:
 _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {
     "expert_tp": False,
     "is_qkv": False,
+    "is_kv_up_proj": False,
+    "is_q_up_proj": False,
+    "is_qkv_down_proj": False,
     "tensor_model_parallel": False,
     "partition_dim": -1,
     "partition_stride": 1,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2268,6 +2268,8 @@ def _add_regularization_args(parser):
     group.add_argument('--muon-no-split-qkv', action='store_false', default=True,
                        dest='muon_split_qkv',
                        help='Whether to split QKV parameters for Muon optimizer')
+    group.add_argument('--muon-split-mla-per-head', action='store_true',
+                       help='Split MLA up-projection parameters per attention head for Muon.')
     group.add_argument('--muon-use-nesterov', action='store_true',
                        help='Whether to use Nesterov-style momentum in the internal SGD')
     group.add_argument('--muon-scale-mode', type=str, default='spectral',

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1559,6 +1559,15 @@ def load_args_from_checkpoint(
     _set_arg('moe_router_enable_expert_bias', force=True)
     _set_arg('moe_router_topk_scaling_factor', force=True)
 
+    # MLA args.
+    _set_arg('multi_latent_attention', force=True)
+    _set_arg('q_lora_rank', force=True)
+    _set_arg('kv_lora_rank', force=True)
+    _set_arg('qk_head_dim', force=True)
+    _set_arg('qk_pos_emb_head_dim', force=True)
+    _set_arg('v_head_dim', force=True)
+    _set_arg('rotary_scaling_factor', force=True)
+
     # Mamba args.
     _set_arg('mamba_state_dim', force=True)
     _set_arg('mamba_head_dim', force=True)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2248,6 +2248,9 @@ def training_log(
         tokens_per_iteration = args.global_batch_size * args.seq_length
         tokens_per_sec = tokens_per_iteration / elapsed_time_per_iteration
         tokens_per_sec_per_gpu = tokens_per_sec / args.world_size
+        iterations_remaining = max(args.train_iters - iteration, 0)
+        eta_seconds = iterations_remaining * elapsed_time_per_iteration
+        eta = str(timedelta(seconds=int(eta_seconds)))
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
 
@@ -2257,8 +2260,12 @@ def training_log(
         if args.log_timers_to_tensorboard and not is_first_iteration:
             if writer:
                 writer.add_scalar('iteration-time', elapsed_time_per_iteration, iteration)
+                writer.add_scalar('eta-seconds', eta_seconds, iteration)
             if wandb_writer:
-                wandb_writer.log({'iteration-time': elapsed_time_per_iteration}, iteration)
+                wandb_writer.log(
+                    {'iteration-time': elapsed_time_per_iteration, 'eta-seconds': eta_seconds},
+                    iteration,
+                )
         log_string = f" [{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')}]"
         log_string += ' iteration {:8d}/{:8d} |'.format(iteration, args.train_iters)
         log_string += ' consumed samples: {:12d} |'.format(args.consumed_train_samples)
@@ -2271,6 +2278,7 @@ def training_log(
         log_string += ' elapsed time per iteration (ms): {:.1f} |'.format(
             elapsed_time_per_iteration * 1000.0
         )
+        log_string += f' eta: {eta} |'
         if args.log_throughput:
             log_string += f' tokens per sec per GPU: {tokens_per_sec_per_gpu:.2f} |'
             log_string += f' throughput per GPU (TFLOP/s/GPU): {throughput:.1f} |'

--- a/tests/unit_tests/test_muon_optimizer.py
+++ b/tests/unit_tests/test_muon_optimizer.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from packaging.version import Version
 
-from megatron.core import parallel_state
+from megatron.core import parallel_state, tensor_parallel
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.optimizer import HAVE_EMERGING_OPTIMIZERS, HAVE_EO_V02, OptimizerConfig
 from megatron.core.optimizer.muon import (
@@ -633,6 +633,116 @@ def test_muon_optimizer_qkv_split():
     assert not torch.equal(
         weight_with_split, weight_without_split
     ), "Weights should be different between split_qkv=True and split_qkv=False"
+
+
+def _record_muon_split_output(param, grad, **muon_kwargs):
+    optimizer = TensorParallelMuon(
+        params=[param],
+        lr=0.01,
+        split_qkv=True,
+        num_ns_steps=5,
+        pg_collection=None,
+        mode="duplicated",
+        **muon_kwargs,
+    )
+    calls = []
+
+    def record_split(split_grad, tp_group, partition_dim):
+        del tp_group, partition_dim
+        calls.append(split_grad.detach().clone())
+        return torch.full_like(split_grad, float(len(calls)))
+
+    optimizer.scaled_orthogonalize_fn = record_split
+    return optimizer.orthogonalize(param, grad), calls
+
+
+def test_muon_optimizer_mla_kv_up_proj_split():
+    param = torch.nn.Parameter(torch.empty(14, 4, device='cuda'))
+    param.is_kv_up_proj = True
+    grad = torch.arange(56, dtype=torch.float32, device='cuda').view(14, 4)
+
+    output, calls = _record_muon_split_output(
+        param,
+        grad,
+        is_kv_up_proj_fn=lambda p: getattr(p, 'is_kv_up_proj', False),
+        kv_up_proj_split_shapes=(8, 6),
+    )
+
+    assert [call.shape for call in calls] == [torch.Size([8, 4]), torch.Size([6, 4])]
+    assert torch.equal(output[:8], torch.ones_like(output[:8]))
+    assert torch.equal(output[8:], torch.full_like(output[8:], 2.0))
+
+
+def test_muon_optimizer_mla_kv_up_proj_split_per_head():
+    param = torch.nn.Parameter(torch.empty(10, 4, device='cuda'))
+    param.is_kv_up_proj = True
+    grad = torch.arange(40, dtype=torch.float32, device='cuda').view(10, 4)
+
+    output, calls = _record_muon_split_output(
+        param,
+        grad,
+        is_kv_up_proj_fn=lambda p: getattr(p, 'is_kv_up_proj', False),
+        kv_up_proj_split_shapes=(3, 2),
+        split_mla_per_head=True,
+    )
+
+    assert [call.shape for call in calls] == [torch.Size([6, 4]), torch.Size([4, 4])]
+    expected = torch.tensor([1, 1, 1, 2, 2, 1, 1, 1, 2, 2], device='cuda').view(10, 1)
+    assert torch.equal(output, expected.expand_as(output))
+
+
+def test_muon_optimizer_mla_q_up_proj_split_per_head():
+    param = torch.nn.Parameter(torch.empty(12, 4, device='cuda'))
+    param.is_q_up_proj = True
+    grad = torch.arange(48, dtype=torch.float32, device='cuda').view(12, 4)
+
+    output, calls = _record_muon_split_output(
+        param,
+        grad,
+        is_q_up_proj_fn=lambda p: getattr(p, 'is_q_up_proj', False),
+        q_up_proj_head_dim=4,
+        split_mla_per_head=True,
+    )
+
+    assert [call.shape for call in calls] == [
+        torch.Size([4, 4]),
+        torch.Size([4, 4]),
+        torch.Size([4, 4]),
+    ]
+    expected = torch.tensor([1] * 4 + [2] * 4 + [3] * 4, device='cuda').view(12, 1)
+    assert torch.equal(output, expected.expand_as(output))
+
+
+def test_muon_optimizer_mla_qkv_down_proj_split_mechanics():
+    param = torch.nn.Parameter(torch.empty(5, 4, device='cuda'))
+    param.is_qkv_down_proj = True
+    grad = torch.arange(20, dtype=torch.float32, device='cuda').view(5, 4)
+
+    output, calls = _record_muon_split_output(
+        param,
+        grad,
+        is_qkv_down_proj_fn=lambda p: getattr(p, 'is_qkv_down_proj', False),
+        qkv_down_proj_split_shapes=(2, 3),
+    )
+
+    assert [call.shape for call in calls] == [torch.Size([2, 4]), torch.Size([3, 4])]
+    assert torch.equal(output[:2], torch.ones_like(output[:2]))
+    assert torch.equal(output[2:], torch.full_like(output[2:], 2.0))
+
+
+def test_muon_mla_param_tags_copy_to_main_param():
+    param = torch.empty(2, 2)
+    tensor_parallel.set_defaults_if_not_set_tensor_model_parallel_attributes(param)
+    param.is_kv_up_proj = True
+    param.is_q_up_proj = True
+    param.is_qkv_down_proj = True
+    main_param = torch.empty_like(param)
+
+    tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
+
+    assert main_param.is_kv_up_proj
+    assert main_param.is_q_up_proj
+    assert main_param.is_qkv_down_proj
 
 
 def test_muon_optimizer_extra_scale_factor():


### PR DESCRIPTION
# Description
This PR adds the MLA Muon projection splitting fix onto apertus-moe/main.

The main change is changing TensorParallelMuon to split MLA projection gradients before orthogonalization, instead of treating the fused projection matrices as a single semantic matrix. This covers:
- MLA KV up-projection splitting
- optional per-head MLA up-projection splitting (from GLM-5, but we will probably not use this)
fused MLA down-projection split path with a TODO to validate the exact Muon treatment
parameter tags for MLA projection weights, preserved through FP32 master-param copies
`--muon-split-mla-per-head` / `muon_split_mla_per_head` config support
Also included:
- checkpoint loading now restores MLA architecture args from checkpoint args
- training logs now include ETA
- focused Muon unit tests for the new split mechanics and tag copying

This are some of the changes that have been used on 30B-A3B MoE multilingual model training https://github.com/NouamaneTazi/Megatron-LM/pull/11

@FFGGSSJJ @AllenHaoHuang 