### PR TITLE
Backport NVIDIA #6306: honor RoPE scaling in ModelOpt

### DIFF
--- a/megatron/post_training/model_builder.py
+++ b/megatron/post_training/model_builder.py
@@ -252,6 +252,7 @@ def modelopt_gpt_mamba_builder(
             "rotary_percent": args.rotary_percent,
             "rotary_base": args.rotary_base,
             "rope_scaling": args.use_rope_scaling,
+            "rope_scaling_factor": args.rope_scaling_factor,
             "pg_collection": pg_collection,
         }
         model = MCoreGPTModel(config=config, **model_kwargs)

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -3,6 +3,7 @@
 import inspect
 import os
 from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -443,3 +444,39 @@ class TestGPTWithDynamicInference:
 
         # Assert that all padding logits are zero.
         assert torch.all(padding_logits == 0.0), "Logits for padding tokens are not all zero."
+
+
+def test_gpt_builder_forwards_rope_scaling_factor():
+    """Test that gpt_builder forwards rope_scaling_factor to GPTModel.
+
+    Regression test for https://github.com/NVIDIA/Megatron-LM/issues/6305
+    The --rope-scaling-factor flag was silently ignored because gpt_builder
+    passed rope_scaling but not rope_scaling_factor, so GPTModel always fell
+    back to its default factor.
+    """
+    mock_config = MagicMock()
+
+    mock_args = MagicMock()
+    mock_args.use_legacy_models = False
+    mock_args.spec = None
+    mock_args.transformer_impl = "transformer_engine"
+    mock_args.experimental_attention_variant = None
+    mock_args.num_experts = None
+    mock_args.heterogeneous_layers_config_path = None
+    mock_args.mtp_num_layers = None
+    mock_args.use_rope_scaling = True
+    mock_args.rope_scaling_factor = 32.0
+
+    with (
+        patch('gpt_builders.GPTModel') as mock_gpt_model,
+        patch('gpt_builders._get_transformer_layer_spec'),
+    ):
+        from gpt_builders import gpt_builder
+
+        gpt_builder(mock_args, pre_process=True, post_process=True, config=mock_config)
+
+        mock_gpt_model.assert_called_once()
+        _, call_kwargs = mock_gpt_model.call_args
+        assert (
+            call_kwargs.get('rope_scaling_factor') == 32.0
+        ), "rope_scaling_factor must be forwarded from args"


### PR DESCRIPTION
## What does this PR do?

The ModelOpt GPT builder currently ignores `--rope-scaling-factor` and uses this fork's constructor default of `1.0`. Forward the parsed factor so values such as `8.0` and `32.0` reach the model.

Backports [NVIDIA/Megatron-LM #6306](https://github.com/NVIDIA/Megatron-LM/pull/6306), commit `892f3db175a46d0afd8839a041027ae334744222`. The upstream PR is still open.

### Adaptation to Swiss AI main

- `gpt_builders.py` already forwards the factor through `52540cabf`; preserve that fix and import the upstream regression test with `use_legacy_models=False` for this branch's builder.
- Apply the missing ModelOpt forwarding change to `modelopt_gpt_mamba_builder`.
- Omit the newer `gpt_config_from_args` hunk and its test module because that API does not exist on this branch.

No dependency, container, or RoPE-default changes are included. Historical launchers whose requested factor was previously ignored must explicitly select the factor they intend to use.

### Validation

- The upstream GPT builder regression passes when invoked in an isolated CPU harness against the real imported `gpt_builder`.
- The production ModelOpt builder body, isolated from optional imports and GPU construction, forwards both `8.0` and `32.0` after the fix. Both checks failed before the fix because the constructor kwarg was missing.
- Changed Python files compile; `git diff --check` passes. The test file passes the repository-pinned Black 24.4.2 and isort 5.13.2 checks.
- Full pytest collection is blocked in the host environment by missing `transformer_engine`; no full-suite or GPU validation is claimed. The isolated ModelOpt harness is local validation, not a checked-in test.

### Pre-checks

- [x] Added the applicable upstream unit regression test
- [ ] Added functional tests
- [ ] Ran the full repository autoformatter

