### PR TITLE
Feat/md decoupling optimizer

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -53,7 +53,12 @@ from ..fp8_utils import dequantize_fp8_tensor, is_float8tensor, quantize_param_s
 from ..transformer.fsdp_dtensor_checkpoint import handle_experts_in_state_dict
 from ..transformer.module import MegatronModule
 from .grad_scaler import MegatronGradScaler
-from .optimizer import MixedPrecisionOptimizer, _zero_grad_group_helper, param_group_identifier_keys
+from .optimizer import (
+    MixedPrecisionOptimizer,
+    _propagate_routing_attrs,
+    _zero_grad_group_helper,
+    param_group_identifier_keys,
+)
 from .optimizer_config import OptimizerConfig
 
 logger = getLogger(__name__)
@@ -373,6 +378,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         )
                         if hasattr(model_param, 'shared'):
                             shard_model_param.shared = model_param.shared
+                        _propagate_routing_attrs(shard_model_param, model_param)
 
                     # Generate main param.
                     if not config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
@@ -408,6 +414,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         )
                         if hasattr(model_param, 'shared'):
                             shard_main_param.shared = model_param.shared
+                        _propagate_routing_attrs(shard_main_param, model_param)
                     else:
                         # When using precision-aware optimizer, main params are held by FusedAdam.
                         shard_main_param = None
@@ -431,6 +438,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     )
                     if hasattr(model_param, 'shared'):
                         shard_model_param.shared = model_param.shared
+                    _propagate_routing_attrs(shard_model_param, model_param)
 
                 else:
                     raise TypeError(

--- a/megatron/core/optimizer/md_decoupling.py
+++ b/megatron/core/optimizer/md_decoupling.py
@@ -2,20 +2,19 @@
 
 """MDDecoupling optimizer (magnitude-direction decoupling).
 
-Ported and slimmed from the ``master`` optimizer in the megatron-muonmd-tp fork. The
-optimizer decouples a 2D weight into a *direction* (hypersphere-normalized weight) and a
-*magnitude* (learnable per-axis gains), with an optional Muon-style orthogonalized update on
-the direction. 1D params (biases / norms) and (optionally) embedding/output params are routed
-to a chained external AdamW by :func:`get_megatron_mddecoupling_optimizer` — the MDDecoupling
-class itself only ever steps on 2D params.
+Decouples a 2D weight into a *direction* (hypersphere-normalized weight) and a *magnitude*
+(learnable per-axis gains), with an optional Muon-style orthogonalized update on the direction:
 
-Slim cut relative to the source ``master``:
-  - L2 hypersphere clipping (post-step only, no update normalization). Modes: row, col, flat, embed.
-  - Gains are an optional fused reparameterization (p = normalized_w * phi(gains)).
-  - ``gain_parametrization`` is ``direct`` or ``softplus`` (no ``offset``).
-  - No AdEMAMix (alpha / beta3 / warmups) and no NorMuon.
-  - ``MDDecoupling`` also handles the no-gains case (hypersphere_gains_mode=None), so a single
-    class covers both.
+  - Direction: post-step L2-sphere projection of the weight (modes: row, col, flat, embed),
+    optionally per-class for embedding/output and router weights.
+  - Magnitude: optional learnable per-axis gains as a fused reparameterization
+    (p = normalized_w * phi(gains)); ``gain_parametrization`` selects phi ∈ {direct, softplus}.
+  - Update: AdamW by default, or Muon orthogonalized updates (``use_orthogonal_updates``).
+
+1D params (biases / norms) and (optionally) embedding/output params are routed to a chained
+external AdamW by :func:`get_megatron_mddecoupling_optimizer` — the ``MDDecoupling`` class itself
+only ever steps on 2D params. Setting ``hypersphere_gains_mode=None`` disables the gain
+machinery, so a single class covers both the gains and no-gains cases.
 """
 
 import logging
@@ -29,7 +28,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.utils import get_pg_size, log_single_rank
 
-# NOTE: these package-level imports are safe because mddecoupling is only imported lazily from
+# NOTE: these package-level imports are safe because this module is only imported lazily from
 # megatron.training.training (never from this package's __init__), so megatron.core.optimizer is
 # fully initialized by the time this module loads — same pattern as muon.py.
 from . import (
@@ -63,8 +62,8 @@ logger = logging.getLogger(__name__)
 def _get_muon_scale_factor(size_out: int, size_in: int, mode: str = "spectral") -> float:
     """Muon orthogonalization scale factor.
 
-    ``shape_up`` is master-specific (= max(d_out/d_in, d_in/d_out)**0.5); other modes delegate
-    to the emerging_optimizers implementation.
+    ``shape_up`` (= max(d_out/d_in, d_in/d_out)**0.5) and ``none`` (= 1.0) are handled here;
+    all other modes delegate to the emerging_optimizers implementation.
     """
     if mode == "shape_up":
         return max(size_out / size_in, size_in / size_out) ** 0.5
@@ -90,7 +89,7 @@ class _MDDecouplingBase(torch.optim.Optimizer):
         hypersphere_embedding_mode: Optional[Literal["row", "col", "flat", "embed", "none"]] = None,
         hypersphere_router_mode: Optional[Literal["row", "col", "flat", "embed", "none"]] = None,
         hypersphere_eps: float = 1e-8,
-        # Muown-style options (off by default).
+        # Tangential-gradient / preserve-init options (off by default).
         hypersphere_tangential_grad: bool = False,
         hypersphere_preserve_init: bool = False,
         # When True, scale the hypersphere target radius for is_out_proj params (linear_proj,
@@ -457,8 +456,8 @@ class MDDecoupling(_MDDecouplingBase):
         gains_eps: float = 1e-8,
         gains_weight_decay: float = 0.0,
         # Reparametrize the per-axis gain: the stored state tensor is `g`, the effective
-        # multiplier applied to `p` is `phi(g)`. "direct" reproduces the original behavior
-        # (phi(g)=g). Applied uniformly to row/col/flat.
+        # multiplier applied to `p` is `phi(g)`. "direct" is the identity (phi(g)=g);
+        # "softplus" uses phi(g)=softplus(g). Applied uniformly to row/col/flat.
         gain_parametrization: Literal["direct", "softplus"] = "direct",
         **kwargs,
     ):
@@ -846,7 +845,7 @@ def _mddecoupling_config_overrides(
     config: OptimizerConfig, base_overrides: Dict[ParamKey, ParamGroupOverride]
 ) -> Dict[ParamKey, ParamGroupOverride]:
     """Build the config_overrides for MDDecoupling: matrix / embedding / output / router LR
-    groups and per-group use_orthogonal_updates routing. Ported from the source 'master' block.
+    groups and per-group use_orthogonal_updates routing.
 
     Starts from ``base_overrides`` (the standard wd-skip + decoupled-LR overrides) and adds the
     MDDecoupling-specific entries on top. Returned dict is passed to BOTH the MDDecoupling param

--- a/megatron/core/optimizer/md_decoupling.py
+++ b/megatron/core/optimizer/md_decoupling.py
@@ -1,0 +1,1090 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""MDDecoupling optimizer (magnitude-direction decoupling).
+
+Ported and slimmed from the ``master`` optimizer in the megatron-muonmd-tp fork. The
+optimizer decouples a 2D weight into a *direction* (hypersphere-normalized weight) and a
+*magnitude* (learnable per-axis gains), with an optional Muon-style orthogonalized update on
+the direction. 1D params (biases / norms) and (optionally) embedding/output params are routed
+to a chained external AdamW by :func:`get_megatron_mddecoupling_optimizer` — the MDDecoupling
+class itself only ever steps on 2D params.
+
+Slim cut relative to the source ``master``:
+  - L2 hypersphere clipping (post-step only, no update normalization). Modes: row, col, flat, embed.
+  - Gains are an optional fused reparameterization (p = normalized_w * phi(gains)).
+  - ``gain_parametrization`` is ``direct`` or ``softplus`` (no ``offset``).
+  - No AdEMAMix (alpha / beta3 / warmups) and no NorMuon.
+  - ``MDDecoupling`` also handles the no-gains case (hypersphere_gains_mode=None), so a single
+    class covers both.
+"""
+
+import logging
+import math
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+import torch
+
+from megatron.core.optimizer_param_scheduler import ParamGroupOverride
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.utils import get_pg_size, log_single_rank
+
+# NOTE: these package-level imports are safe because mddecoupling is only imported lazily from
+# megatron.training.training (never from this package's __init__), so megatron.core.optimizer is
+# fully initialized by the time this module loads — same pattern as muon.py.
+from . import (
+    HAVE_EMERGING_OPTIMIZERS,
+    _get_param_groups,
+    get_megatron_optimizer,
+    get_standard_config_overrides,
+)
+from .layer_wise_optimizer import LayerWiseDistributedOptimizer
+from .optimizer import (
+    ChainedOptimizer,
+    Float16OptimizerWithFloat16Params,
+    FP32Optimizer,
+    MegatronOptimizer,
+)
+from .optimizer_config import OptimizerConfig, ParamKey, ParamPredicate
+
+try:
+    import emerging_optimizers
+    from emerging_optimizers.orthogonalized_optimizers import (
+        get_muon_scale_factor as _emerging_get_muon_scale_factor,
+    )
+    from emerging_optimizers.orthogonalized_optimizers.muon_utils import newton_schulz_tp
+except ImportError:
+    emerging_optimizers = None
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_muon_scale_factor(size_out: int, size_in: int, mode: str = "spectral") -> float:
+    """Muon orthogonalization scale factor.
+
+    ``shape_up`` is master-specific (= max(d_out/d_in, d_in/d_out)**0.5); other modes delegate
+    to the emerging_optimizers implementation.
+    """
+    if mode == "shape_up":
+        return max(size_out / size_in, size_in / size_out) ** 0.5
+    if mode == "none":
+        return 1.0
+    return _emerging_get_muon_scale_factor(size_out, size_in, mode=mode)
+
+
+class _MDDecouplingBase(torch.optim.Optimizer):
+    """AdamW + optional Muon orthogonalized updates + L2 hypersphere post-step weight clipping."""
+
+    def __init__(
+        self,
+        params,
+        # Common.
+        lr: float = 1e-3,
+        weight_decay: float = 0.0,
+        # Adam.
+        betas: tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-8,
+        # Hypersphere (L2, post-step weight projection only).
+        hypersphere_mode: Optional[Literal["row", "col", "flat", "embed"]] = None,
+        hypersphere_embedding_mode: Optional[Literal["row", "col", "flat", "embed", "none"]] = None,
+        hypersphere_router_mode: Optional[Literal["row", "col", "flat", "embed", "none"]] = None,
+        hypersphere_eps: float = 1e-8,
+        # Muown-style options (off by default).
+        hypersphere_tangential_grad: bool = False,
+        hypersphere_preserve_init: bool = False,
+        # When True, scale the hypersphere target radius for is_out_proj params (linear_proj,
+        # linear_fc2) by 1/sqrt(2 * num_layers) — matches scaled_init_method_normal so the
+        # constraint preserves Megatron's depth-aware init for residual-out projections.
+        hypersphere_scale_out_proj_init: bool = False,
+        num_layers: Optional[int] = None,
+        # Muon (orthogonalized updates).
+        use_orthogonal_updates: bool = False,
+        momentum_beta: float = 0.95,
+        use_nesterov: bool = True,
+        split_qkv: bool = True,
+        qkv_split_shapes: Optional[tuple[int, int, int]] = None,
+        qkv_dim: Optional[int] = None,
+        is_qkv_fn: Optional[Callable[[torch.Tensor], bool]] = None,
+        fp32_matmul_prec: str = "medium",
+        coefficient_type: str = "quintic",
+        num_ns_steps: int = 5,
+        scale_mode: str = "spectral",
+        extra_scale_factor: float = 1.0,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+        tp_mode: Literal["blockwise", "duplicated", "distributed"] = "duplicated",
+    ):
+        self.fp32_matmul_prec = fp32_matmul_prec
+        self.use_nesterov = use_nesterov
+
+        self.hypersphere_mode = hypersphere_mode
+        self.hypersphere_embedding_mode = hypersphere_embedding_mode
+        self.hypersphere_router_mode = hypersphere_router_mode
+        self.hypersphere_eps = hypersphere_eps
+        self.hypersphere_tangential_grad = hypersphere_tangential_grad
+        self.hypersphere_preserve_init = hypersphere_preserve_init
+        if hypersphere_scale_out_proj_init:
+            assert num_layers is not None and num_layers > 0, (
+                "hypersphere_scale_out_proj_init=True requires num_layers"
+            )
+            self.out_proj_radius_scale = 1.0 / math.sqrt(2 * num_layers)
+        else:
+            self.out_proj_radius_scale = 1.0
+
+        self.split_qkv = split_qkv
+        self.is_qkv_fn = is_qkv_fn if is_qkv_fn is not None else (lambda p: False)
+        self.qkv_split_shapes = qkv_split_shapes
+        self.qkv_dim = qkv_dim
+
+        self.coefficient_type = coefficient_type
+        self.num_ns_steps = num_ns_steps
+        self.scale_mode = scale_mode
+        self.extra_scale_factor = extra_scale_factor
+
+        self.pg_collection = pg_collection
+        self.tp_mode = tp_mode
+
+        defaults = dict(
+            lr=lr,
+            weight_decay=weight_decay,
+            beta1=betas[0],
+            beta2=betas[1],
+            momentum_beta=momentum_beta,
+            step=0,
+            eps=eps,
+            use_orthogonal_updates=use_orthogonal_updates,
+        )
+        super().__init__(params, defaults)
+
+        # Ckpt-resume workaround: Megatron's _filter_and_reorder_param_groups (optimizer.py) keys
+        # saved groups by (wd_mult, lr_mult, is_expert_parallel, is_decoupled_lr). MDDecoupling's
+        # overrides differ only in max_lr / min_lr / use_orthogonal_updates, so multiple groups
+        # (matrix, embedding, LM-head, router, ...) collide on that tuple. The loader's dict-based
+        # map then silently overwrites colliding entries and reassigns the surviving group's
+        # `params` repeatedly, which trips torch.optim.Optimizer.load_state_dict's per-group size
+        # check. lr_mult is unused at runtime (OptimizerParamScheduler reads max_lr/min_lr), so a
+        # unique tag per group disambiguates the loader without touching training math. Save/load
+        # round-trip works because both jobs run this same code in the same param-group order.
+        for _i, _g in enumerate(self.param_groups):
+            _g['lr_mult'] = float(_i + 1)
+
+        # Normalize parameters at init so the first forward sees on-sphere weights. When
+        # hypersphere_preserve_init=True we skip this so the model's init magnitude survives into
+        # training (gains absorb the magnitude downstream in MDDecoupling._maybe_init_gain_state).
+        if (not self.hypersphere_preserve_init
+                and (self.hypersphere_mode is not None
+                     or self.hypersphere_embedding_mode is not None
+                     or self.hypersphere_router_mode is not None)):
+            with torch.no_grad():
+                for group in self.param_groups:
+                    for p in group["params"]:
+                        if p.ndim != 2:
+                            continue
+                        is_qkv = self.is_qkv_fn(p)
+                        is_out_proj = getattr(p, "is_out_proj", False)
+                        is_embedding = getattr(p, "is_embedding_or_output_parameter", False)
+                        is_router = getattr(p, "is_router", False)
+                        self._normalize(p, p, is_qkv=is_qkv, is_out_proj=is_out_proj,
+                                        is_embedding=is_embedding, is_router=is_router)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            group["step"] += 1
+            if "momentum_beta" not in group:  # Old checkpoint compat.
+                group["momentum_beta"] = group["beta1"]
+            for p in group["params"]:
+                if p.grad is not None:
+                    self._param_step(p, group)
+
+        return loss
+
+    def _param_step(self, p, group):
+        grad = p.grad
+        state = self.state[p]
+
+        if "exp_avg" not in state:  # row_gain may already be present from gains.
+            state["exp_avg"] = torch.zeros_like(grad)
+            if not group["use_orthogonal_updates"] and group["beta2"] != 0:
+                state["exp_avg_sq"] = torch.zeros_like(grad)
+
+        exp_avg = state["exp_avg"]
+        beta1 = group["beta1"]
+        momentum_beta = group["momentum_beta"]
+        is_qkv = self.is_qkv_fn(p)
+        is_out_proj = getattr(p, "is_out_proj", False)
+        is_embedding = getattr(p, "is_embedding_or_output_parameter", False)
+        is_router = getattr(p, "is_router", False)
+
+        # Strip the radial component of grad before it feeds any momentum buffer or 2nd-moment
+        # estimate (applies to both Muon and AdamW).
+        if self.hypersphere_tangential_grad:
+            self._project_tangent_inplace(
+                p, grad, is_qkv=is_qkv, is_out_proj=is_out_proj,
+                is_embedding=is_embedding, is_router=is_router,
+            )
+
+        if group["use_orthogonal_updates"]:  # Muon branch.
+            assert emerging_optimizers is not None, (
+                "emerging_optimizers package required for --use-orthogonal-updates"
+            )
+            self._apply_weight_decay_inplace(p, group)
+            exp_avg.lerp_(grad, 1 - momentum_beta)
+            if self.use_nesterov:
+                grad = grad.lerp(exp_avg, momentum_beta)
+            else:
+                grad = exp_avg
+            with emerging_optimizers.utils.fp32_matmul_precision(self.fp32_matmul_prec):
+                update = self._orthogonalize_param(p, grad, is_qkv=is_qkv)
+            # Shrink Muon update for is_out_proj params to match the smaller target sphere. Muon's
+            # shape_up (and spectral) scale targets the natural RMS of a unit-row/col matrix; with
+            # target radius 1/sqrt(2L) the bare update needs the same shrink factor.
+            radius_scale = self._resolve_radius_scale(is_out_proj)
+            if radius_scale != 1.0:
+                update = update * radius_scale
+        else:  # AdamW branch.
+            beta2 = group["beta2"]
+            exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+            bias_correction1 = 1.0 - (beta1 ** group["step"])
+
+            if beta2 == 0:  # plain SGD with momentum (no exp_avg_sq).
+                update = exp_avg / bias_correction1
+            else:  # Adam.
+                exp_avg_sq = state["exp_avg_sq"]
+                bias_correction2 = 1.0 - (beta2 ** group["step"])
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
+                denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(group["eps"])
+                update = exp_avg.div(bias_correction1) / denom
+
+            self._apply_weight_decay_inplace(p, group)
+
+        # Apply update.
+        p.add_(update, alpha=-group["lr"])
+
+        # Post-step hypersphere normalization (matrix clipping).
+        if p.ndim == 2 and self._resolve_mode(is_embedding, is_router) is not None:
+            self._normalize(p, p, is_qkv=is_qkv, is_out_proj=is_out_proj,
+                            is_embedding=is_embedding, is_router=is_router)
+
+    def _apply_weight_decay_inplace(self, p, group):
+        weight_decay = group["weight_decay"]
+        if weight_decay != 0:
+            p.add_(p, alpha=-weight_decay * group["lr"])
+
+    def _orthogonalize_param(self, p, grad, is_qkv: bool = False):
+        """Newton-Schulz orthogonalization, with optional QKV split."""
+        if self.pg_collection is not None:
+            tp_group = (self.pg_collection.expt_tp
+                        if getattr(p, "expert_tp", False)
+                        else self.pg_collection.tp)
+        else:
+            tp_group = None
+        partition_dim = None if self.tp_mode == "blockwise" else getattr(p, "partition_dim", None)
+        if partition_dim == -1:
+            partition_dim = None
+
+        if self.split_qkv and is_qkv:
+            qs, ks, vs = _split_qkv(grad, self.qkv_split_shapes)
+            qs = self._orthogonalize_tensor(qs, tp_group, partition_dim)
+            ks = self._orthogonalize_tensor(ks, tp_group, partition_dim)
+            vs = self._orthogonalize_tensor(vs, tp_group, partition_dim)
+            return _merge_qkv((qs, ks, vs), grad.shape, self.qkv_split_shapes)
+        return self._orthogonalize_tensor(grad, tp_group, partition_dim)
+
+    def _orthogonalize_tensor(self, grad, tp_group, partition_dim):
+        assert grad.ndim == 2
+        size = [grad.size(-2), grad.size(-1)]
+        if partition_dim is not None:
+            size[partition_dim] *= get_pg_size(tp_group)
+        orth = newton_schulz_tp(
+            grad,
+            steps=self.num_ns_steps,
+            coefficient_type=self.coefficient_type,
+            tp_group=tp_group,
+            partition_dim=partition_dim,
+            tp_mode=("duplicated" if self.tp_mode == "blockwise" else self.tp_mode),
+        )
+        scale = _get_muon_scale_factor(size[0], size[1], mode=self.scale_mode)
+        return orth * scale * self.extra_scale_factor
+
+    def _resolve_mode(self, is_embedding: bool, is_router: bool = False):
+        if is_router and self.hypersphere_router_mode is not None:
+            mode = self.hypersphere_router_mode
+        elif is_embedding and self.hypersphere_embedding_mode is not None:
+            mode = self.hypersphere_embedding_mode
+        else:
+            mode = self.hypersphere_mode
+        return None if mode == "none" else mode
+
+    def _resolve_radius_scale(self, is_out_proj: bool) -> float:
+        """Effective hypersphere radius scale for this param. Returns 1.0 unless
+        --hypersphere-scale-out-proj-init is on AND the param is is_out_proj. When gains +
+        preserve_init are both active the gain absorbs the init magnitude
+        (_maybe_init_gain_state), so we keep bare scale=1 to avoid double-counting."""
+        if not is_out_proj or self.out_proj_radius_scale == 1.0:
+            return 1.0
+        if (getattr(self, "hypersphere_gains_mode", None) is not None
+                and self.hypersphere_preserve_init):
+            return 1.0
+        return self.out_proj_radius_scale
+
+    def _project_tangent_inplace(self, p, grad, is_qkv: bool = False, is_out_proj: bool = False,
+                                  is_embedding: bool = False, is_router: bool = False):
+        """In-place: remove the radial component of `grad` w.r.t. the hypersphere mode at `p`.
+        Mirrors _normalize's QKV-split layout so the constraint matches the post-step projection."""
+        mode = self._resolve_mode(is_embedding, is_router)
+        if mode is None:
+            return
+        if is_qkv and self.split_qkv:
+            ps = _split_qkv(p, self.qkv_split_shapes)
+            gs = _split_qkv(grad, self.qkv_split_shapes)
+            for pi, gi in zip(ps, gs):
+                self._project_tangent_single_(pi, gi, is_out_proj, mode)
+            grad.copy_(_merge_qkv(gs, grad.size(), self.qkv_split_shapes))
+            return
+        self._project_tangent_single_(p, grad, is_out_proj, mode)
+
+    def _project_tangent_single_(self, p, grad, is_out_proj: bool, mode: str):
+        if mode == "col":
+            dim = 0
+        elif mode == "row":
+            dim = 1
+        elif mode == "embed":
+            dim = 0 if is_out_proj else 1
+        elif mode == "flat":
+            dim = None
+        else:
+            return
+        if dim is None:
+            p_norm_sq = (p * p).sum().clamp_min(self.hypersphere_eps)
+            radial = (p * grad).sum() / p_norm_sq
+        else:
+            p_norm_sq = (p * p).sum(dim=dim, keepdim=True).clamp_min(self.hypersphere_eps)
+            radial = (p * grad).sum(dim=dim, keepdim=True) / p_norm_sq
+        grad.sub_(p * radial)
+
+    def _normalize(self, p, x, is_qkv: bool = False, is_out_proj: bool = False,
+                   is_embedding: bool = False, is_router: bool = False):
+        """In-place L2-sphere projection of a 2D tensor `x` (sized like `p`).
+
+        For QKV-merged weights, normalize each of Q/K/V separately. Modes:
+            row    → unit-norm each output row     (dim=1)
+            col    → unit-norm each input column   (dim=0)
+            flat   → unit Frobenius then scale by sqrt(max(d_out, d_in))
+            embed  → row for non-out_proj, col for out_proj
+        """
+        mode = self._resolve_mode(is_embedding, is_router)
+        if mode is None:
+            return
+
+        partition_dim = getattr(p, "partition_dim", None)
+        radius_scale = self._resolve_radius_scale(is_out_proj)
+
+        is_expert_tp = getattr(p, "expert_tp", False)
+        if is_qkv and self.split_qkv:
+            qs, ks, vs = _split_qkv(x, self.qkv_split_shapes)
+            self._normalize_single(qs, is_out_proj, mode, radius_scale, partition_dim, is_expert_tp)
+            self._normalize_single(ks, is_out_proj, mode, radius_scale, partition_dim, is_expert_tp)
+            self._normalize_single(vs, is_out_proj, mode, radius_scale, partition_dim, is_expert_tp)
+            x.copy_(_merge_qkv((qs, ks, vs), x.size(), self.qkv_split_shapes))
+            return
+
+        self._normalize_single(x, is_out_proj, mode, radius_scale, partition_dim, is_expert_tp)
+
+    def _normalize_single(self, x, is_out_proj: bool, mode: str, radius_scale: float = 1.0,
+                          partition_dim: Optional[int] = None, is_expert_tp: bool = False):
+        if mode == "col":
+            dim = 0
+        elif mode == "row":
+            dim = 1
+        elif mode == "flat":
+            dim = None
+        elif mode == "embed":
+            dim = 0 if is_out_proj else 1
+        else:
+            raise ValueError(f"Unsupported hypersphere mode: {mode}")
+
+        # Find norm of x, sync with TP group if needed.
+        tp_group = self.pg_collection.expt_tp if is_expert_tp else self.pg_collection.tp
+        if partition_dim in {0, 1} and (mode == "flat" or partition_dim == dim):
+            norm = torch.norm(x, dim=dim, keepdim=True)
+            norm_squared = norm**2
+            torch.distributed.all_reduce(norm_squared, group=tp_group)
+            norm = torch.sqrt(norm_squared).clamp_min(self.hypersphere_eps)
+        else:
+            norm = torch.norm(x, dim=dim, keepdim=True).clamp_min(self.hypersphere_eps)
+
+        # Normalize x.
+        x.div_(norm)
+        if mode == "flat":
+            tp_size = get_pg_size(tp_group) if partition_dim in {0, 1} else 1
+            global_sizes = [x.size(-2), x.size(-1)]
+            if partition_dim in {0, 1}:
+                global_sizes[partition_dim] *= tp_size
+            x.mul_(max(global_sizes) ** 0.5)
+        if radius_scale != 1.0:
+            x.mul_(radius_scale)
+
+
+class MDDecoupling(_MDDecouplingBase):
+    """MDDecoupling with learnable per-axis gains as a fused reparameterization
+    (p = normalized_w * phi(gains)).
+
+    Setting `hypersphere_gains_mode=None` makes this class behave identically to plain
+    `_MDDecouplingBase` — no gain tensors are created and the gain hooks in step() are no-ops.
+    This lets a single class cover both cases.
+
+    Gain optimizer state (1st/2nd moments) is tracked manually as plain tensors in
+    `self.state[p]`. This avoids registering gain `nn.Parameter`s in an inner `AdamW` that lives
+    outside `self.param_groups` — torch.optim's state_dict id-mapping doesn't survive that. Gain
+    tensors have a different shape than `p`, so use `--ckpt-format torch`.
+    """
+
+    def __init__(
+        self,
+        params,
+        hypersphere_gains_mode: Optional[Literal["row", "col", "rowcol", "flat", "embed"]] = None,
+        hypersphere_gains_mode_output: Optional[Literal["row", "col", "rowcol", "flat", "none"]] = None,
+        hypersphere_gains_mode_embedding: Optional[Literal["row", "col", "rowcol", "flat", "none"]] = None,
+        gains_lr: Optional[float] = None,
+        gains_betas: tuple[float, float] = (0.9, 0.999),
+        gains_eps: float = 1e-8,
+        gains_weight_decay: float = 0.0,
+        # Reparametrize the per-axis gain: the stored state tensor is `g`, the effective
+        # multiplier applied to `p` is `phi(g)`. "direct" reproduces the original behavior
+        # (phi(g)=g). Applied uniformly to row/col/flat.
+        gain_parametrization: Literal["direct", "softplus"] = "direct",
+        **kwargs,
+    ):
+        self.hypersphere_gains_mode = hypersphere_gains_mode
+        self.hypersphere_gains_mode_output = hypersphere_gains_mode_output
+        self.hypersphere_gains_mode_embedding = hypersphere_gains_mode_embedding
+        self.gains_lr = gains_lr  # None → follow group["lr"] verbatim
+        self.gains_betas = gains_betas
+        self.gains_eps = gains_eps
+        self.gains_weight_decay = gains_weight_decay
+        self.gain_parametrization = gain_parametrization
+        super().__init__(params, **kwargs)
+        # Gain state is initialized lazily at first step (see step() → _maybe_init_gain_state).
+        # Eager init here would write entries into self.state keyed by the bf16 model param, but
+        # the Float16 wrapper later clones bf16 → fp32 main_params and migrates self.state only
+        # for params still in param_groups on this rank. Deferring to step() keeps the keys
+        # consistent with the post-wrap main_params.
+
+    def _phi(self, g: torch.Tensor) -> torch.Tensor:
+        """Forward map from raw gain g to effective multiplier phi(g)."""
+        mode = self.gain_parametrization
+        if mode == "direct":
+            return g
+        if mode == "softplus":
+            return torch.nn.functional.softplus(g)
+        raise ValueError(f"Unknown gain_parametrization {mode}")
+
+    def _phi_prime(self, g: torch.Tensor):
+        """Derivative phi'(g). Returns scalar 1.0 for the linear mode so the caller can skip
+        a multiply."""
+        mode = self.gain_parametrization
+        if mode == "direct":
+            return 1.0
+        if mode == "softplus":
+            return torch.sigmoid(g)
+        raise ValueError(f"Unknown gain_parametrization {mode}")
+
+    def _phi_inv(self, x: torch.Tensor) -> torch.Tensor:
+        """Inverse map: given a target effective multiplier x>0, return g s.t. phi(g) = x. Used
+        at init to seed the raw gain so the first step's effective multiplier matches the desired
+        target (1.0 in the identity case, ||p[i]|| / cur_frob in the preserve_init absorb case)."""
+        mode = self.gain_parametrization
+        if mode == "direct":
+            return x
+        if mode == "softplus":
+            # Stable softplus_inv for x > 0: g = x + log1p(-exp(-x)).
+            # As x → ∞, g → x. As x → 0+, g → −∞.
+            return x + torch.log1p(-torch.exp(-x))
+        raise ValueError(f"Unknown gain_parametrization {mode}")
+
+    @torch.no_grad()
+    def _tp_reduced_norm(self, x, dim, partition_dim=None, is_expert_tp=False):
+        """L2 norm of `x` over `dim` (full Frobenius if dim is None), all-reduced across the TP
+        group when the reduced axis is the TP-sharded one — so the preserve_init gains absorb the
+        SAME global magnitude on TP=1 and TP>1. Mirrors the distributed-norm logic in
+        _normalize_single:
+            dim is None (flat) -> reduce iff the param is sharded (partition_dim in {0,1})
+            dim in {0, 1}      -> reduce iff partition_dim == dim (reduced axis is sharded)
+        """
+        norm = torch.norm(x) if dim is None else torch.norm(x, dim=dim)
+        should_reduce = self.pg_collection is not None and (
+            partition_dim in {0, 1} if dim is None else partition_dim == dim
+        )
+        if should_reduce:
+            tp_group = self.pg_collection.expt_tp if is_expert_tp else self.pg_collection.tp
+            norm_squared = norm**2
+            torch.distributed.all_reduce(norm_squared, group=tp_group)
+            norm = torch.sqrt(norm_squared)
+        return norm.to(torch.float32).clamp_min(self.hypersphere_eps)
+
+    def _maybe_init_gain_state(self, p):
+        if self.hypersphere_gains_mode is None or p.ndim < 2:
+            return
+        mode = self._resolve_gains_mode(p)
+        if mode is None or mode == "none":
+            return
+        state = self.state[p]
+        if any(k in state for k in ("row_gain", "col_gain", "flat_gain")):
+            return
+        is_out_proj = getattr(p, "is_out_proj", False)
+        preserve = self.hypersphere_preserve_init
+        # TP sharding info: the absorbed norm must be reduced across the TP group when it reduces
+        # over the sharded dimension, else TP=1 and TP>1 absorb different magnitudes.
+        partition_dim = getattr(p, "partition_dim", None)
+        is_expert_tp = getattr(p, "expert_tp", False)
+
+        wants_row = ("row" in mode) or (mode == "embed" and not is_out_proj)
+        wants_col = ("col" in mode) or (mode == "embed" and is_out_proj)
+        wants_flat = mode == "flat"
+
+        # For preserve_init, absorb the original magnitude into exactly one axis (row wins when
+        # both are configured — the rowcol canonical decomposition leaves col_gain at 1). Other
+        # gain axes start at 1. We do NOT touch p.data: the decomposition is implicit at init — p
+        # still holds the original weight, and the next step's _preprocess_gains will divide by
+        # gain_init to recover bare_p before updating.
+        absorb_axis = None
+        if preserve:
+            if wants_row:
+                absorb_axis = "row"
+            elif wants_col:
+                absorb_axis = "col"
+            elif wants_flat:
+                absorb_axis = "flat"
+
+        # The stored tensor is the raw gain `g`; the effective multiplier is phi(g). For the
+        # identity branch we want phi(g)=1 → seed phi_inv(1). For the preserve_init absorb branch
+        # we want phi(g)=||p[i]|| (or cur_frob/target_frob) → seed phi_inv of that.
+        if wants_row:
+            if absorb_axis == "row":
+                # norm over dim=1 (the in dim) → reduced iff row-parallel (partition_dim==1)
+                target = self._tp_reduced_norm(p.detach(), dim=1,
+                                               partition_dim=partition_dim,
+                                               is_expert_tp=is_expert_tp)
+            else:
+                target = torch.ones(p.size(0), dtype=torch.float32, device=p.device)
+            state["row_gain"] = self._phi_inv(target)
+            state["row_gain_m"] = torch.zeros_like(state["row_gain"])
+            state["row_gain_v"] = torch.zeros_like(state["row_gain"])
+
+        if wants_col:
+            if absorb_axis == "col":
+                # norm over dim=0 (the out dim) → reduced iff col-parallel (partition_dim==0)
+                target = self._tp_reduced_norm(p.detach(), dim=0,
+                                               partition_dim=partition_dim,
+                                               is_expert_tp=is_expert_tp)
+            else:
+                target = torch.ones(p.size(1), dtype=torch.float32, device=p.device)
+            state["col_gain"] = self._phi_inv(target)
+            state["col_gain_m"] = torch.zeros_like(state["col_gain"])
+            state["col_gain_v"] = torch.zeros_like(state["col_gain"])
+
+        if wants_flat:
+            if absorb_axis == "flat":
+                # full Frobenius norm → reduced iff the param is sharded at all. target_frob uses
+                # GLOBAL sizes so TP=1 and TP>1 match.
+                gsizes = [p.size(-2), p.size(-1)]
+                if self.pg_collection is not None and partition_dim in {0, 1}:
+                    tp_group = self.pg_collection.expt_tp if is_expert_tp else self.pg_collection.tp
+                    gsizes[partition_dim] *= get_pg_size(tp_group)
+                target_frob = max(gsizes) ** 0.5
+                cur_frob = self._tp_reduced_norm(p.detach(), dim=None,
+                                                 partition_dim=partition_dim,
+                                                 is_expert_tp=is_expert_tp)
+                target = (cur_frob / target_frob).reshape(())
+            else:
+                target = torch.ones((), dtype=torch.float32, device=p.device)
+            state["flat_gain"] = self._phi_inv(target)
+            state["flat_gain_m"] = torch.zeros_like(state["flat_gain"])
+            state["flat_gain_v"] = torch.zeros_like(state["flat_gain"])
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        if self.hypersphere_gains_mode is None:
+            return super().step(closure)
+
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            group["step"] += 1
+            if "momentum_beta" not in group:
+                group["momentum_beta"] = group["beta1"]
+            for p in group["params"]:
+                if p.grad is not None:
+                    self._maybe_init_gain_state(p)
+                    gain_grads = self._preprocess_gains(p)
+                    self._param_step(p, group)
+                    self._gains_step(p, group, gain_grads)
+                    self._apply_gains(p)
+
+        return loss
+
+    @torch.no_grad()
+    def _preprocess_gains(self, p):
+        state = self.state[p]
+        eps = 1e-8
+        flat = state.get("flat_gain")
+        row = state.get("row_gain")
+        col = state.get("col_gain")
+        if flat is None and row is None and col is None:
+            return None
+
+        # Effective per-axis multipliers phi(g). For "direct" these are identical to the stored
+        # raw gains (no-op overhead).
+        flat_eff = self._phi(flat) if flat is not None else None
+        row_eff = self._phi(row) if row is not None else None
+        col_eff = self._phi(col) if col is not None else None
+
+        # Undo gains to recover bare normalized weight.
+        if flat_eff is not None:
+            p.div_(flat_eff.clamp_min(eps))
+        if row_eff is not None:
+            p.div_(row_eff[:, None].clamp_min(eps))
+        if col_eff is not None:
+            p.div_(col_eff[None, :].clamp_min(eps))
+
+        # Compute ∂L/∂phi(g) from bare p and the gain-baked grad still on p.grad.
+        p_times_pgrad = p * p.grad
+        gain_grads = {}
+        if flat is not None:
+            assert row is None and col is None
+            gain_grads["flat_gain"] = torch.sum(p_times_pgrad)
+        elif row is not None and col is not None:
+            gain_grads["row_gain"] = torch.sum(p_times_pgrad * col_eff[None, :], dim=1)
+            gain_grads["col_gain"] = torch.sum(p_times_pgrad * row_eff[:, None], dim=0)
+        elif row is not None:
+            gain_grads["row_gain"] = torch.sum(p_times_pgrad, dim=1)
+        else:
+            gain_grads["col_gain"] = torch.sum(p_times_pgrad, dim=0)
+
+        # Sync gains with TP group.
+        if self.pg_collection is not None:
+            # partition_dim=0 -> column parallel sharding.
+            # partition_dim=1 -> row parallel sharding.
+            partition_dim = getattr(p, "partition_dim", None)
+            if partition_dim in {0, 1}:  # Otherwise, p is not sharded so we don't need to sync it.
+                tp_group = self.pg_collection.expt_tp if getattr(p, "expert_tp", False) else self.pg_collection.tp
+                if flat is not None:  # Flat gains always need to all-reduce to complete the decomposition.
+                    torch.distributed.all_reduce(gain_grads["flat_gain"], group=tp_group)
+                if row is not None and partition_dim == 1:  # row gains sync only when row-sharded.
+                    torch.distributed.all_reduce(gain_grads["row_gain"], group=tp_group)
+                if col is not None and partition_dim == 0:  # col gains sync only when col-sharded.
+                    torch.distributed.all_reduce(gain_grads["col_gain"], group=tp_group)
+
+        # Chain rule: ∂L/∂g = phi'(g) · ∂L/∂phi(g). For "direct" phi'≡1 and _phi_prime returns
+        # the scalar 1.0; skip the multiply.
+        if self.gain_parametrization != "direct":
+            for name in gain_grads:
+                gain_grads[name] = gain_grads[name] * self._phi_prime(state[name])
+
+        # Rescale p.grad so the base step sees ∂L/∂(bare p).
+        if flat_eff is not None:
+            p.grad.mul_(flat_eff)
+        if row_eff is not None:
+            p.grad.mul_(row_eff[:, None])
+        if col_eff is not None:
+            p.grad.mul_(col_eff[None, :])
+
+        return gain_grads
+
+    @torch.no_grad()
+    def _gains_step(self, p, group, gain_grads):
+        if not gain_grads:
+            return
+        state = self.state[p]
+        step = group["step"]
+        beta1, beta2 = self.gains_betas
+        eps = self.gains_eps
+        wd = self.gains_weight_decay
+
+        # Gains follow the param-group LR. If gains_lr is unset, use group["lr"] verbatim (so the
+        # param scheduler drives gains too). Otherwise treat gains_lr as a base LR and apply the
+        # param schedule shape on top.
+        if self.gains_lr is None:
+            lr = group["lr"]
+        else:
+            max_lr = group.get("max_lr", group["lr"])
+            schedule_mult = (group["lr"] / max_lr) if max_lr > 0 else 1.0
+            lr = self.gains_lr * schedule_mult
+
+        bias_correction1 = 1.0 - beta1 ** step
+        bias_correction2 = 1.0 - beta2 ** step
+
+        for name, grad in gain_grads.items():
+            gain = state[name]
+            m = state[f"{name}_m"]
+            v = state[f"{name}_v"]
+            if wd != 0.0:
+                gain.mul_(1.0 - lr * wd)
+            m.mul_(beta1).add_(grad, alpha=1 - beta1)
+            v.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
+            denom = (v.sqrt() / math.sqrt(bias_correction2)).add_(eps)
+            gain.addcdiv_(m, denom, value=-lr / bias_correction1)
+
+    @torch.no_grad()
+    def _apply_gains(self, p):
+        state = self.state[p]
+        flat = state.get("flat_gain")
+        row = state.get("row_gain")
+        col = state.get("col_gain")
+        if flat is not None:
+            p.mul_(self._phi(flat))
+        if row is not None:
+            p.mul_(self._phi(row)[:, None])
+        if col is not None:
+            p.mul_(self._phi(col)[None, :])
+
+    def _resolve_gains_mode(self, p):
+        is_output = getattr(p, "is_output_parameter", False)
+        is_embedding = getattr(p, "is_embedding_parameter", False)
+        if is_output and self.hypersphere_gains_mode_output is not None:
+            return self.hypersphere_gains_mode_output
+        if is_embedding and self.hypersphere_gains_mode_embedding is not None:
+            return self.hypersphere_gains_mode_embedding
+        return self.hypersphere_gains_mode
+
+
+def _split_qkv(x, shapes: tuple[int, int, int]) -> list[torch.Tensor]:
+    """Split grouped attention (Q, K, V / GQA) along the head-group dim."""
+    shape = x.shape
+    num_query_groups = shape[0] // sum(shapes)
+    qkv = torch.split(
+        x.view(num_query_groups, sum(shapes), -1),
+        shapes,
+        dim=1,
+    )
+    return [g.reshape(-1, shape[-1]) for g in qkv]
+
+
+def _merge_qkv(qkv, xshape: tuple[int, int], shapes: tuple[int, int, int]) -> torch.Tensor:
+    num_query_groups = xshape[0] // sum(shapes)
+    qkv = [g.view(num_query_groups, -1, xshape[-1]) for g in qkv]
+    return torch.cat(qkv, dim=1).view(xshape)
+
+
+# ===========================================================================
+# Optimizer builder
+# ===========================================================================
+
+
+def _group_min_lr(config: OptimizerConfig, max_lr: float) -> float:
+    """Per-group min_lr policy for any param group with a custom max_lr.
+
+    The LR scheduler decays every group from its own max_lr to its own min_lr along the same
+    schedule shape. To keep the decay curve well-formed, a group's min_lr must be derived from its
+    max_lr — not left at the global config.min_lr, which would invert the schedule when
+    max_lr < config.min_lr. Controlled by config.min_lr_mode:
+
+    'relative' (default): proportional decay — min_lr = max_lr * (config.min_lr / config.lr).
+    'absolute': shared floor — min_lr = config.min_lr (clamped to <= max_lr).
+    """
+    floor = config.min_lr if config.min_lr is not None else 0.0
+    if config.min_lr_mode == 'absolute':
+        return min(floor, max_lr)
+    ratio = (floor / config.lr) if (config.lr and config.lr > 0) else 0.0
+    return max_lr * ratio
+
+
+def _mddecoupling_config_overrides(
+    config: OptimizerConfig, base_overrides: Dict[ParamKey, ParamGroupOverride]
+) -> Dict[ParamKey, ParamGroupOverride]:
+    """Build the config_overrides for MDDecoupling: matrix / embedding / output / router LR
+    groups and per-group use_orthogonal_updates routing. Ported from the source 'master' block.
+
+    Starts from ``base_overrides`` (the standard wd-skip + decoupled-LR overrides) and adds the
+    MDDecoupling-specific entries on top. Returned dict is passed to BOTH the MDDecoupling param
+    groups and the chained Adam ``get_megatron_optimizer`` call, so each override applies wherever
+    its matching params materialize.
+    """
+    overrides: Dict[ParamKey, ParamGroupOverride] = dict(base_overrides) if base_overrides else {}
+    matrix_lr = (config.matrix_lr if config.matrix_lr is not None
+                 else config.muon_lr_factor * (config.lr or 0.0))
+
+    # Embedding/output: when a hypersphere mode for embeddings is requested they stay in
+    # MDDecoupling on the Adam branch (use_orthogonal_updates=False) + post-step normalization.
+    # When it is None they are routed to the external chained Adam (see the param partition in
+    # get_megatron_mddecoupling_optimizer), so no MDDecoupling override is needed here.
+    if config.hypersphere_embedding_mode is not None:
+        overrides[ParamKey(attr='is_embedding_or_output_parameter')] = {
+            'use_orthogonal_updates': False
+        }
+
+    # MoE router branch override. Effective branch: explicit override > global flag.
+    router_uses_adam = (
+        config.md_router_use_orthogonal_updates is False
+        or (config.md_router_use_orthogonal_updates is None
+            and not config.use_orthogonal_updates)
+    )
+    router_override: ParamGroupOverride = {}
+    if config.md_router_use_orthogonal_updates is not None:
+        router_override['use_orthogonal_updates'] = config.md_router_use_orthogonal_updates
+    if router_uses_adam:
+        # Adam routers use base lr (matrix_lr is Muon-tuned; doesn't fit Adam).
+        router_override['max_lr'] = config.lr
+        router_override['min_lr'] = _group_min_lr(config, config.lr)
+    if router_override:
+        overrides[ParamKey(attr='is_router')] = router_override
+
+    # Matrix LR for non-embedding/non-output 2D weights. Adam-branch routers are excluded — they
+    # get base lr from the router_override above.
+    non_emb_2d = ParamPredicate(
+        name="md_non_embedding_or_output_2d",
+        fn=lambda p: (not getattr(p, "is_embedding_or_output_parameter", False)
+                      and len(p.shape) == 2
+                      and not (router_uses_adam and getattr(p, "is_router", False))),
+    )
+    overrides[ParamKey(predicate=non_emb_2d)] = {
+        'max_lr': matrix_lr,
+        'min_lr': _group_min_lr(config, matrix_lr),
+    }
+
+    # Embedding LR (embedding + tied LM head share is_embedding_parameter).
+    if config.embedding_lr_multiplier is not None:
+        emb_lr = config.embedding_lr_multiplier * config.lr
+        overrides[ParamKey(attr='is_embedding_parameter')] = {
+            'max_lr': emb_lr,
+            'min_lr': _group_min_lr(config, emb_lr),
+        }
+
+    # Output (untied LM head) LR: absolute, independent of embedding/scalar knobs.
+    if config.output_lr is not None:
+        output_only = ParamPredicate(
+            name="md_output_not_embedding",
+            fn=lambda p: (getattr(p, "is_output_parameter", False)
+                          and not getattr(p, "is_embedding_parameter", False)),
+        )
+        overrides[ParamKey(predicate=output_only)] = {
+            'max_lr': config.output_lr,
+            'min_lr': _group_min_lr(config, config.output_lr),
+        }
+
+    return overrides
+
+
+def _md_init_state_fn(opt, config=None):
+    """Initialize MDDecoupling state for torch_dist checkpoint compatibility (gain state is still
+    created lazily at first step; recommend --ckpt-format torch when gains are enabled)."""
+    for group in opt.param_groups:
+        for p in group['params']:
+            if "exp_avg" not in opt.state[p]:
+                opt.state[p]["exp_avg"] = torch.zeros_like(p.data)
+                if not group.get("use_orthogonal_updates", False) and group.get("beta2", 0) != 0:
+                    opt.state[p]["exp_avg_sq"] = torch.zeros_like(p.data)
+
+
+def _adam_init_state_fn(opt, config=None):
+    for group in opt.param_groups:
+        for p in group['params']:
+            if len(opt.state[p]) == 0:
+                if config is None or not config.use_precision_aware_optimizer:
+                    opt.state[p]['exp_avg'] = torch.zeros_like(p.data)
+                    opt.state[p]['exp_avg_sq'] = torch.zeros_like(p.data)
+                else:
+                    opt.initialize_state(p)
+
+
+def get_megatron_mddecoupling_optimizer(
+    config: OptimizerConfig,
+    model_chunks: List[MegatronModule],
+    config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]] = None,
+    use_gloo_process_groups: bool = True,
+    layer_wise_distributed_optimizer: bool = False,
+    pg_collection: Optional[ProcessGroupCollection] = None,
+) -> MegatronOptimizer:
+    """Build the MDDecoupling optimizer for the given model chunks.
+
+    Mirrors :func:`megatron.core.optimizer.muon.get_megatron_muon_optimizer`: 2D matrix params
+    (plus routers, and embedding/output params when a hypersphere embedding mode is set) are
+    optimized by :class:`MDDecoupling`; everything else (1D biases/norms, and embedding/output
+    params when no embedding hypersphere mode is set) is delegated to a chained external AdamW via
+    :func:`get_megatron_optimizer`. When ``layer_wise_distributed_optimizer`` is True the whole
+    chain is wrapped in :class:`LayerWiseDistributedOptimizer` to shard optimizer state over DP.
+    """
+    assert HAVE_EMERGING_OPTIMIZERS or not config.use_orthogonal_updates, (
+        "emerging-optimizers is required for --use-orthogonal-updates under --optimizer md_decoupling."
+    )
+    # The standard distributed optimizer flattens each param shard to 1-D, which breaks the 2-D
+    # hypersphere/Muon math. Shard optimizer state via the layer-wise optimizer instead.
+    if config.use_distributed_optimizer:
+        raise Exception(
+            'md_decoupling with the standard distributed optimizer is not supported; '
+            'use --use-layer-wise-distributed-optimizer to shard optimizer state.'
+        )
+    if config.fp16:
+        raise Exception('md_decoupling with fp16 is not supported (use bf16 or fp32).')
+
+    if pg_collection is None:
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    log_single_rank(logger, logging.INFO, f'Setting up MDDecoupling optimizer with config {config}')
+
+    base_overrides = (
+        config_overrides if config_overrides is not None else get_standard_config_overrides(config)
+    )
+
+    # Tag parameters with optimizer-specific attributes and compute qkv split shapes.
+    qkv_split_shapes: Optional[List[int]] = None
+    for model_chunk in model_chunks:
+        cfg = model_chunk.config
+        qkv_split_shapes = [
+            cfg.num_attention_heads // cfg.num_query_groups * cfg.kv_channels,
+            cfg.kv_channels,
+            cfg.kv_channels,
+        ]
+        for name, param in model_chunk.named_parameters():
+            if not param.requires_grad:
+                continue
+            if 'experts' in name and 'shared' not in name:
+                param.expert_tp = True
+            # TODO(deyuf): support MLA
+            if 'linear_qkv.weight' in name and len(param.shape) == 2:
+                param.is_qkv = True
+            if name.endswith('router.weight') and len(param.shape) == 2:
+                param.is_router = True
+            if ('linear_fc2' in name or 'linear_proj' in name) and len(param.shape) == 2:
+                param.is_out_proj = True
+
+    # Partition params: MDDecoupling-managed ("linear") vs external chained Adam ("nonlinear").
+    emb_in_md = config.hypersphere_embedding_mode is not None
+    linear_params = []
+    nonlinear_params = []
+    for model_chunk in model_chunks:
+        for name, param in model_chunk.named_parameters():
+            if not param.requires_grad:
+                continue
+            is_emb = getattr(param, 'is_embedding_or_output_parameter', False)
+            if len(param.shape) == 2 and (not is_emb or emb_in_md):
+                linear_params.append(param)
+            else:
+                nonlinear_params.append(param)
+
+    md_overrides = _mddecoupling_config_overrides(config, base_overrides)
+
+    md_kwargs = dict(
+        lr=(config.matrix_lr if config.matrix_lr is not None
+            else config.muon_lr_factor * (config.lr or 0.0)),
+        weight_decay=config.weight_decay,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_eps,
+        hypersphere_mode=config.hypersphere_mode,
+        hypersphere_embedding_mode=config.hypersphere_embedding_mode,
+        hypersphere_router_mode=config.hypersphere_router_mode,
+        hypersphere_tangential_grad=config.hypersphere_tangential_grad,
+        hypersphere_preserve_init=config.hypersphere_preserve_init,
+        hypersphere_scale_out_proj_init=config.hypersphere_scale_out_proj_init,
+        num_layers=model_chunks[0].config.num_layers,
+        use_orthogonal_updates=config.use_orthogonal_updates,
+        momentum_beta=config.muon_momentum,
+        use_nesterov=config.muon_use_nesterov,
+        split_qkv=config.muon_split_qkv,
+        is_qkv_fn=lambda p: getattr(p, "is_qkv", False),
+        qkv_split_shapes=qkv_split_shapes,
+        qkv_dim=model_chunks[0].config.kv_channels,
+        fp32_matmul_prec=config.muon_fp32_matmul_prec,
+        coefficient_type=config.muon_coefficient_type,
+        num_ns_steps=config.muon_num_ns_steps,
+        scale_mode=config.muon_scale_mode,
+        extra_scale_factor=config.muon_extra_scale_factor,
+        pg_collection=pg_collection,
+        tp_mode=config.muon_tp_mode,
+        hypersphere_gains_mode=config.hypersphere_gains_mode,
+        hypersphere_gains_mode_output=config.hypersphere_gains_mode_output,
+        hypersphere_gains_mode_embedding=config.hypersphere_gains_mode_embedding,
+        gains_lr=config.gains_lr if config.gains_lr is not None else config.lr,
+        gains_betas=(config.adam_beta1, config.adam_beta2),
+        gains_eps=config.adam_eps,
+        gains_weight_decay=config.weight_decay,
+        gain_parametrization=config.gain_parametrization,
+    )
+
+    optimizers = []
+
+    # Freeze nonlinear params so only MDDecoupling-managed params materialize in these groups.
+    for param in nonlinear_params:
+        param.requires_grad = False
+
+    md_param_groups = _get_param_groups(model_chunks, config, md_overrides)
+    # When NOT layer-wise, expert-parallel params need a separate optimizer instance (their grad
+    # stats reduce over the expert TP-PP group). The layer-wise optimizer handles experts itself.
+    expert_param_groups = []
+    if not layer_wise_distributed_optimizer:
+        expert_param_groups = [g for g in md_param_groups if g['is_expert_parallel']]
+        md_param_groups = [g for g in md_param_groups if not g['is_expert_parallel']]
+
+    optimizer = MDDecoupling(md_param_groups, **md_kwargs)
+
+    reset_config_bf16 = False
+    if config.bf16:
+        if layer_wise_distributed_optimizer:
+            # Creating master weights before layer-wise sharding wastes memory, so defer master
+            # weight creation into the layer-wise wrapper. Unsetting config.bf16 also keeps the
+            # adam optimizers below unwrapped so the wrapper can manage them uniformly.
+            config.bf16 = False
+            reset_config_bf16 = True
+        else:
+            optimizer = Float16OptimizerWithFloat16Params(optimizer, config, None, _md_init_state_fn)
+    else:
+        optimizer = FP32Optimizer(optimizer, config, _md_init_state_fn)
+    optimizers.append(optimizer)
+
+    if len(expert_param_groups) > 0:
+        expert_optimizer = MDDecoupling(expert_param_groups, **md_kwargs)
+        if config.bf16:
+            expert_optimizer = Float16OptimizerWithFloat16Params(
+                expert_optimizer, config, None, _md_init_state_fn
+            )
+        else:
+            expert_optimizer = FP32Optimizer(expert_optimizer, config, _md_init_state_fn)
+        setattr(expert_optimizer, 'grad_stats_parallel_group', pg_collection.tp_ep_pp)
+        optimizers.append(expert_optimizer)
+
+    # Done with MDDecoupling: unfreeze nonlinear, freeze linear, build the chained Adam for the
+    # rest. Linear params are skipped by get_megatron_optimizer because they're frozen.
+    for param in nonlinear_params:
+        param.requires_grad = True
+    for param in linear_params:
+        param.requires_grad = False
+
+    prev_optimizer = config.optimizer
+    config.optimizer = 'adam'
+    chained_adam = get_megatron_optimizer(
+        config,
+        model_chunks,
+        config_overrides=md_overrides,
+        use_gloo_process_groups=use_gloo_process_groups,
+    )
+    config.optimizer = prev_optimizer
+
+    # Unfreeze everything.
+    for param in linear_params:
+        param.requires_grad = True
+
+    init_fns = [_md_init_state_fn] + len(chained_adam.chained_optimizers) * [_adam_init_state_fn]
+    optimizers += chained_adam.chained_optimizers
+
+    if layer_wise_distributed_optimizer:
+        log_single_rank(logger, logging.INFO, 'Using LayerWiseDistributedOptimizer for MDDecoupling')
+        if reset_config_bf16:
+            config.bf16 = True
+        return LayerWiseDistributedOptimizer(
+            optimizers,
+            config,
+            pg_collection,
+            init_state_fn_list=init_fns,
+            model_chunks=model_chunks,
+            async_allgather=config.overlap_param_gather,
+        )
+    return ChainedOptimizer(optimizers)

--- a/megatron/core/optimizer/md_decoupling.py
+++ b/megatron/core/optimizer/md_decoupling.py
@@ -735,16 +735,27 @@ class MDDecoupling(_MDDecouplingBase):
         bias_correction1 = 1.0 - beta1 ** step
         bias_correction2 = 1.0 - beta2 ** step
 
+        # Persistent 0-dim fp32 scalar buffers (gain state is fp32), updated in
+        # place each step. Reusing the same tensors keeps the compiled kernel's
+        # guards stable across steps; updating via fill_ avoids per-step H2D copies.
+        dev = p.device
+        if getattr(self, "_gain_lr_buf", None) is None or self._gain_lr_buf.device != dev:
+            self._gain_lr_buf = torch.zeros((), dtype=torch.float32, device=dev)
+            self._gain_bc1_buf = torch.zeros((), dtype=torch.float32, device=dev)
+            self._gain_bc2_buf = torch.zeros((), dtype=torch.float32, device=dev)
+        self._gain_lr_buf.fill_(lr)
+        self._gain_bc1_buf.fill_(bias_correction1)
+        self._gain_bc2_buf.fill_(bias_correction2)
+
         for name, grad in gain_grads.items():
             gain = state[name]
             m = state[f"{name}_m"]
             v = state[f"{name}_v"]
-            if wd != 0.0:
-                gain.mul_(1.0 - lr * wd)
-            m.mul_(beta1).add_(grad, alpha=1 - beta1)
-            v.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
-            denom = (v.sqrt() / math.sqrt(bias_correction2)).add_(eps)
-            gain.addcdiv_(m, denom, value=-lr / bias_correction1)
+            _fused_gain_adam(
+                gain, m, v, grad,
+                self._gain_lr_buf, self._gain_bc1_buf, self._gain_bc2_buf,
+                beta1, beta2, eps, wd,
+            )
 
     @torch.no_grad()
     def _apply_gains(self, p):
@@ -767,6 +778,27 @@ class MDDecoupling(_MDDecouplingBase):
         if is_embedding and self.hypersphere_gains_mode_embedding is not None:
             return self.hypersphere_gains_mode_embedding
         return self.hypersphere_gains_mode
+
+
+@torch.compile(dynamic=True)
+def _fused_gain_adam(gain, m, v, grad, lr, bc1, bc2, beta1, beta2, eps, wd):
+    """Fused in-place Adam update for one gain tensor (compiled leaf kernel).
+
+    lr / bc1 / bc2 are 0-dim tensors (they change every step, so passing them as
+    tensors instead of Python floats avoids per-step recompilation); beta1, beta2,
+    eps and wd are run constants. `dynamic=True` shares one graph across the
+    differently shaped gain tensors. Equivalent to the eager update:
+        if wd: gain *= 1 - lr*wd
+        m  = beta1*m + (1-beta1)*grad
+        v  = beta2*v + (1-beta2)*grad^2
+        gain -= (lr/bc1) * m / (v.sqrt()/bc2.sqrt() + eps)
+    """
+    if wd != 0.0:
+        gain.mul_(1.0 - lr * wd)
+    m.mul_(beta1).add_(grad, alpha=1.0 - beta1)
+    v.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
+    denom = (v.sqrt() / bc2.sqrt()).add_(eps)
+    gain.sub_((lr / bc1) * (m / denom))
 
 
 def _split_qkv(x, shapes: tuple[int, int, int]) -> list[torch.Tensor]:

--- a/megatron/core/optimizer/md_decoupling.py
+++ b/megatron/core/optimizer/md_decoupling.py
@@ -452,6 +452,7 @@ class MDDecoupling(_MDDecouplingBase):
         hypersphere_gains_mode_output: Optional[Literal["row", "col", "rowcol", "flat", "none"]] = None,
         hypersphere_gains_mode_embedding: Optional[Literal["row", "col", "rowcol", "flat", "none"]] = None,
         gains_lr: Optional[float] = None,
+        gains_min_lr: Optional[float] = None,
         gains_betas: tuple[float, float] = (0.9, 0.999),
         gains_eps: float = 1e-8,
         gains_weight_decay: float = 0.0,
@@ -465,6 +466,7 @@ class MDDecoupling(_MDDecouplingBase):
         self.hypersphere_gains_mode_output = hypersphere_gains_mode_output
         self.hypersphere_gains_mode_embedding = hypersphere_gains_mode_embedding
         self.gains_lr = gains_lr  # None → follow group["lr"] verbatim
+        self.gains_min_lr = gains_min_lr  # gains LR floor (matches the group's min_lr policy)
         self.gains_betas = gains_betas
         self.gains_eps = gains_eps
         self.gains_weight_decay = gains_weight_decay
@@ -711,14 +713,24 @@ class MDDecoupling(_MDDecouplingBase):
         wd = self.gains_weight_decay
 
         # Gains follow the param-group LR. If gains_lr is unset, use group["lr"] verbatim (so the
-        # param scheduler drives gains too). Otherwise treat gains_lr as a base LR and apply the
-        # param schedule shape on top.
+        # param scheduler drives gains too — already floored at the group's min_lr). Otherwise
+        # schedule gains on their OWN [gains_min_lr, gains_lr] band using the scheduler's shared
+        # decay coefficient, recovered from the group's lr:
+        #     group["lr"] = min_lr + coeff * (max_lr - min_lr)   (OptimizerParamScheduler)
+        #  => coeff = (group["lr"] - min_lr) / (max_lr - min_lr)
+        # so gains decay gains_lr -> gains_min_lr exactly like a real param group (and honour
+        # --min-lr-mode absolute, i.e. a fixed gains_min_lr floor — NOT the gains_lr * lr/max_lr
+        # rescaling, which would floor at gains_lr * min_lr/max_lr and ignore min_lr).
         if self.gains_lr is None:
             lr = group["lr"]
         else:
-            max_lr = group.get("max_lr", group["lr"])
-            schedule_mult = (group["lr"] / max_lr) if max_lr > 0 else 1.0
-            lr = self.gains_lr * schedule_mult
+            gmax = group.get("max_lr", group["lr"])
+            gmin = group.get("min_lr", 0.0)
+            denom = gmax - gmin
+            coeff = ((group["lr"] - gmin) / denom) if denom > 0 else 1.0
+            coeff = min(1.0, max(0.0, coeff))
+            gains_floor = self.gains_min_lr if self.gains_min_lr is not None else 0.0
+            lr = gains_floor + coeff * (self.gains_lr - gains_floor)
 
         bias_correction1 = 1.0 - beta1 ** step
         bias_correction2 = 1.0 - beta2 ** step
@@ -1004,6 +1016,11 @@ def get_megatron_mddecoupling_optimizer(
         hypersphere_gains_mode_output=config.hypersphere_gains_mode_output,
         hypersphere_gains_mode_embedding=config.hypersphere_gains_mode_embedding,
         gains_lr=config.gains_lr if config.gains_lr is not None else config.lr,
+        # Gains decay on their own band down to this floor, honouring --min-lr-mode
+        # (absolute → gains_min_lr = min(config.min_lr, gains_base) = config.min_lr).
+        gains_min_lr=_group_min_lr(
+            config, config.gains_lr if config.gains_lr is not None else config.lr
+        ),
         gains_betas=(config.adam_beta1, config.adam_beta2),
         gains_eps=config.adam_eps,
         gains_weight_decay=config.weight_decay,

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -96,6 +96,26 @@ def _multi_tensor_copy_this_to_that(
 
 param_group_identifier_keys = ('wd_mult', 'lr_mult', 'is_expert_parallel', 'is_decoupled_lr')
 
+# Parameter routing attributes that param-group-aware optimizers (e.g. MDDecoupling) read off the
+# params they step on, but which are NOT covered by copy_tensor_model_parallel_attributes (that
+# only handles expert_tp / is_qkv / tensor_model_parallel / partition_dim / partition_stride).
+# These must be explicitly propagated from the model param onto the fp32 main/shard param,
+# otherwise the optimizer silently sees them as False on the main params it actually optimizes.
+_MAIN_PARAM_ROUTING_ATTRS = (
+    'is_out_proj',
+    'is_router',
+    'is_embedding_or_output_parameter',
+    'is_embedding_parameter',
+    'is_output_parameter',
+)
+
+
+def _propagate_routing_attrs(main_param, model_param):
+    """Copy MDDecoupling routing attributes from a model param onto its fp32 main/shard copy."""
+    for _attr in _MAIN_PARAM_ROUTING_ATTRS:
+        if hasattr(model_param, _attr):
+            setattr(main_param, _attr, getattr(model_param, _attr))
+
 
 class MegatronOptimizer(ABC):
     """
@@ -680,6 +700,9 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                             tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
                             if hasattr(param, 'shared'):
                                 main_param.shared = param.shared
+                            # Propagate MDDecoupling routing attrs (is_router / is_out_proj /
+                            # is_embedding_or_output_parameter / ...) not covered above.
+                            _propagate_routing_attrs(main_param, param)
                             # Replace the optimizer params with the new fp32 copy.
                             param_group['params'][i] = main_param
 

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -302,6 +302,86 @@ class OptimizerConfig:
     """Second beta coefficient for Lion optimizer (used in momentum EMA update).
     Defaults to 0.98."""
 
+    ###################################################################################
+    # MDDecoupling (magnitude-direction decoupling: hypersphere normalization + learnable
+    # per-axis gains + optional Muon orthogonalized updates). Reuses the muon_* / adam_* /
+    # weight_decay fields above for shared knobs. All defaults are off; existing runs unaffected.
+    ###################################################################################
+    matrix_lr: Optional[float] = None
+    """Absolute LR for matrix (2D non-embedding/output) params under --optimizer md_decoupling.
+    Overrides muon_lr_factor * lr."""
+
+    embedding_lr_multiplier: Optional[float] = None
+    """LR multiplier for embedding (and tied LM-head) params under md_decoupling. Final
+    max_lr = embedding_lr_multiplier * lr. When unset, those params use the base --lr."""
+
+    output_lr: Optional[float] = None
+    """Absolute LR for the (untied) output LM-head params under md_decoupling. When unset, the
+    output layer uses the base --lr."""
+
+    min_lr_mode: str = 'relative'
+    """How per-group min_lr is set for any group with a custom max_lr. 'relative' (default):
+    every group decays by the same fraction (config.min_lr / config.lr). 'absolute': every group
+    decays to the same floor (config.min_lr)."""
+
+    muon_lr_factor: float = 1.0
+    """When --matrix-lr is unset, matrix-param LR for md_decoupling is muon_lr_factor * lr."""
+
+    hypersphere_mode: Optional[str] = None
+    """Hypersphere normalization mode for non-embedding/output 2D matrices. One of
+    'row'/'col'/'flat'/'embed'. Applied post-step to project the weight onto the L2 sphere.
+    None = off."""
+
+    hypersphere_embedding_mode: Optional[str] = None
+    """Hypersphere mode override for embedding + LM head. When set, those params stay in
+    MDDecoupling (Adam branch) and get post-step normalization. When None, they route to the
+    chained external Adam with no hypersphere. One of 'row'/'col'/'flat'/'embed'/'none'."""
+
+    hypersphere_router_mode: Optional[str] = None
+    """Hypersphere mode override for MoE router weights. One of 'row'/'col'/'flat'/'embed'/'none'.
+    None disables router-specific normalization."""
+
+    hypersphere_tangential_grad: bool = False
+    """Project p.grad onto the hypersphere tangent space before the update."""
+
+    hypersphere_preserve_init: bool = False
+    """Skip init-time hypersphere projection so the model init magnitude survives into training.
+    When gains are configured (single-axis), gains absorb the per-axis init magnitude."""
+
+    hypersphere_scale_out_proj_init: bool = False
+    """Scale the hypersphere target radius for is_out_proj params (linear_proj, linear_fc2) by
+    1/sqrt(2 * num_layers), matching scaled_init_method_normal."""
+
+    md_router_use_orthogonal_updates: Optional[bool] = None
+    """Per-param-group override for use_orthogonal_updates on MoE router weights. True forces
+    Muon for routers, False forces the Adam branch, None follows --use-orthogonal-updates."""
+
+    use_orthogonal_updates: bool = False
+    """Use Muon-style orthogonalized updates for matrix params under md_decoupling. Embedding +
+    LM head ALWAYS use the Adam branch regardless of this flag."""
+
+    hypersphere_gains_mode: Optional[str] = None
+    """Learnable per-axis gains for matrix params. One of 'row'/'col'/'rowcol'/'flat'/'embed'."""
+
+    hypersphere_gains_mode_output: Optional[str] = None
+    """Gains mode override for the LM head. One of 'row'/'col'/'rowcol'/'flat'/'none'."""
+
+    hypersphere_gains_mode_embedding: Optional[str] = None
+    """Gains mode override for the embedding. One of 'row'/'col'/'rowcol'/'flat'/'none'."""
+
+    gains_lr: Optional[float] = None
+    """Absolute LR for the per-axis gains AdamW. When unset, falls back to --lr (and still tracks
+    the schedule shape of the main LR)."""
+
+    gain_parametrization: str = 'direct'
+    """Reparametrize the stored gain g; effective multiplier is phi(g). 'direct' keeps phi(g)=g;
+    'softplus' uses phi(g)=softplus(g) (always positive). Applied uniformly to row/col/flat."""
+
+    use_layer_wise_distributed_optimizer: bool = False
+    """If true, wrap the optimizer with LayerWiseDistributedOptimizer to shard optimizer state
+    over the data-parallel group (used by md_decoupling instead of the standard distributed
+    optimizer, which is incompatible with 2D hypersphere/Muon math)."""
+
     #######################
     # Distributed optimizer
     #######################

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -327,17 +327,17 @@ class OptimizerConfig:
     muon_lr_factor: float = 1.0
     """When --matrix-lr is unset, matrix-param LR for md_decoupling is muon_lr_factor * lr."""
 
-    hypersphere_mode: Optional[str] = None
+    hypersphere_mode: Optional[str] = 'flat'
     """Hypersphere normalization mode for non-embedding/output 2D matrices. One of
     'row'/'col'/'flat'/'embed'. Applied post-step to project the weight onto the L2 sphere.
     None = off."""
 
-    hypersphere_embedding_mode: Optional[str] = None
+    hypersphere_embedding_mode: Optional[str] = 'row'
     """Hypersphere mode override for embedding + LM head. When set, those params stay in
     MDDecoupling (Adam branch) and get post-step normalization. When None, they route to the
     chained external Adam with no hypersphere. One of 'row'/'col'/'flat'/'embed'/'none'."""
 
-    hypersphere_router_mode: Optional[str] = None
+    hypersphere_router_mode: Optional[str] = 'row'
     """Hypersphere mode override for MoE router weights. One of 'row'/'col'/'flat'/'embed'/'none'.
     None disables router-specific normalization."""
 
@@ -348,19 +348,19 @@ class OptimizerConfig:
     """Skip init-time hypersphere projection so the model init magnitude survives into training.
     When gains are configured (single-axis), gains absorb the per-axis init magnitude."""
 
-    hypersphere_scale_out_proj_init: bool = False
+    hypersphere_scale_out_proj_init: bool = True
     """Scale the hypersphere target radius for is_out_proj params (linear_proj, linear_fc2) by
     1/sqrt(2 * num_layers), matching scaled_init_method_normal."""
 
-    md_router_use_orthogonal_updates: Optional[bool] = None
+    md_router_use_orthogonal_updates: Optional[bool] = True
     """Per-param-group override for use_orthogonal_updates on MoE router weights. True forces
     Muon for routers, False forces the Adam branch, None follows --use-orthogonal-updates."""
 
-    use_orthogonal_updates: bool = False
+    use_orthogonal_updates: bool = True
     """Use Muon-style orthogonalized updates for matrix params under md_decoupling. Embedding +
     LM head ALWAYS use the Adam branch regardless of this flag."""
 
-    hypersphere_gains_mode: Optional[str] = None
+    hypersphere_gains_mode: Optional[str] = 'rowcol'
     """Learnable per-axis gains for matrix params. One of 'row'/'col'/'rowcol'/'flat'/'embed'."""
 
     hypersphere_gains_mode_output: Optional[str] = None
@@ -373,7 +373,7 @@ class OptimizerConfig:
     """Absolute LR for the per-axis gains AdamW. When unset, falls back to --lr (and still tracks
     the schedule shape of the main LR)."""
 
-    gain_parametrization: str = 'direct'
+    gain_parametrization: str = 'softplus'
     """Reparametrize the stored gain g; effective multiplier is phi(g). 'direct' keeps phi(g)=g;
     'softplus' uses phi(g)=softplus(g) (always positive). Applied uniformly to row/col/flat."""
 

--- a/megatron/core/transformer/moe/fp8_jit.py
+++ b/megatron/core/transformer/moe/fp8_jit.py
@@ -4,7 +4,16 @@ import triton
 import triton.language as tl
 from typing import Tuple
 
-from deep_gemm.utils.math import align, pack_ue8m0_to_int
+try:
+    from deep_gemm.utils.math import align, pack_ue8m0_to_int
+except ImportError:
+    # deep_gemm is only needed for the FP8 quantization paths in this module
+    # (align / pack_ue8m0_to_int are used solely inside FP8 helper functions).
+    # Guard the import so the MoE stack is importable without deep_gemm when FP8
+    # is disabled — mirrors the `try: import deep_gemm` guard in fp8_utils.py.
+    # Any FP8 path that calls these will fail loudly at call time if deep_gemm
+    # is missing.
+    align = pack_ue8m0_to_int = None
 
 # referred from DeepGEMM utils
 def per_block_cast_to_fp8_cpu(x: torch.Tensor, gran_k: int = 128) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -802,7 +802,7 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         # sum(output_splits) == received tokens dim0. A mismatch ("Split sizes doesn't match
         # total dim 0 size") means input_splits/output_splits are inconsistent with the
         # permuted tensor (stale state, wrong routing_map, or unsynced DtoH copy).
-        if int(self.input_splits.sum()) != permutated_local_input_tokens.shape[0]:
+        if self.input_splits is not None and int(self.input_splits.sum()) != permutated_local_input_tokens.shape[0]:
             import torch.distributed as _dist
 
             raise RuntimeError(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1494,6 +1494,38 @@ def validate_args(args, defaults={}):
         assert not args.use_megatron_fsdp, "Muon optimizer does not support Megatron-FSDP for now."
         assert args.ckpt_format in ["torch", "torch_dist"], "Muon optimizer supports torch and torch_dist checkpoint format."
 
+    # MDDecoupling optimizer check. The 2D hypersphere/Muon math is incompatible with the standard
+    # distributed optimizer (it flattens each param shard to 1D); shard optimizer state via
+    # --use-layer-wise-distributed-optimizer instead.
+    if args.optimizer == 'md_decoupling':
+        assert not args.use_distributed_optimizer, (
+            "md_decoupling does not support the standard distributed optimizer; use "
+            "--use-layer-wise-distributed-optimizer to shard optimizer state.")
+        assert not args.fp16, "md_decoupling does not support fp16 (use bf16 or fp32)."
+        assert not args.use_torch_fsdp2, "md_decoupling does not support Torch-FSDP2."
+        assert not args.use_megatron_fsdp, "md_decoupling does not support Megatron-FSDP."
+        assert args.ckpt_format in ["torch", "torch_dist"], (
+            "md_decoupling supports torch and torch_dist checkpoint format.")
+        # Grad-reduce / param-gather overlap is only supported via the layer-wise
+        # optimizer (same as dist_muon vs plain muon); the non-layer-wise path
+        # (Float16/FP32 + ChainedOptimizer) does not handle it.
+        if not args.use_layer_wise_distributed_optimizer:
+            assert not args.overlap_grad_reduce, (
+                "md_decoupling without --use-layer-wise-distributed-optimizer does not support "
+                "--overlap-grad-reduce; enable the layer-wise optimizer.")
+            assert not args.overlap_param_gather, (
+                "md_decoupling without --use-layer-wise-distributed-optimizer does not support "
+                "--overlap-param-gather; enable the layer-wise optimizer.")
+        gains_enabled = (
+            args.hypersphere_gains_mode is not None
+            or args.hypersphere_gains_mode_output is not None
+            or args.hypersphere_gains_mode_embedding is not None
+        )
+        if gains_enabled:
+            assert args.ckpt_format == "torch", (
+                "md_decoupling with learnable gains requires --ckpt-format torch (gain state "
+                "tensors differ in shape from their parameter, which torch_dist cannot round-trip).")
+
     # Optimizer CPU offload check
     if args.optimizer_cpu_offload:
         assert args.use_precision_aware_optimizer, (
@@ -2271,7 +2303,7 @@ def _add_regularization_args(parser):
     group.add_argument('--muon-use-nesterov', action='store_true',
                        help='Whether to use Nesterov-style momentum in the internal SGD')
     group.add_argument('--muon-scale-mode', type=str, default='spectral',
-                       choices=['spectral', 'unit_rms_norm', 'shape_scaling'],
+                       choices=['spectral', 'unit_rms_norm', 'shape_scaling', 'shape_up', 'none'],
                        help='Scale mode for Muon optimizer. With MuP, set '
                        '--muon-scale-mode unit_rms_norm to use unit_rms_norm scaling, '
                        'or set --muon-scale-mode spectral to keep spectral scaling.')
@@ -2516,8 +2548,89 @@ def _add_training_args(parser):
                        help='use FlashAttention implementation of attention. '
                        'https://arxiv.org/abs/2205.14135')
     group.add_argument('--optimizer', type=str, default='adam',
-                       choices=['adam', 'sgd', 'muon', 'dist_muon', 'lion'],
+                       choices=['adam', 'sgd', 'muon', 'dist_muon', 'lion', 'md_decoupling'],
                        help='Optimizer function')
+    # ---- MDDecoupling optimizer (--optimizer md_decoupling) ----
+    # Magnitude-direction decoupling: hypersphere normalization (direction) + learnable per-axis
+    # gains (magnitude) + optional Muon orthogonalized updates. Reuses --adam-beta1/--adam-beta2/
+    # --adam-eps/--weight-decay and the --muon-* knobs (momentum, nesterov, scale-mode, num-ns-steps,
+    # tp-mode, extra-scale-factor, coefficient-type, fp32-matmul-prec, split-qkv). All defaults off.
+    group.add_argument('--matrix-lr', type=float, default=None,
+                       help='Absolute LR for matrix (2D non-embedding/output) params under '
+                       '--optimizer md_decoupling. Overrides muon_lr_factor * lr.')
+    group.add_argument('--embedding-lr-multiplier', type=float, default=None,
+                       help='LR multiplier for embedding (and tied LM-head) params under '
+                       'md_decoupling. Final max_lr = embedding_lr_multiplier * lr. When unset, '
+                       'those params use the base --lr.')
+    group.add_argument('--output-lr', type=float, default=None,
+                       help='Absolute LR for the (untied) output LM-head params under '
+                       'md_decoupling. When unset, the output layer uses the base --lr.')
+    group.add_argument('--min-lr-mode', dest='min_lr_mode', type=str, default='relative',
+                       choices=['relative', 'absolute'],
+                       help='How per-group min_lr is set for any group with a custom max_lr. '
+                       '"relative" (default): every group decays by the same fraction '
+                       '(config.min_lr / config.lr). "absolute": every group decays to the same '
+                       'floor (config.min_lr).')
+    group.add_argument('--muon-lr-factor', type=float, default=1.0,
+                       help='When --matrix-lr is unset, matrix-param LR for md_decoupling is '
+                       'muon_lr_factor * lr. Default 1.0.')
+    group.add_argument('--hypersphere-mode', type=str, default=None,
+                       choices=['row', 'col', 'flat', 'embed'],
+                       help='Hypersphere normalization mode for non-embedding/output 2D matrices '
+                       'under md_decoupling. Applied post-step to project the weight onto the L2 '
+                       'sphere. None = off.')
+    group.add_argument('--hypersphere-embedding-mode', type=str, default=None,
+                       choices=['row', 'col', 'flat', 'embed', 'none'],
+                       help='Hypersphere mode override for embedding + LM head under md_decoupling. '
+                       'When set, those params stay in MDDecoupling (Adam branch) and get post-step '
+                       'normalization. When None, they route to external Adam with no hypersphere.')
+    group.add_argument('--hypersphere-router-mode', type=str, default=None,
+                       choices=['row', 'col', 'flat', 'embed', 'none'],
+                       help='Hypersphere mode override for MoE router weights under md_decoupling. '
+                       'None disables router-specific normalization.')
+    group.add_argument('--hypersphere-tangential-grad', action='store_true', default=False,
+                       help='Project p.grad onto the hypersphere tangent space before the update '
+                       '(only effective with an active hypersphere mode).')
+    group.add_argument('--hypersphere-preserve-init', action='store_true', default=False,
+                       help='Skip init-time hypersphere projection so the model init magnitude '
+                       'survives into training. When gains are configured (single-axis), gains '
+                       'absorb the per-axis init magnitude.')
+    group.add_argument('--hypersphere-scale-out-proj-init', action='store_true', default=False,
+                       help='Scale the hypersphere target radius for is_out_proj params '
+                       '(linear_proj, linear_fc2) by 1/sqrt(2 * num_layers), matching '
+                       'scaled_init_method_normal.')
+    group.add_argument('--md-router-use-orthogonal-updates',
+                       type=lambda s: {'true': True, 'false': False}[s.lower()],
+                       default=None, choices=[True, False],
+                       help='Per-param-group override for use_orthogonal_updates on MoE router '
+                       'weights under md_decoupling. "true" forces Muon for routers, "false" forces '
+                       'the Adam branch, unset (default) follows --use-orthogonal-updates.')
+    group.add_argument('--hypersphere-gains-mode', type=str, default=None,
+                       choices=['row', 'col', 'rowcol', 'flat', 'embed'],
+                       help='Learnable per-axis gains for matrix params under md_decoupling.')
+    group.add_argument('--hypersphere-gains-mode-output', type=str, default=None,
+                       choices=['row', 'col', 'rowcol', 'flat', 'none'],
+                       help="Gains mode override for the LM head under md_decoupling. 'none' "
+                       'disables gains for the LM head.')
+    group.add_argument('--hypersphere-gains-mode-embedding', type=str, default=None,
+                       choices=['row', 'col', 'rowcol', 'flat', 'none'],
+                       help='Gains mode override for the embedding under md_decoupling.')
+    group.add_argument('--gains-lr', type=float, default=None,
+                       help='Absolute LR for the per-axis gains AdamW under md_decoupling. When '
+                       'unset, falls back to --lr (and still tracks the schedule shape of --lr).')
+    group.add_argument('--gain-parametrization', type=str, default='direct',
+                       choices=['direct', 'softplus'],
+                       help='Reparametrize the stored gain g; effective multiplier is phi(g). '
+                       '"direct" (default) keeps phi(g)=g. "softplus" uses phi(g)=softplus(g) '
+                       '(always positive). Applied uniformly to row/col/flat gains.')
+    group.add_argument('--use-orthogonal-updates', action='store_true', default=False,
+                       help='Use Muon-style orthogonalized updates for matrix params under '
+                       'md_decoupling. Embedding + LM head ALWAYS use the Adam branch.')
+    group.add_argument('--use-layer-wise-distributed-optimizer', action='store_true', default=False,
+                       help='For --optimizer md_decoupling: wrap the optimizer with '
+                       'LayerWiseDistributedOptimizer to shard optimizer state over the '
+                       'data-parallel group (the standard distributed optimizer is incompatible '
+                       'with 2D hypersphere/Muon math).')
     group.add_argument('--optimizer-cpu-offload', action='store_true',
                        help='Offload optimizer state to CPU')
     group.add_argument('--optimizer-cuda-graph', action='store_true',

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -178,6 +178,7 @@ from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
 from megatron.core.optimizer import get_megatron_optimizer, AdamOptimizerConfig, SGDOptimizerConfig, OptimizerConfig, ParamKey
 from megatron.core.optimizer.muon import get_megatron_muon_optimizer
+from megatron.core.optimizer.md_decoupling import get_megatron_mddecoupling_optimizer
 from megatron.core.rerun_state_machine import (
     get_rerun_state_machine,
     destroy_rerun_state_machine,
@@ -1592,9 +1593,10 @@ def get_megatron_optimizer_config(args: Any) -> OptimizerConfig:
     """Return a Megatron optimizer config object from Megatron's arguments."""
 
     config = None
-    if args.optimizer == 'adam' or 'muon' in args.optimizer:
+    if args.optimizer == 'adam' or 'muon' in args.optimizer or args.optimizer == 'md_decoupling':
         # TODO(deyuf): Muon needs both adam + muon but get() only receive one config
-        # So for now we keep using adam config that's back compat with old way
+        # So for now we keep using adam config that's back compat with old way.
+        # md_decoupling likewise chains an external Adam, so it reuses AdamOptimizerConfig.
         kwargs = {}
         for f in dataclasses.fields(AdamOptimizerConfig):
             if hasattr(args, f.name):
@@ -1656,7 +1658,15 @@ def setup_model_and_optimizer(
             if mup_overrides:
                 config_overrides = {**(config_overrides or {}), **mup_overrides}
 
-        if 'muon' not in config.optimizer:
+        if config.optimizer == 'md_decoupling':
+            optimizer = get_megatron_mddecoupling_optimizer(
+                config,
+                model,
+                config_overrides=config_overrides,
+                use_gloo_process_groups=args.use_gloo_process_groups,
+                layer_wise_distributed_optimizer=config.use_layer_wise_distributed_optimizer,
+            )
+        elif 'muon' not in config.optimizer:
             # If the user is asking for a non-zero embedding init std, skip weight decay for embeddings
             # to avoid embeddings from shrinking to zero as recommended in https://arxiv.org/abs/2312.16903
             # default_skip_embedding_weight_decay=args.embedding_init_method_std is not None,


### PR DESCRIPTION
WIP, but all my tests work as intended for now. usage will look like:

```
    --optimizer md_decoupling
    --use-layer-wise-distributed-optimizer
    # LR routing: matrix (2D / Muon) params at 1e-2; --lr (1e-3) drives everything
    # else incl. gains; all groups floor at --min-lr via absolute mode.
    --matrix-lr 1e-2
    --min-lr-mode absolute
    --use-orthogonal-updates
    --hypersphere-mode flat
    --hypersphere-embedding-mode none
    --hypersphere-router-mode row
    --hypersphere-gains-mode rowcol
    --gain-parametrization softplus
    --md-router-use-orthogonal-updates True
    --gains-lr 1e-3             # optional; unset → gains use --lr (1e-3) base
    --muon-scale-mode shape_up
    --muon-momentum 0.95
    --muon-use-nesterov
    --overlap-grad-reduce
    --hypersphere-scale-out-proj-init
```

with 

```
    --lr 1e-3
    --min-lr 1e-4
    --lr-decay-style linear
    --lr-warmup-samples 0
```