### PR TITLE
fix: set rope scaling factor default to 1 and fix factor call in gpt_builders

### DIFF
--- a/gpt_builders.py
+++ b/gpt_builders.py
@@ -91,6 +91,7 @@ def gpt_builder(args, pre_process, post_process, vp_stage=None, config=None, pg_
             rotary_percent=args.rotary_percent,
             rotary_base=args.rotary_base,
             rope_scaling=args.use_rope_scaling,
+            rope_scaling_factor=args.rope_scaling_factor,
             mtp_block_spec=mtp_block_spec,
             vp_stage=vp_stage,
             pg_collection=pg_collection,

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -63,7 +63,7 @@ class RotaryEmbedding(nn.Module):
         seq_len_interpolation_factor: float = None,
         rotary_base: int = 10000,
         rope_scaling: bool = False,
-        rope_scaling_factor: float = 8.0,
+        rope_scaling_factor: float = 1.0,
         use_cpu_initialization: bool = False,
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
     ) -> None:
@@ -92,7 +92,7 @@ class RotaryEmbedding(nn.Module):
     def _apply_scaling(
         self,
         freqs,
-        factor=8,
+        factor=1,
         low_freq_factor=1,
         high_freq_factor=4,
         original_max_position_embeddings=8192,

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -48,7 +48,7 @@ class RotaryEmbedding(nn.Module):
         rotary_base (int, optional): Base period for rotary position embeddings. Defaults to
             10000.
         rope_scaling (bool, optional): Apply rope scaling as used in llama 3.x.
-        rope_scaling_factor (float, optional): rope scaling factor in llama 3.x. Defaults to 8.
+        rope_scaling_factor (float, optional): rope scaling factor in llama 3.x. Defaults to 1.
         use_cpu_initialization (bool, optional): If False, initialize the inv_freq directly
             on the GPU. Defaults to False
         cp_group (torch.distributed.ProcessGroup, optional): Process group for context parallel.

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -73,7 +73,7 @@ class GPTModel(LanguageModule):
             position_embedding_type is 'rope'.
             Defaults to 10000.
         rope_scaling (bool, optional): Toggle RoPE scaling.
-        rope_scaling_factor (float): RoPE scaling factor. Default 8.
+        rope_scaling_factor (float): RoPE scaling factor. Default 1.
         scatter_embedding_sequence_parallel (bool, optional):
             Whether embeddings should be scattered across sequence parallel
             region or not. Defaults to True.
@@ -100,7 +100,7 @@ class GPTModel(LanguageModule):
         rotary_percent: float = 1.0,
         rotary_base: int = 10000,
         rope_scaling: bool = False,
-        rope_scaling_factor: float = 8.0,
+        rope_scaling_factor: float = 1.0,
         scatter_embedding_sequence_parallel: bool = True,
         seq_len_interpolation_factor: Optional[float] = None,
         mtp_block_spec: Optional[ModuleSpec] = None,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1833,7 +1833,7 @@ def _add_network_size_args(parser):
                        help='Sequence length interpolation factor for rotary embeddings.')
     group.add_argument('--use-rope-scaling', action='store_true',
                        help='Apply rope scaling as used in llama3.x')
-    group.add_argument('--rope-scaling-factor', type=float, default=8.0,
+    group.add_argument('--rope-scaling-factor', type=float, default=1.0,
                        help='Rope scaling factor in llama3.x models')
     group.add_argument('--no-rope-freq', type=no_rope_freq_type, default=None,
                        help='Controls which layers to skip performing Rotary Position Embedding. Accepts either: '


### PR DESCRIPTION
# Problem description

- Current implementation takes `rope_scaling_factor=8` as a default parameter, which is correct for CPT setups, but is incorrect for pre-training giving that this factor is used for scaling the sequence length. [[ref](https://arxiv.org/pdf/2309.00071)]
- Current implementation ignores if there's an argument `rope_scaling_factor!=8` in the pre-training config given that the argument is not given in the `gpt_builders.py` implementation.

## Changes
- Current default value is `rope_scaling_factor=8`.
- Adding `--rope-scaling-factor 32` to the training config will correctly reach gpt_builders.py function.

## Tests

Intereacted with the RoPE call to verify that the `rope_scaling_factor` is correctly reaching its call.