### PR TITLE
Add expert load violation metrics

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -21,7 +21,12 @@ from megatron.core.pipeline_parallel.utils import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 
 from .. import parallel_state
-from ..transformer.moe.moe_utils import get_updated_expert_bias
+from ..num_microbatches_calculator import get_num_microbatches
+from ..transformer.moe.moe_utils import (
+    expert_load_violation_batchwise,
+    get_updated_expert_bias,
+    save_to_aux_losses_tracker,
+)
 from ..transformer.transformer_config import TransformerConfig
 from ..utils import (
     get_attr_wrapped_model,
@@ -281,13 +286,68 @@ def reset_model_temporary_tensors(config: TransformerConfig, model: List[torch.n
     """
     for model_chunk in model:
         for module in get_attr_wrapped_model(model_chunk, 'modules')():
-            if config.moe_router_enable_expert_bias and hasattr(module, 'expert_bias'):
+            if (
+                hasattr(module, 'local_tokens_per_expert')
+                and module.local_tokens_per_expert is not None
+            ):
                 module.local_tokens_per_expert.zero_()
             if (
                 config.moe_router_load_balancing_type == "global_aux_loss"
                 or "global_aux_loss" in config.moe_router_load_balancing_type
             ) and hasattr(module, 'reset_global_aux_loss_tracker'):
                 module.reset_global_aux_loss_tracker()
+
+
+def _log_global_router_metrics(model: List[torch.nn.Module], config: TransformerConfig):
+    """Log global-batch MoE routing metrics for all MoE routers."""
+    router_modules = []
+    tokens_per_expert_list = []
+    for model_chunk in model:
+        for module in get_attr_wrapped_model(model_chunk, 'modules')():
+            if (
+                hasattr(module, 'local_tokens_per_expert')
+                and module.local_tokens_per_expert is not None
+            ):
+                router_modules.append(module)
+                tokens_per_expert_list.append(module.local_tokens_per_expert)
+
+    if len(router_modules) == 0:
+        return
+
+    stacked = torch.stack(tokens_per_expert_list, dim=0).clone()
+    torch.distributed.all_reduce(
+        stacked,
+        group=parallel_state.get_tensor_and_data_parallel_group(with_context_parallel=True),
+    )
+
+    num_layers = config.num_layers
+    if config.mtp_num_layers is not None:
+        num_layers += config.mtp_num_layers
+
+    # track_moe_metrics applies value times loss_scale=1/num_microbatches, so pre-multiply
+    # to cancel it out because this already contains all microbatch routing counts.
+    num_microbatches = get_num_microbatches()
+    with torch.no_grad():
+        for module, global_tokens_per_expert in zip(router_modules, stacked):
+            total_num_tokens = int(global_tokens_per_expert.sum().item()) // module.topk
+            max_violation, min_violation, avg_violation = expert_load_violation_batchwise(
+                tokens_per_expert=global_tokens_per_expert,
+                num_experts=global_tokens_per_expert.shape[0],
+                total_num_tokens=total_num_tokens,
+                topk=module.topk,
+            )
+            for name, value in (
+                ("global_expert_max_violation", max_violation),
+                ("global_expert_min_violation", min_violation),
+                ("global_expert_avg_violation", avg_violation),
+            ):
+                save_to_aux_losses_tracker(
+                    name,
+                    value * num_microbatches,
+                    module.layer_number,
+                    num_layers,
+                    reduce_group_has_dp=True,
+                )
 
 
 def _update_router_expert_bias(model: List[torch.nn.Module], config: TransformerConfig):
@@ -479,6 +539,8 @@ def finalize_model_grads(
 
     if config.moe_router_enable_expert_bias:
         _update_router_expert_bias(model, config)
+
+    _log_global_router_metrics(model, config)
 
     reset_model_temporary_tensors(config, model)
 

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -940,6 +940,35 @@ def apply_router_token_dropping(
     return final_probs, final_map
 
 
+def expert_load_violation_batchwise(
+    tokens_per_expert: torch.Tensor,
+    num_experts: int,
+    total_num_tokens: int,
+    topk: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute max, min, and avg expert load violation relative to perfect balance."""
+    effective_total_tokens = total_num_tokens * topk
+    ideal_tokens_per_expert = effective_total_tokens / num_experts
+    violation_ratios = (tokens_per_expert - ideal_tokens_per_expert) / ideal_tokens_per_expert
+    return violation_ratios.max(), violation_ratios.min(), violation_ratios.mean()
+
+
+def expert_max_violation_batchwise(
+    tokens_per_expert: torch.Tensor,
+    num_experts: int,
+    total_num_tokens: int,
+    topk: int,
+) -> torch.Tensor:
+    """Compute the max expert load violation relative to perfect balance."""
+    max_violation, _, _ = expert_load_violation_batchwise(
+        tokens_per_expert=tokens_per_expert,
+        num_experts=num_experts,
+        total_num_tokens=total_num_tokens,
+        topk=topk,
+    )
+    return max_violation
+
+
 def save_to_aux_losses_tracker(
     name: str,
     loss: torch.Tensor,

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -14,6 +14,7 @@ from megatron.core.transformer.moe.moe_utils import (
     apply_random_logits,
     apply_router_token_dropping,
     compute_routing_scores_for_aux_loss,
+    expert_load_violation_batchwise,
     get_tokens_per_expert_and_token_count,
     router_gating_linear,
     save_to_aux_losses_tracker,
@@ -169,17 +170,18 @@ class TopKRouter(Router):
         self.score_function = self.config.moe_router_score_function
         self.input_jitter = None
 
+        self.register_buffer(
+            'local_tokens_per_expert',
+            torch.zeros(
+                self.config.num_moe_experts,
+                dtype=torch.float32,
+                device=torch.cuda.current_device(),
+            ),
+            persistent=False,
+        )
+
         self.enable_expert_bias = self.config.moe_router_enable_expert_bias
         if self.enable_expert_bias:
-            self.register_buffer(
-                'local_tokens_per_expert',
-                torch.zeros(
-                    self.config.num_moe_experts,
-                    dtype=torch.float32,
-                    device=torch.cuda.current_device(),
-                ),
-                persistent=False,
-            )
             self.register_buffer(
                 'expert_bias',
                 torch.zeros(
@@ -189,7 +191,6 @@ class TopKRouter(Router):
                 ),
             )
         else:
-            self.local_tokens_per_expert = None
             self.expert_bias = None
 
         # Initialize global tokens per expert for global aux loss
@@ -578,7 +579,7 @@ class TopKRouter(Router):
         Update expert bias and tokens_per_expert
         Prevent extra local tokens accumulation on evaluation or activation recomputation
         """
-        if self.enable_expert_bias and torch.is_grad_enabled():
+        if torch.is_grad_enabled():
             with torch.no_grad():
                 if padding_mask is not None:
                     routing_map = routing_map & (~padding_mask)
@@ -669,6 +670,38 @@ class TopKRouter(Router):
 
         # Optionally apply expert bias
         self._apply_expert_bias(routing_map, padding_mask=padding_mask)
+
+        if self.training and torch.is_grad_enabled():
+            with torch.no_grad():
+                num_layers = self.config.num_layers
+                if self.config.mtp_num_layers is not None:
+                    num_layers += self.config.mtp_num_layers
+
+                expert_max_violation_routing_map = routing_map
+                total_num_tokens = routing_map.shape[0]
+                if padding_mask is not None:
+                    expert_max_violation_routing_map = routing_map & (~padding_mask.unsqueeze(-1))
+                    total_num_tokens = (~padding_mask).sum().item()
+
+                tokens_per_expert = expert_max_violation_routing_map.sum(dim=0).float()
+                max_violation, min_violation, avg_violation = expert_load_violation_batchwise(
+                    tokens_per_expert=tokens_per_expert,
+                    num_experts=self.config.num_moe_experts,
+                    total_num_tokens=total_num_tokens,
+                    topk=self.topk,
+                )
+                for name, value in (
+                    ("expert_max_violation", max_violation),
+                    ("expert_min_violation", min_violation),
+                    ("expert_avg_violation", avg_violation),
+                ):
+                    save_to_aux_losses_tracker(
+                        name,
+                        value,
+                        self.layer_number,
+                        num_layers,
+                        reduce_group=self.tp_cp_group,
+                    )
 
         return probs, routing_map
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2179,6 +2179,12 @@ def training_log(
             track_names.append("global_load_balancing_loss")
         if args.moe_z_loss_coeff is not None:
             track_names.append("z_loss")
+        track_names.append("expert_max_violation")
+        track_names.append("expert_min_violation")
+        track_names.append("expert_avg_violation")
+        track_names.append("global_expert_max_violation")
+        track_names.append("global_expert_min_violation")
+        track_names.append("global_expert_avg_violation")
 
         if is_hybrid_model(args):
             from operator import itemgetter


### PR DESCRIPTION
Port the MoE expert load violation logging metric from NouamaneTazi/Megatron-LM#6.

This adds max, min, and average expert violation metrics for both microbatch routing and global-batch aggregated routing counts. The router token-count buffer is decoupled from expert-bias updates so the metrics can be logged for any MoE routing mode.

@AllenHaoHuang 