### PR TITLE
Backport SFT correctness fixes and opt-in checkpoint improvements

### DIFF
--- a/megatron/core/datasets/indexed_dataset.py
+++ b/megatron/core/datasets/indexed_dataset.py
@@ -961,7 +961,7 @@ class IndexedDatasetBuilder(object):
         self.sequence_lengths.extend(lengths)
         self.document_indices.append(len(self.sequence_lengths))
         if self.multimodal:
-            self.sequence_modes.extend(modes if modes is not None else [0] * lengths)
+            self.sequence_modes.extend(modes if modes is not None else [0] * len(lengths))
 
     def end_document(self) -> None:
         """Finalize the document, for use with IndexedDatasetBuilder.add_item"""

--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -162,6 +162,9 @@ class FullyParallelLoadStrategyWrapper(LoadShardedStrategy):
             - gather_object (default) - ranks all_gather_object the whole loaded state dicts
             - gather_rounds (default) - ranks all gather individual tensors in rounds
             See method docs for more details.
+        per_rank_object_load (bool): load all ShardedObjects requested by each rank
+            directly from storage instead of exchanging main replicas across WORLD.
+            Defaults to False, preserving the gather-based object exchange.
     """
 
     def __init__(
@@ -170,6 +173,7 @@ class FullyParallelLoadStrategyWrapper(LoadShardedStrategy):
         parallelization_group: Optional[torch.distributed.ProcessGroup] = None,
         do_cache_distribution: bool = False,
         exchange_algo: str = 'broadcast',
+        per_rank_object_load: bool = False,
     ):
         super().__init__()
         self.base_strategy = strategy
@@ -180,6 +184,7 @@ class FullyParallelLoadStrategyWrapper(LoadShardedStrategy):
         self.parallelization_group = parallelization_group
         self.do_cache_distribution = do_cache_distribution
         self.exchange_algo = exchange_algo
+        self.per_rank_object_load = per_rank_object_load
 
         self.cached_distribution: Optional[ShardDistribution] = None
         self.cached_global_metadata: Optional[Metadata] = None
@@ -230,8 +235,7 @@ class FullyParallelLoadStrategyWrapper(LoadShardedStrategy):
             ), 'Expecting non-trivial distribution for non-trivial parallelization group'
 
         # Step 3: load part of the checkpoint.
-        # Load only sharded objects first. ShardedTensors will be loaded separately
-        # so that we can keep track of sharded tensors loaded by this rank
+        # Track tensors and objects separately so each can use its own exchange.
         (sharded_tensors, sharded_state_dict, to_load_shards, unloaded_shards) = (
             self._defer_loading_sharded_tensors(sharded_state_dict)
         )
@@ -243,13 +247,23 @@ class FullyParallelLoadStrategyWrapper(LoadShardedStrategy):
         assert (
             len(sharded_state_dict) == 0
         ), "sharded_state_dict is not empty after deferring tensors and objects"
-        with debug_time("base_load_ShardedObjects", logger):
-            # Load sharded objects first
-            loaded_objects = self.base_strategy.load(to_load_objects, checkpoint_dir)
-
-        with debug_time("base_load_ShardedTensors", logger):
-            # Load sharded tensors separately
-            loaded_tensors = self.base_strategy.load(to_load_shards, checkpoint_dir)
+        if self.per_rank_object_load:
+            # Object unique_keys contain key, offset and shape, but not replica_id.
+            # Each object is saved once by its main replica; any rank requesting
+            # that object can read the same stored value, including non-main replicas.
+            all_objects_to_load = {**to_load_objects, **unloaded_objects}
+            # A mixed load uses one metadata read and load plan for tensors and objects.
+            with debug_time("base_load_ShardedTensorsAndObjects", logger):
+                loaded = self.base_strategy.load(
+                    {**to_load_shards, **all_objects_to_load}, checkpoint_dir
+                )
+            loaded_tensors = {shard_id: loaded[shard_id] for shard_id in to_load_shards}
+            loaded_objects = {shard_id: loaded[shard_id] for shard_id in all_objects_to_load}
+        else:
+            with debug_time("base_load_ShardedObjects", logger):
+                loaded_objects = self.base_strategy.load(to_load_objects, checkpoint_dir)
+            with debug_time("base_load_ShardedTensors", logger):
+                loaded_tensors = self.base_strategy.load(to_load_shards, checkpoint_dir)
 
         with debug_time("self.exchange_loaded_tensors", logger):
 
@@ -271,14 +285,16 @@ class FullyParallelLoadStrategyWrapper(LoadShardedStrategy):
             with debug_time("torch.cuda.synchronize", logger):
                 torch.cuda.synchronize()
 
-        all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
-
-        if not set(unloaded_objects.keys()).issubset(all_loaded_objects.keys()):
-            missing_object_shards = set(unloaded_objects.keys()) - all_loaded_objects.keys()
-            raise CheckpointingException(
-                f'Missing object shards after fully parallel loading: {missing_object_shards}'
-            )
-        torch.cuda.synchronize()
+        if self.per_rank_object_load:
+            all_loaded_objects = loaded_objects
+        else:
+            all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
+            if not set(unloaded_objects.keys()).issubset(all_loaded_objects.keys()):
+                missing_object_shards = set(unloaded_objects.keys()) - all_loaded_objects.keys()
+                raise CheckpointingException(
+                    f'Missing object shards after fully parallel loading: {missing_object_shards}'
+                )
+            torch.cuda.synchronize()
 
         self.fill_in_deferred_sharded_tensors(sharded_tensors, all_loaded_tensors)
         self.fill_in_deferred_sharded_objects(sharded_objects, all_loaded_objects)

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -417,7 +417,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                 # fp32 params.
                 elif model_param.type() == 'torch.cuda.FloatTensor':
-                    shard_model_param = model_param.view(-1)[param_range.start : param_range.end]
+                    shard_model_param = model_param.detach().view(-1)[
+                        param_range.start : param_range.end
+                    ]
                     model_fp32_params_this_group.append(model_param)
                     shard_fp32_params_this_group.append(shard_model_param)
                     tensor_parallel.copy_tensor_model_parallel_attributes(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2748,6 +2748,20 @@ def _add_checkpointing_args(parser):
     group.add_argument('--ckpt-fully-parallel-load', action='store_true',
                        help='Apply full load parallelization across DP for'
                             ' distributed checkpoints.')
+    group.add_argument('--ckpt-fully-parallel-load-per-rank-objects', action='store_true',
+                       default=False,
+                       help='During fully parallel distributed checkpoint load, read all'
+                            ' ShardedObjects requested by each rank directly from storage'
+                            ' instead of exchanging them with a WORLD all_gather_object.'
+                            ' Defaults to the existing gather-based object exchange.')
+    group.add_argument('--ckpt-drop-redundant-extra-state', action='store_true',
+                       default=False,
+                       help='Keep redundant TE `_extra_state` local instead of persisting'
+                            ' it in distributed checkpoints. Delayed-scaling FP8 amax'
+                            ' history and scales are always persisted. Applies to both'
+                            ' save and load requests; off by default. Older checkpoints'
+                            ' remain loadable when enabled. Keep this flag enabled when'
+                            ' resuming a checkpoint saved with redundant state dropped.')
     group.add_argument('--ckpt-assume-constant-structure', action='store_true',
                        help='If the model and optimizer state dict structure is'
                             'constant throughout a *single training job*, it allows for'

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2756,10 +2756,10 @@ def _add_checkpointing_args(parser):
                             ' Defaults to the existing gather-based object exchange.')
     group.add_argument('--ckpt-drop-redundant-extra-state', action='store_true',
                        default=False,
-                       help='Keep redundant TE `_extra_state` local instead of persisting'
-                            ' it in distributed checkpoints. Delayed-scaling FP8 amax'
-                            ' history and scales are always persisted. Applies to both'
-                            ' save and load requests; off by default. Older checkpoints'
+                       help='Keep empty TE `_extra_state` local in non-FP8/non-FP4 distributed'
+                            ' checkpoints. Has no effect during FP8/FP4 training or calibration;'
+                            ' all nonempty and unknown payloads remain persistent. Applies'
+                            ' to save and load requests; off by default. Older checkpoints'
                             ' remain loadable when enabled. Keep this flag enabled when'
                             ' resuming a checkpoint saved with redundant state dropped.')
     group.add_argument('--ckpt-assume-constant-structure', action='store_true',

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -21,7 +21,8 @@ from typing import Optional, Union, List, Dict, Any
 from torch.distributed.checkpoint import FileSystemReader, default_planner
 
 from megatron.core import dist_checkpointing, mpu, tensor_parallel
-from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
+from megatron.core.dist_checkpointing.mapping import LocalNonpersistentObject, ShardedObject
 from megatron.core.dist_checkpointing.serialization import get_default_load_sharded_strategy
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
     FullyParallelLoadStrategyWrapper,
@@ -887,7 +888,98 @@ def generate_state_dict(
     if not args.no_save_rng and rng_state:
         state_dict["rng_state"] = rng_state
 
+    # This entry point builds both save state dicts and load requests, keeping
+    # redundant-extra-state handling symmetric and disabled by default.
+    if args.ckpt_format == "torch_dist" and getattr(
+        args, "ckpt_drop_redundant_extra_state", False
+    ):
+        _localize_redundant_extra_states(state_dict)
+
     return state_dict
+
+
+# Byte markers of the dict keys that TE `get_extra_state` writes ONLY under
+# `if recipe.delayed():` (see TransformerEngine `module/base.py`). Their presence
+# in the serialized payload is a robust, unpickle-free signal that the
+# `_extra_state` carries persistent delayed-scaling state (amax history + scale).
+_FP8_PERSISTENT_EXTRA_STATE_MARKERS = (b"amax_history_fwd", b"scale_fwd", b"scale_bwd")
+
+
+def _fp8_extra_state_is_persistent(data) -> bool:
+    """Whether a TE `_extra_state` payload must be checkpointed.
+
+    A `_extra_state` is worth persisting only when it carries state that cannot
+    be reconstructed from the run config at model-build time, i.e. the
+    delayed-scaling FP8 amax history + scale. Concretely:
+
+    * ``None`` / empty ``uint8`` tensor  -> FP8 disabled        -> NOT persistent
+    * non-empty, no delayed-scaling key  -> block/current scaling (NVFP4, MXFP8,
+      Float8CurrentScaling): recipe + scalars only, all config-derived
+                                                                  -> NOT persistent
+    * non-empty, has ``scale_fwd`` / ``amax_history_fwd`` / ``scale_bwd``
+                                          -> delayed scaling      -> persistent
+
+    The check operates on the raw serialized bytes (the uint8 tensor that
+    ``get_extra_state`` returns) so it needs no unpickling and no TE import.
+    Anything unrecognized defaults to persistent, so real state is never
+    silently dropped.
+    """
+    if data is None:
+        return False
+    if isinstance(data, torch.Tensor):
+        if data.dtype != torch.uint8:
+            return True
+        if data.numel() == 0:
+            return False
+        try:
+            raw = data.detach().cpu().contiguous().numpy().tobytes()
+        except Exception:
+            return True
+        return any(marker in raw for marker in _FP8_PERSISTENT_EXTRA_STATE_MARKERS)
+    # Unknown payload type: keep it persistent to be safe.
+    return True
+
+
+def _localize_redundant_extra_states(state_dict):
+    """Rewrite non-persistent TE `_extra_state` ShardedObjects as local objects.
+
+    For checkpoints with no FP8, or with block/current FP8 scaling (NVFP4,
+    MXFP8, Float8CurrentScaling), every `_extra_state` is either empty or a
+    recipe-only blob that the freshly-built model reproduces from config — see
+    `_fp8_extra_state_is_persistent`. Such artifacts are pure overhead: in a
+    large MoE model they account for the overwhelming majority of the
+    checkpoint's ShardedObjects (e.g. ~50k on the 55B hybrid-MoE run).
+
+    Wrapping them in ``LocalNonpersistentObject`` (instead of ``ShardedObject``)
+    means, via the dist-checkpointing pipeline:
+
+    * SAVE: ``save_preprocess`` drops them, so they are never written to disk.
+    * LOAD: ``load_preprocess`` unwraps them back into the loaded state dict with
+      the local (freshly-built) value, so the module's ``_extra_state`` key is
+      still present (strict ``load_state_dict`` stays happy) and
+      ``set_extra_state`` no-ops on the empty/recipe payload.
+
+    Because this runs in ``generate_state_dict`` (shared by save and the load
+    request), the decision is symmetric: dropped keys are never *requested*, so
+    loading an older checkpoint that still stores them simply does not read them
+    (they are neither "missing" nor "unexpected" in the request) — backward
+    compatible. Delayed-scaling `_extra_state` stays a ``ShardedObject`` and is
+    saved/loaded exactly as before.
+
+    Keep the flag enabled when resuming checkpoints saved with redundant state
+    dropped: disabling it would request artifacts that were never persisted.
+    """
+
+    def _maybe_localize(value):
+        if (
+            isinstance(value, ShardedObject)
+            and value.key.endswith("_extra_state")
+            and not _fp8_extra_state_is_persistent(value.data)
+        ):
+            return LocalNonpersistentObject(value.data)
+        return value
+
+    dict_list_map_inplace(_maybe_localize, state_dict)
 
 
 def preprocess_fsdp_dtensor_state_dict(args, raw_state_dict, model):
@@ -1061,7 +1153,9 @@ def _load_global_dist_base_checkpoint(
     # NOTE: `args.ckpt_fully_parallel_load` applies to both persistent and non-persistent checkpoints.
     if args.ckpt_fully_parallel_load:
         load_strategy = FullyParallelLoadStrategyWrapper(
-            load_strategy, mpu.get_data_parallel_group(with_context_parallel=True)
+            load_strategy,
+            mpu.get_data_parallel_group(with_context_parallel=True),
+            per_rank_object_load=getattr(args, 'ckpt_fully_parallel_load_per_rank_objects', False),
         )
     if checkpointing_context is not None:
         checkpointing_context["load_strategy"] = load_strategy

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -888,86 +888,46 @@ def generate_state_dict(
     if not args.no_save_rng and rng_state:
         state_dict["rng_state"] = rng_state
 
-    # This entry point builds both save state dicts and load requests, keeping
-    # redundant-extra-state handling symmetric and disabled by default.
-    if args.ckpt_format == "torch_dist" and getattr(
-        args, "ckpt_drop_redundant_extra_state", False
+    # Fresh TE modules can return empty extra state before their first FP8
+    # forward, even when a checkpoint contains scaling history. Never localize
+    # FP8, FP4 or calibration load requests based on those uninitialized payloads.
+    # Apply the same conservative decision to save and load state dicts.
+    if (
+        args.ckpt_format == "torch_dist"
+        and getattr(args, "ckpt_drop_redundant_extra_state", False)
+        and not getattr(args, "fp8", None)
+        and not getattr(args, "fp4", None)
+        and not getattr(args, "fp8_calibration", False)
     ):
         _localize_redundant_extra_states(state_dict)
 
     return state_dict
 
 
-# Byte markers of the dict keys that TE `get_extra_state` writes ONLY under
-# `if recipe.delayed():` (see TransformerEngine `module/base.py`). Their presence
-# in the serialized payload is a robust, unpickle-free signal that the
-# `_extra_state` carries persistent delayed-scaling state (amax history + scale).
-_FP8_PERSISTENT_EXTRA_STATE_MARKERS = (b"amax_history_fwd", b"scale_fwd", b"scale_bwd")
-
-
 def _fp8_extra_state_is_persistent(data) -> bool:
-    """Whether a TE `_extra_state` payload must be checkpointed.
+    """Keep every nonempty or unknown payload; only absent/empty bytes are redundant.
 
-    A `_extra_state` is worth persisting only when it carries state that cannot
-    be reconstructed from the run config at model-build time, i.e. the
-    delayed-scaling FP8 amax history + scale. Concretely:
-
-    * ``None`` / empty ``uint8`` tensor  -> FP8 disabled        -> NOT persistent
-    * non-empty, no delayed-scaling key  -> block/current scaling (NVFP4, MXFP8,
-      Float8CurrentScaling): recipe + scalars only, all config-derived
-                                                                  -> NOT persistent
-    * non-empty, has ``scale_fwd`` / ``amax_history_fwd`` / ``scale_bwd``
-                                          -> delayed scaling      -> persistent
-
-    The check operates on the raw serialized bytes (the uint8 tensor that
-    ``get_extra_state`` returns) so it needs no unpickling and no TE import.
-    Anything unrecognized defaults to persistent, so real state is never
-    silently dropped.
+    This conservative backport targets empty TE artifacts in non-FP8/non-FP4 runs.
+    Payload contents cannot identify the recipe of an uninitialized load request,
+    so callers must separately exclude FP8/FP4 training and calibration.
     """
-    if data is None:
-        return False
-    if isinstance(data, torch.Tensor):
-        if data.dtype != torch.uint8:
-            return True
-        if data.numel() == 0:
-            return False
-        try:
-            raw = data.detach().cpu().contiguous().numpy().tobytes()
-        except Exception:
-            return True
-        return any(marker in raw for marker in _FP8_PERSISTENT_EXTRA_STATE_MARKERS)
-    # Unknown payload type: keep it persistent to be safe.
-    return True
+    return not (
+        data is None
+        or (isinstance(data, torch.Tensor) and data.dtype == torch.uint8 and data.numel() == 0)
+    )
 
 
 def _localize_redundant_extra_states(state_dict):
-    """Rewrite non-persistent TE `_extra_state` ShardedObjects as local objects.
+    """Keep empty TE extra state local for non-FP8/non-FP4 distributed checkpoints.
 
-    For checkpoints with no FP8, or with block/current FP8 scaling (NVFP4,
-    MXFP8, Float8CurrentScaling), every `_extra_state` is either empty or a
-    recipe-only blob that the freshly-built model reproduces from config — see
-    `_fp8_extra_state_is_persistent`. Such artifacts are pure overhead: in a
-    large MoE model they account for the overwhelming majority of the
-    checkpoint's ShardedObjects (e.g. ~50k on the 55B hybrid-MoE run).
+    ``generate_state_dict`` invokes this only outside FP8/FP4 training and calibration,
+    using the same decision for save state dicts and load requests. Nonempty
+    payloads, including delayed-scaling history and recipe blobs, stay persistent.
 
-    Wrapping them in ``LocalNonpersistentObject`` (instead of ``ShardedObject``)
-    means, via the dist-checkpointing pipeline:
-
-    * SAVE: ``save_preprocess`` drops them, so they are never written to disk.
-    * LOAD: ``load_preprocess`` unwraps them back into the loaded state dict with
-      the local (freshly-built) value, so the module's ``_extra_state`` key is
-      still present (strict ``load_state_dict`` stays happy) and
-      ``set_extra_state`` no-ops on the empty/recipe payload.
-
-    Because this runs in ``generate_state_dict`` (shared by save and the load
-    request), the decision is symmetric: dropped keys are never *requested*, so
-    loading an older checkpoint that still stores them simply does not read them
-    (they are neither "missing" nor "unexpected" in the request) — backward
-    compatible. Delayed-scaling `_extra_state` stays a ``ShardedObject`` and is
-    saved/loaded exactly as before.
-
-    Keep the flag enabled when resuming checkpoints saved with redundant state
-    dropped: disabling it would request artifacts that were never persisted.
+    ``LocalNonpersistentObject`` omits the empty artifact on save and restores
+    its local value on load, retaining the key for strict module state loading.
+    Keep the flag enabled when resuming checkpoints saved with empty artifacts
+    dropped: disabling it would request files that were never persisted.
     """
 
     def _maybe_localize(value):

--- a/tests/unit_tests/data/test_builder.py
+++ b/tests/unit_tests/data/test_builder.py
@@ -65,6 +65,27 @@ def create_file_prefixes(tokenizer, number_of_files, maximum_number_of_documents
     return file_prefixes
 
 
+def test_multimodal_builder_add_document_default_modes():
+    # add_document documents modes as defaulting to None. On a multimodal builder
+    # that default must assign one mode (0) per item, matching the sequence
+    # lengths - not crash. Regression test for `[0] * lengths` (list * list).
+    with tempfile.TemporaryDirectory() as temp_dir:
+        builder = IndexedDatasetBuilder(
+            os.path.join(temp_dir, "mm.bin"), dtype=numpy.int32, multimodal=True
+        )
+
+        builder.add_document(numpy.array([1, 2, 3, 4, 5], dtype=numpy.int32), [3, 2])
+        builder.add_document(numpy.array([6, 7], dtype=numpy.int32), [2])
+
+        assert builder.sequence_lengths == [3, 2, 2]
+        assert builder.sequence_modes == [0, 0, 0]
+        assert len(builder.sequence_modes) == len(builder.sequence_lengths)
+
+        # Explicit modes are still honored.
+        builder.add_document(numpy.array([8], dtype=numpy.int32), [1], modes=[4])
+        assert builder.sequence_modes == [0, 0, 0, 4]
+
+
 def do_setup(odir):
     paths = defaultdict(list)
 

--- a/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
+++ b/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the ``--ckpt-drop-redundant-extra-state`` optimization.
+
+These cover the two pure-logic helpers that decide which TE ``_extra_state``
+artifacts are redundant and rewrite them as local (non-persistent) objects:
+``_fp8_extra_state_is_persistent`` and ``_localize_redundant_extra_states``.
+
+The logic operates on the raw serialized ``_extra_state`` bytes, so it is
+exercised here with TE-format payloads built the same way TE's
+``get_extra_state`` does (a ``torch.save`` of a small dict into a ``uint8``
+tensor). This needs no FP8 hardware, so it runs identically on FP8-capable CI
+(H100 / GB200) and elsewhere.
+"""
+
+import io
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing.mapping import (
+    LocalNonpersistentObject,
+    ShardedObject,
+    ShardedTensor,
+)
+from megatron.core.dist_checkpointing.state_dict_utils import load_preprocess, save_preprocess
+from megatron.training.checkpointing import (
+    _fp8_extra_state_is_persistent,
+    _localize_redundant_extra_states,
+    generate_state_dict,
+)
+
+
+def _te_like_extra_state(payload: dict) -> torch.Tensor:
+    """Serialize ``payload`` the way TE's ``get_extra_state`` does: a
+    ``torch.save`` of a dict into a ``uint8`` byte tensor."""
+    buf = io.BytesIO()
+    torch.save(payload, buf)
+    return torch.frombuffer(bytearray(buf.getvalue()), dtype=torch.uint8)
+
+
+# A delayed-scaling FP8 payload carries amax history + scale buffers -> persistent.
+_DELAYED = {
+    "amax_history_fwd": torch.zeros(3),
+    "scale_fwd": torch.ones(1),
+    "scale_bwd": torch.ones(1),
+}
+# Block / current scaling (NVFP4, MXFP8, Float8CurrentScaling) only stores
+# recipe + config-derived scalars, none of the delayed-scaling markers.
+_RECIPE_ONLY = {"recipe": "Float8CurrentScaling", "global_steps": 7}
+
+
+class TestFp8ExtraStateIsPersistent:
+    def test_none_is_not_persistent(self):
+        assert _fp8_extra_state_is_persistent(None) is False
+
+    def test_empty_tensor_is_not_persistent(self):
+        # FP8 disabled: get_extra_state returns an empty uint8 tensor.
+        assert _fp8_extra_state_is_persistent(torch.empty(0, dtype=torch.uint8)) is False
+
+    def test_recipe_only_is_not_persistent(self):
+        # Block / current scaling: no delayed-scaling markers in the payload.
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_RECIPE_ONLY)) is False
+
+    @pytest.mark.parametrize("marker", ["amax_history_fwd", "scale_fwd", "scale_bwd"])
+    def test_delayed_scaling_markers_are_persistent(self, marker):
+        # Any one delayed-scaling marker is enough to keep the payload.
+        assert (
+            _fp8_extra_state_is_persistent(_te_like_extra_state({marker: torch.zeros(2)})) is True
+        )
+
+    def test_full_delayed_payload_is_persistent(self):
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_DELAYED)) is True
+
+    def test_unknown_payload_defaults_to_persistent(self):
+        # Anything that is not a tensor is kept, so real state is never dropped.
+        assert _fp8_extra_state_is_persistent({"not": "a tensor"}) is True
+
+    @pytest.mark.parametrize('data', [torch.ones(2), torch.empty(0)])
+    def test_non_byte_tensor_defaults_to_persistent(self, data):
+        assert _fp8_extra_state_is_persistent(data) is True
+
+
+class TestLocalizeRedundantExtraStates:
+    def _sharded_object(self, key, data):
+        return ShardedObject(key, data, (1,), (0,))
+
+    def test_localizes_only_redundant_extra_states(self):
+        empty_es = self._sharded_object("decoder.0.self_attention._extra_state", None)
+        recipe_es = self._sharded_object(
+            "decoder.0.mlp._extra_state", _te_like_extra_state(_RECIPE_ONLY)
+        )
+        delayed_es = self._sharded_object(
+            "decoder.1.mlp._extra_state", _te_like_extra_state(_DELAYED)
+        )
+        # A ShardedObject that is NOT an _extra_state must be left alone.
+        other_obj = self._sharded_object("decoder.0.metadata", {"foo": "bar"})
+        weight = ShardedTensor.from_rank_offsets("decoder.0.weight", torch.zeros(4), replica_id=0)
+
+        state_dict = {
+            "empty_es": empty_es,
+            "recipe_es": recipe_es,
+            "delayed_es": delayed_es,
+            "other_obj": other_obj,
+            "weight": weight,
+        }
+        _localize_redundant_extra_states(state_dict)
+
+        # Redundant (empty / recipe-only) _extra_state -> dropped on save.
+        assert isinstance(state_dict["empty_es"], LocalNonpersistentObject)
+        assert isinstance(state_dict["recipe_es"], LocalNonpersistentObject)
+        # The wrapped value is preserved so load can restore the key locally.
+        assert state_dict["recipe_es"].unwrap() is recipe_es.data
+        # Delayed-scaling _extra_state stays a ShardedObject (still checkpointed).
+        assert state_dict["delayed_es"] is delayed_es
+        # Non-_extra_state objects and tensors are untouched.
+        assert state_dict["other_obj"] is other_obj
+        assert state_dict["weight"] is weight
+
+    def test_noop_when_no_redundant_extra_states(self):
+        delayed_es = self._sharded_object(
+            "decoder.0.mlp._extra_state", _te_like_extra_state(_DELAYED)
+        )
+        state_dict = {"delayed_es": delayed_es}
+        _localize_redundant_extra_states(state_dict)
+        assert state_dict["delayed_es"] is delayed_es
+
+    def test_nested_local_values_are_dropped_on_save_and_restored_on_load(self):
+        recipe = _te_like_extra_state(_RECIPE_ONLY)
+        delayed = self._sharded_object('decoder.1._extra_state', _te_like_extra_state(_DELAYED))
+        state_dict = {
+            'model': {
+                'layers': [self._sharded_object('decoder.0._extra_state', recipe), delayed]
+            }
+        }
+        _localize_redundant_extra_states(state_dict)
+        saved, common = save_preprocess(state_dict, validate_access_integrity=False)
+        requested, local, _ = load_preprocess(state_dict)
+
+        assert common == {}
+        assert saved['model']['layers'] == [delayed]
+        assert requested['model']['layers'] == [delayed]
+        assert local['model']['layers'][0] is recipe
+
+
+@pytest.mark.parametrize('enabled', [None, False, True])
+@pytest.mark.parametrize('ckpt_format', ['torch', 'torch_dist'])
+def test_generate_state_dict_only_localizes_when_opted_in(enabled, ckpt_format):
+    args = SimpleNamespace(ckpt_format=ckpt_format, no_save_optim=True, no_save_rng=True)
+    if enabled is not None:
+        args.ckpt_drop_redundant_extra_state = enabled
+
+    class Model:
+        def sharded_state_dict(self, **kwargs):
+            return {'extra': ShardedObject('decoder._extra_state', None, (1,), (0,))}
+
+        state_dict_for_save_checkpoint = sharded_state_dict
+
+    # Both save and load requests use this same entry point.
+    for _ in range(2):
+        state = generate_state_dict(
+            args, [Model()], None, None, None, model_sd_kwargs={'metadata': {}}
+        )
+        expected_type = (
+            LocalNonpersistentObject if enabled and ckpt_format == 'torch_dist' else ShardedObject
+        )
+        assert isinstance(state['model']['extra'], expected_type)

--- a/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
+++ b/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
@@ -127,9 +127,7 @@ class TestLocalizeRedundantExtraStates:
         empty = torch.empty(0, dtype=torch.uint8)
         delayed = self._sharded_object('decoder.1._extra_state', _te_like_extra_state(_DELAYED))
         state_dict = {
-            'model': {
-                'layers': [self._sharded_object('decoder.0._extra_state', empty), delayed]
-            }
+            'model': {'layers': [self._sharded_object('decoder.0._extra_state', empty), delayed]}
         }
         _localize_redundant_extra_states(state_dict)
         saved, common = save_preprocess(state_dict, validate_access_integrity=False)
@@ -171,8 +169,13 @@ def test_generate_state_dict_only_localizes_when_opted_in(enabled, ckpt_format):
 )
 def test_quantized_load_request_preserves_fresh_empty_extra_state(fp8, fp4, fp8_calibration):
     args = SimpleNamespace(
-        ckpt_format='torch_dist', ckpt_drop_redundant_extra_state=True,
-        no_save_optim=True, no_save_rng=True, fp8=fp8, fp4=fp4, fp8_calibration=fp8_calibration,
+        ckpt_format='torch_dist',
+        ckpt_drop_redundant_extra_state=True,
+        no_save_optim=True,
+        no_save_rng=True,
+        fp8=fp8,
+        fp4=fp4,
+        fp8_calibration=fp8_calibration,
     )
     # TE 2.10 has not initialized FP8 metadata before the first forward. Its
     # empty local payload must still request the saved delayed-scaling history.
@@ -182,9 +185,7 @@ def test_quantized_load_request_preserves_fresh_empty_extra_state(fp8, fp4, fp8_
         def sharded_state_dict(self, **kwargs):
             return {'extra': extra}
 
-    state = generate_state_dict(
-        args, [Model()], None, None, None, model_sd_kwargs={'metadata': {}}
-    )
+    state = generate_state_dict(args, [Model()], None, None, None, model_sd_kwargs={'metadata': {}})
     requested, local, _ = load_preprocess(state)
     assert requested['model']['extra'] is extra
     assert local == {}

--- a/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
+++ b/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
@@ -8,12 +8,12 @@ artifacts are redundant and rewrite them as local (non-persistent) objects:
 
 The logic operates on the raw serialized ``_extra_state`` bytes, so it is
 exercised here with TE-format payloads built the same way TE's
-``get_extra_state`` does (a ``torch.save`` of a small dict into a ``uint8``
+``get_extra_state`` does (a ``pickle.dumps`` of a small dict into a ``uint8``
 tensor). This needs no FP8 hardware, so it runs identically on FP8-capable CI
 (H100 / GB200) and elsewhere.
 """
 
-import io
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -34,10 +34,8 @@ from megatron.training.checkpointing import (
 
 def _te_like_extra_state(payload: dict) -> torch.Tensor:
     """Serialize ``payload`` the way TE's ``get_extra_state`` does: a
-    ``torch.save`` of a dict into a ``uint8`` byte tensor."""
-    buf = io.BytesIO()
-    torch.save(payload, buf)
-    return torch.frombuffer(bytearray(buf.getvalue()), dtype=torch.uint8)
+    ``pickle.dumps`` of a dict into a ``uint8`` byte tensor."""
+    return torch.frombuffer(bytearray(pickle.dumps(payload)), dtype=torch.uint8)
 
 
 # A delayed-scaling FP8 payload carries amax history + scale buffers -> persistent.
@@ -56,16 +54,16 @@ class TestFp8ExtraStateIsPersistent:
         assert _fp8_extra_state_is_persistent(None) is False
 
     def test_empty_tensor_is_not_persistent(self):
-        # FP8 disabled: get_extra_state returns an empty uint8 tensor.
+        # TE may return empty bytes when disabled or not yet initialized.
         assert _fp8_extra_state_is_persistent(torch.empty(0, dtype=torch.uint8)) is False
 
-    def test_recipe_only_is_not_persistent(self):
+    def test_recipe_only_remains_persistent(self):
         # Block / current scaling: no delayed-scaling markers in the payload.
-        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_RECIPE_ONLY)) is False
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_RECIPE_ONLY)) is True
 
     @pytest.mark.parametrize("marker", ["amax_history_fwd", "scale_fwd", "scale_bwd"])
     def test_delayed_scaling_markers_are_persistent(self, marker):
-        # Any one delayed-scaling marker is enough to keep the payload.
+        # Every nonempty payload remains persistent, including delayed scaling.
         assert (
             _fp8_extra_state_is_persistent(_te_like_extra_state({marker: torch.zeros(2)})) is True
         )
@@ -107,11 +105,10 @@ class TestLocalizeRedundantExtraStates:
         }
         _localize_redundant_extra_states(state_dict)
 
-        # Redundant (empty / recipe-only) _extra_state -> dropped on save.
+        # Only empty state is dropped; all nonempty payloads stay persistent.
         assert isinstance(state_dict["empty_es"], LocalNonpersistentObject)
-        assert isinstance(state_dict["recipe_es"], LocalNonpersistentObject)
-        # The wrapped value is preserved so load can restore the key locally.
-        assert state_dict["recipe_es"].unwrap() is recipe_es.data
+        assert state_dict["recipe_es"] is recipe_es
+        assert state_dict["empty_es"].unwrap() is None
         # Delayed-scaling _extra_state stays a ShardedObject (still checkpointed).
         assert state_dict["delayed_es"] is delayed_es
         # Non-_extra_state objects and tensors are untouched.
@@ -127,11 +124,11 @@ class TestLocalizeRedundantExtraStates:
         assert state_dict["delayed_es"] is delayed_es
 
     def test_nested_local_values_are_dropped_on_save_and_restored_on_load(self):
-        recipe = _te_like_extra_state(_RECIPE_ONLY)
+        empty = torch.empty(0, dtype=torch.uint8)
         delayed = self._sharded_object('decoder.1._extra_state', _te_like_extra_state(_DELAYED))
         state_dict = {
             'model': {
-                'layers': [self._sharded_object('decoder.0._extra_state', recipe), delayed]
+                'layers': [self._sharded_object('decoder.0._extra_state', empty), delayed]
             }
         }
         _localize_redundant_extra_states(state_dict)
@@ -141,7 +138,7 @@ class TestLocalizeRedundantExtraStates:
         assert common == {}
         assert saved['model']['layers'] == [delayed]
         assert requested['model']['layers'] == [delayed]
-        assert local['model']['layers'][0] is recipe
+        assert local['model']['layers'][0] is empty
 
 
 @pytest.mark.parametrize('enabled', [None, False, True])
@@ -166,3 +163,32 @@ def test_generate_state_dict_only_localizes_when_opted_in(enabled, ckpt_format):
             LocalNonpersistentObject if enabled and ckpt_format == 'torch_dist' else ShardedObject
         )
         assert isinstance(state['model']['extra'], expected_type)
+
+
+@pytest.mark.parametrize(
+    'fp8,fp4,fp8_calibration',
+    [('hybrid', None, False), ('e4m3', None, False), (None, None, True), (None, 'e2m1', False)],
+)
+def test_quantized_load_request_preserves_fresh_empty_extra_state(fp8, fp4, fp8_calibration):
+    args = SimpleNamespace(
+        ckpt_format='torch_dist', ckpt_drop_redundant_extra_state=True,
+        no_save_optim=True, no_save_rng=True, fp8=fp8, fp4=fp4, fp8_calibration=fp8_calibration,
+    )
+    # TE 2.10 has not initialized FP8 metadata before the first forward. Its
+    # empty local payload must still request the saved delayed-scaling history.
+    extra = ShardedObject('decoder._extra_state', torch.empty(0, dtype=torch.uint8), (1,), (0,))
+
+    class Model:
+        def sharded_state_dict(self, **kwargs):
+            return {'extra': extra}
+
+    state = generate_state_dict(
+        args, [Model()], None, None, None, model_sd_kwargs={'metadata': {}}
+    )
+    requested, local, _ = load_preprocess(state)
+    assert requested['model']['extra'] is extra
+    assert local == {}
+
+
+def test_unknown_byte_payload_remains_persistent():
+    assert _fp8_extra_state_is_persistent(torch.tensor([1, 2, 3], dtype=torch.uint8)) is True

--- a/tests/unit_tests/dist_checkpointing/test_fully_parallel_objects.py
+++ b/tests/unit_tests/dist_checkpointing/test_fully_parallel_objects.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Object-load correctness and collective coverage for fully parallel checkpoints."""
+
+from copy import deepcopy
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing import load, save
+from megatron.core.dist_checkpointing.core import CheckpointingException
+from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedTensor
+from megatron.core.dist_checkpointing.serialization import get_default_load_sharded_strategy
+from megatron.core.dist_checkpointing.strategies import fully_parallel
+from megatron.core.dist_checkpointing.utils import _sharded_object_id, _sharded_tensor_shard_id
+from megatron.core.msc_utils import MultiStorageClientFeature
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+
+class StoredValuesLoadStrategy:
+    """A local storage boundary that rejects missing checkpoint entries."""
+
+    def __init__(self, values):
+        self.values = values
+        self.requests = []
+
+    def load(self, sharded_state_dict, checkpoint_dir):
+        self.requests.append(set(sharded_state_dict))
+        missing = set(sharded_state_dict) - self.values.keys()
+        if missing:
+            raise CheckpointingException(f'Missing object in checkpoint: {missing}')
+        return {key: self.values[key] for key in sharded_state_dict}
+
+
+class TestFullyParallelObjectLoad:
+    @pytest.fixture
+    def planned_load(self, monkeypatch):
+        # Keep real object deferral/reassembly; replace distributed planning and
+        # tensor transport so the object-load contract also runs without GPUs.
+        monkeypatch.setattr(fully_parallel, 'get_pg_size', lambda group: 2)
+        monkeypatch.setattr(
+            fully_parallel.FullyParallelLoadStrategyWrapper,
+            'apply_loading_parallelization',
+            lambda self, state: object(),
+        )
+        monkeypatch.setattr(
+            fully_parallel, 'exchange_by_distribution', lambda loaded, *args: loaded
+        )
+        monkeypatch.setattr(torch.cuda, 'synchronize', lambda: None)
+
+    @staticmethod
+    def state_and_values(with_tensor):
+        main = ShardedObject('extra', None, (2,), (0,), replica_id=0)
+        remote = ShardedObject('extra', None, (2,), (1,), replica_id=1)
+        # Multiple local references to one stored object must restore identically.
+        alias = ShardedObject('extra', None, (2,), (0,), replica_id=1)
+        state = {'model': {'main': main, 'remote': remote, 'alias': alias}}
+        values = {_sharded_object_id(main): {'rank': 0}, _sharded_object_id(remote): {'rank': 1}}
+        if with_tensor:
+            weight = ShardedTensor.from_rank_offsets('weight', torch.zeros(3))
+            state['model']['weight'] = weight
+            values[_sharded_tensor_shard_id(weight)] = torch.tensor([2.0, 4.0, 6.0])
+        return state, values
+
+    @pytest.mark.parametrize('with_tensor', [False, True])
+    def test_per_rank_load_reads_all_objects_without_exchange(self, planned_load, with_tensor):
+        state, values = self.state_and_values(with_tensor)
+        base = StoredValuesLoadStrategy(values)
+        strategy = fully_parallel.FullyParallelLoadStrategyWrapper(base, per_rank_object_load=True)
+        with mock.patch.object(
+            fully_parallel,
+            'exchange_loaded_objects_gather_object',
+            side_effect=AssertionError('Per-rank objects must not be exchanged'),
+        ):
+            loaded = strategy.load(state, None)['model']
+
+        assert loaded['main'] == {'rank': 0}
+        assert loaded['remote'] == {'rank': 1}
+        assert loaded['alias'] == loaded['main']
+        if with_tensor:
+            torch.testing.assert_close(loaded['weight'], torch.tensor([2.0, 4.0, 6.0]))
+        # All object replicas and local tensors share a single storage plan.
+        assert base.requests == [set(values)]
+
+    def test_default_load_exchanges_only_main_replicas(self, planned_load):
+        state, values = self.state_and_values(with_tensor=True)
+        base = StoredValuesLoadStrategy(values)
+        strategy = fully_parallel.FullyParallelLoadStrategyWrapper(base)
+        with mock.patch.object(
+            fully_parallel,
+            'exchange_loaded_objects_gather_object',
+            return_value={('extra', (0,), (2,)): {'rank': 0}, ('extra', (1,), (2,)): {'rank': 1}},
+        ) as exchange:
+            loaded = strategy.load(state, None)['model']
+
+        assert loaded['main'] == {'rank': 0}
+        assert loaded['remote'] == {'rank': 1}
+        assert loaded['alias'] == loaded['main']
+        torch.testing.assert_close(loaded['weight'], torch.tensor([2.0, 4.0, 6.0]))
+        assert base.requests == [{('extra', (0,), (2,))}, {('weight', (0,), None)}]
+        exchange.assert_called_once_with({('extra', (0,), (2,)): {'rank': 0}})
+
+    def test_default_load_rejects_missing_remote_objects(self, planned_load):
+        state, values = self.state_and_values(with_tensor=False)
+        strategy = fully_parallel.FullyParallelLoadStrategyWrapper(StoredValuesLoadStrategy(values))
+        with mock.patch.object(
+            fully_parallel, 'exchange_loaded_objects_gather_object', return_value={}
+        ):
+            with pytest.raises(CheckpointingException, match='Missing object shards'):
+                strategy.load(state, None)
+
+    def test_per_rank_load_propagates_missing_storage_object(self, planned_load):
+        state, values = self.state_and_values(with_tensor=False)
+        del values[('extra', (1,), (2,))]
+        strategy = fully_parallel.FullyParallelLoadStrategyWrapper(
+            StoredValuesLoadStrategy(values), per_rank_object_load=True
+        )
+        with pytest.raises(CheckpointingException, match='Missing object in checkpoint'):
+            strategy.load(state, None)
+
+
+class TestFullyParallelObjectRoundTrip:
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize('per_rank_object_load', [False, True])
+    def test_mixed_tensor_object_round_trip(self, tmp_path, per_rank_object_load):
+        if Utils.world_size < 2:
+            pytest.skip('Requires at least two distributed ranks')
+        Utils.initialize_model_parallel(1, 1)
+        # Share rank 0's path without depending on the global asset-download
+        # fixtures, so this test can also run with --noconftest.
+        checkpoint_paths = [str(tmp_path / 'checkpoint') if Utils.rank == 0 else None]
+        torch.distributed.broadcast_object_list(checkpoint_paths)
+        state = {
+            'model': {
+                'weight': ShardedTensor.from_rank_offsets(
+                    'weight', torch.tensor([2.0, 4.0, 6.0]), replica_id=Utils.rank
+                ),
+                'objects': [
+                    ShardedObject(
+                        'objects',
+                        {'owner': i},
+                        (Utils.world_size,),
+                        (i,),
+                        replica_id=abs(Utils.rank - i),
+                    )
+                    for i in range(Utils.world_size)
+                ],
+            }
+        }
+        with (
+            mock.patch.object(MultiStorageClientFeature, 'is_enabled', return_value=False),
+            TempNamedDir(Path(checkpoint_paths[0])) as checkpoint_dir,
+        ):
+            save(deepcopy(state), checkpoint_dir)
+            strategy = fully_parallel.FullyParallelLoadStrategyWrapper(
+                get_default_load_sharded_strategy(checkpoint_dir),
+                per_rank_object_load=per_rank_object_load,
+            )
+            with mock.patch.object(
+                fully_parallel,
+                'exchange_loaded_objects_gather_object',
+                wraps=fully_parallel.exchange_loaded_objects_gather_object,
+            ) as exchange:
+                loaded = load(deepcopy(state), checkpoint_dir, strategy)
+            assert exchange.call_count == int(not per_rank_object_load)
+            torch.testing.assert_close(loaded['model']['weight'], torch.tensor([2.0, 4.0, 6.0]))
+            assert loaded['model']['objects'] == [{'owner': i} for i in range(Utils.world_size)]

--- a/tests/unit_tests/test_optimizer_cpu_offloading.py
+++ b/tests/unit_tests/test_optimizer_cpu_offloading.py
@@ -139,3 +139,55 @@ def test_multi_device_hybrid_optimizer(
         assert torch.allclose(
             v, ref_params[k], atol=1e-03
         ), f"Weight {k} value mismatch, max error: {(v - ref_params[k]).abs().max()}"
+
+
+def test_distributed_optimizer_with_cpu_offload_and_fp32_param():
+    """Test that DistributedOptimizer works with HybridDeviceOptimizer (CPU offloading)
+    when the model has FP32 parameters without raising non-leaf Tensor ValueError.
+    """
+    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+    from megatron.core.transformer import TransformerConfig
+    from tests.unit_tests.test_utilities import Utils
+
+    class MixedPrecisionToyNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16)
+            self.scale = nn.Parameter(torch.ones(4, dtype=torch.float32))
+
+        def forward(self, x):
+            return self.proj(x) * self.scale
+
+    Utils.initialize_distributed()
+    Utils.initialize_model_parallel()
+
+    try:
+        model = MixedPrecisionToyNet().cuda()
+        assert model.proj.weight.dtype == torch.bfloat16
+        assert model.scale.dtype == torch.float32
+
+        ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+        transformer_config = TransformerConfig(num_attention_heads=1, num_layers=1)
+        ddp_model = DistributedDataParallel(transformer_config, ddp_config, model)
+
+        optimizer_config = OptimizerConfig(
+            optimizer='adam',
+            lr=1e-3,
+            bf16=True,
+            use_distributed_optimizer=True,
+            optimizer_cpu_offload=True,
+            optimizer_offload_fraction=1.0,
+        )
+
+        optimizer = get_megatron_optimizer(optimizer_config, [ddp_model])
+
+        inputs = torch.ones(2, 4, device="cuda", dtype=torch.bfloat16)
+        output = ddp_model(inputs)
+        loss = output.sum()
+        loss.backward()
+
+        update_successful, grad_norm, _ = optimizer.step()
+        assert update_successful
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
This backports two correctness fixes and two opt-in checkpoint optimizations for SFT without changing the training image or dependencies.

- NVIDIA/Megatron-LM#6982: detach FP32 parameter views before creating distributed optimizer shards; adapt the regression to this fork's mixed-precision API.
- NVIDIA/Megatron-LM#5726: supply one default multimodal mode per sequence in `IndexedDatasetBuilder.add_document`.
- NVIDIA/Megatron-LM#5551: add `--ckpt-fully-parallel-load-per-rank-objects` to read each rank's requested objects directly, avoiding the object WORLD gather. Adapt to the existing two-argument loader and argparse configuration.
- NVIDIA/Megatron-LM#5552: add `--ckpt-drop-redundant-extra-state`, conservatively restricted to empty artifacts in non-FP8/non-FP4 runs. Both options default off.

The extra-state backport deliberately retains all nonempty/unknown payloads and bypasses localization during FP8/FP4 training or calibration. Fresh TE modules can return empty extra state before their first FP8 forward, so classifying load requests solely by their initial payload could silently omit saved scaling statistics. Keep the drop flag enabled when resuming checkpoints saved with empty artifacts omitted.

Validation: 30 CPU tests passed (two distributed cases skipped without GPUs), then all 33 focused tests passed on each of four GPU ranks in the existing `ngc_25-12-alps2` image. This includes mixed-precision distributed optimizer construction/update and both default and per-rank checkpoint object round trips. The multimodal regression fails on the baseline and passes with the fix. Source syntax and `git diff --check` pass. No dependency manifests or compiled sources changed.

Two-node SFT validation completed in the same image using the May 14 tokenized text dataset, base iteration 7000, BF16, TP2/DP4, 8K sequences, GBS8 and explicit padded vocabulary 266752. Jobs 3316344, 3316435 and 3316558 all completed with exit 0. All 40 rank-level runtime audits passed, including actual RoPE factor-8 frequencies and packed sequence parameters. Candidate checkpoint save, optimizer/RNG reload, further updates and another save completed with both options enabled. Checkpoint metadata contains zero extra-state entries versus 193 in the baseline.

The initial continuous-baseline versus independently trained candidate restart comparison exceeded its `1e-3` absolute-loss gate at update 4 (0.4451420 versus 0.4440575, 0.244%). That result is retained. The saved update-2 weights already differed: 198 of 274,496 elements checked in small model tensors, maximum absolute difference 0.0001221. This was not a comparison from identical saved weights.

Two additional controls resumed the **same baseline update-2 checkpoint**, on the same two nodes:

| Code and flags | Update 3 loss | Update 4 loss |
| --- | ---: | ---: |
| Baseline, default flags | 0.3359418 | 0.4451381 |
| Candidate, both options enabled | 0.3359418 | 0.4454298 |

The first resumed loss matches at logged precision; the next differs by 0.0002917 (0.0655%), below the unchanged `1e-3` gate. This supports compatibility in the tested BF16 configuration, not bitwise state or restart equivalence. The run permits nondeterministic arithmetic, and the exact source of the numerical variation is not isolated. This short test does not establish training quality or 64-node throughput. Logs, launchers, preserved initial comparison and restart-control analysis are under `runs/upstream-sft-backports-20260907/validation/` in the CSCS workspace.
